### PR TITLE
llama index hotfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "python-dotenv >= 1.0.0",
     "pyvis >= 0.3.1",
     "llama-index >= 0.12.0",
-    "llama-index-llms-openai >= 0.3.0",
+    "llama-index-llms-openai >= 0.3.0,<=0.3.38",
     "llama-index-llms-anthropic >= 0.6.0",
     "nltk >= 3.9.1"
 ]


### PR DESCRIPTION
Sets the requirement for llama-index-llms-openai to be >= 0.3.0,<=0.3.38 so that it doesn't have the error.
