### PR TITLE
added nltk to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "llama-index == 0.12.*",
     "llama-index-llms-openai == 0.3.*",
     "llama-index-llms-anthropic == 0.6.*",
+    "nltk == 3.9.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
Added NLTK to requirments to get around the weird issue in LlamaIndex where it would download it at run-time. This could cause issues on any machine that doesn't allow run-time downloads. The error was pointed out in #45 

## Checklist for Author

- [x] Linked your tickets to this pull request
- [x] Ran tests locally and all pass

