### PR TITLE
bug fix to typing in library nodes

### DIFF
--- a/src/requestcompletion/nodes/library/structured_llm.py
+++ b/src/requestcompletion/nodes/library/structured_llm.py
@@ -9,54 +9,6 @@ from abc import ABC, abstractmethod
 
 _TOutput = TypeVar("_TOutput", bound=BaseModel)
 
-
-def structured_llm(
-    output_model: Type[_TOutput],
-    system_message: SystemMessage | None = None,
-    model: ModelBase | None = None,
-    pretty_name: str | None = None,
-):
-    class StructuredLLMNode(StructuredLLM):
-        def __init__(
-            self,
-            message_history: MessageHistory,
-            llm_model: ModelBase | None = None,
-        ):
-            message_history_copy = deepcopy(message_history)
-            if system_message is not None:
-                if len([x for x in message_history_copy if x.role == "system"]) > 0:
-                    warnings.warn("System message already exists in message history. We will replace it.")
-                    message_history_copy = [x for x in message_history_copy if x.role != "system"]
-                    message_history_copy.insert(0, system_message)
-                else:
-                    message_history_copy.insert(0, system_message)
-
-            if llm_model is not None:
-                if model is not None:
-                    warnings.warn(
-                        "You have provided a model as a parameter and as a class varaible. We will use the parameter."
-                    )
-            else:
-                if model is None:
-                    raise RuntimeError("You Must provide a model to the StructuredLLM class")
-                llm_model = model
-
-            super().__init__(message_history=message_history_copy, model=llm_model)
-
-        @classmethod
-        def output_model(cls) -> Type[_TOutput]:
-            return output_model
-
-        @classmethod
-        def pretty_name(cls) -> str:
-            if pretty_name is None:
-                return output_model.__name__
-            else:
-                return pretty_name
-
-    return StructuredLLMNode
-
-
 class StructuredLLM(Node[_TOutput], ABC):
 
     # TODO: allow for more general (non-pydantic) outputs
@@ -99,3 +51,51 @@ class StructuredLLM(Node[_TOutput], ABC):
             node=self,
             detail="ModelLLM returned an unexpected message type.",
         )
+
+
+def structured_llm(
+    output_model: Type[_TOutput],
+    system_message: SystemMessage | None = None,
+    model: ModelBase | None = None,
+    pretty_name: str | None = None,
+) -> Type[StructuredLLM]:
+    class StructuredLLMNode(StructuredLLM):
+        def __init__(
+            self,
+            message_history: MessageHistory,
+            llm_model: ModelBase | None = None,
+        ):
+            message_history_copy = deepcopy(message_history)
+            if system_message is not None:
+                if len([x for x in message_history_copy if x.role == "system"]) > 0:
+                    warnings.warn("System message already exists in message history. We will replace it.")
+                    message_history_copy = [x for x in message_history_copy if x.role != "system"]
+                    message_history_copy.insert(0, system_message)
+                else:
+                    message_history_copy.insert(0, system_message)
+
+            if llm_model is not None:
+                if model is not None:
+                    warnings.warn(
+                        "You have provided a model as a parameter and as a class varaible. We will use the parameter."
+                    )
+            else:
+                if model is None:
+                    raise RuntimeError("You Must provide a model to the StructuredLLM class")
+                llm_model = model
+
+            super().__init__(message_history=message_history_copy, model=llm_model)
+
+        @classmethod
+        def output_model(cls) -> Type[_TOutput]:
+            return output_model
+
+        @classmethod
+        def pretty_name(cls) -> str:
+            if pretty_name is None:
+                return output_model.__name__
+            else:
+                return pretty_name
+
+    return StructuredLLMNode
+

--- a/src/requestcompletion/nodes/library/terminal_llm.py
+++ b/src/requestcompletion/nodes/library/terminal_llm.py
@@ -1,16 +1,44 @@
 import warnings
-
+from typing import Type
 from ...llm import MessageHistory, ModelBase, SystemMessage
-from ..nodes import Node, ResetException
+from ..nodes import Node
 
 from abc import ABC
 from copy import deepcopy
+
+class TerminalLLM(Node[str], ABC):
+    """A simple LLM nodes that takes in a message and returns a response. It is the simplest of all llms."""
+
+    def __init__(self, message_history: MessageHistory, model: ModelBase):
+        """Creates a new instance of the TerminalLLM class
+
+        Args:
+
+        """
+        super().__init__()
+        self.model = model
+        self.message_hist = deepcopy(message_history)
+
+    async def invoke(self) -> str | None:
+        """Makes a call containing the inputted message and system prompt to the model and returns the response
+
+        Returns:
+            (TerminalLLM.Output): The response message from the model
+        """
+
+        returned_mess = self.model.chat(self.message_hist)
+
+        self.message_hist.append(returned_mess.message)
+        if returned_mess.message.role == "assistant":
+            cont = returned_mess.message.content
+            return cont
+
 
 def terminal_llm(
     pretty_name: str | None = None,
     system_message: SystemMessage | None = None,
     model: ModelBase | None = None,
-):
+) -> Type[TerminalLLM]:
     class TerminalLLMNode(TerminalLLM):
         def __init__(
             self,
@@ -47,30 +75,3 @@ def terminal_llm(
 
     return TerminalLLMNode
 
-
-class TerminalLLM(Node[str], ABC):
-    """A simple LLM nodes that takes in a message and returns a response. It is the simplest of all llms."""
-
-    def __init__(self, message_history: MessageHistory, model: ModelBase):
-        """Creates a new instance of the TerminalLLM class
-
-        Args:
-
-        """
-        super().__init__()
-        self.model = model
-        self.message_hist = deepcopy(message_history)
-
-    async def invoke(self) -> str:
-        """Makes a call containing the inputted message and system prompt to the model and returns the response
-
-        Returns:
-            (TerminalLLM.Output): The response message from the model
-        """
-
-        returned_mess = self.model.chat(self.message_hist)
-
-        self.message_hist.append(returned_mess.message)
-        if returned_mess.message.role == "assistant":
-            cont = returned_mess.message.content
-            return cont


### PR DESCRIPTION
# Fix Type Checking for library nodes Easy Usage Wrapper

## Issue
The easy usage wrapper method for creating LLM nodes (`terminal_llm()`, `structured_llm()`, and `tool_call_llm()`) werenot properly type checked statically when used with `rc.call()`. While nodes created with the class-based approach were properly type checked, those created with the wrapper method were not, leading to potential type errors at runtime that were not caught during development.

## Root Cause
The `terminal_llm()` function was missing a proper return type annotation, and there was a circular dependency issue where the `TerminalLLM` class was being referenced in type annotations before it was defined.

## Solution
1. Restructured the file to define the `TerminalLLM` class before the `terminal_llm()` function
2. Added a proper return type annotation to the easy usage wrappers:
   ```python
   def terminal_llm(...) -> Type[TerminalLLM]:
   ```
   ```python
   def structured_llm(...) -> Type[StructuredLLM]:
   ```
   ```python
   def tool_call_llm(...) -> Type[OutputLessToolCallLLM[Union[MessageHistory, AssistantMessage]]]:
   ```

## Results
Now both node creation approaches (class-based and easy usage wrapper) can be properly statically type checked:
- IDE type checking will show errors when incorrect argument types are provided
- Static type checkers like mypy will catch type errors earlier in the development process

## Example
```python
# This now correctly type checks
MathDetectiveNode = rc.library.terminal_llm(pretty_name="Math Detective Node", system_message=system_math_genius, model=model)
```
![image](https://github.com/user-attachments/assets/ea7806dc-80e5-42c6-826a-cd7967f177b4)

## Implementation Details
- This fix didn't require any runtime behavior changes
- No external dependencies were added
- The change is backward compatible with existing code

## Alternative Approaches Considered
- Using the `typing.Protocol` class to define an interface
- Using forward references with string literal type annotations
- Using the TYPE_CHECKING constant for conditional imports

These alternatives would have worked but introduced unnecessary complexity compared to simply reordering the class definitions and adding the proper return type annotation.

## Checklist for Author

- [x] Linked your tickets to this pull request

---

