### PR TITLE
fix: add read permission for contents in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  contents: read
   id-token: write # Required for Azure authentication
 
 jobs:


### PR DESCRIPTION
Fix permissions when checking out repository