### PR TITLE
removed publisher shutdown sequence

### DIFF
--- a/src/requestcompletion/run.py
+++ b/src/requestcompletion/run.py
@@ -187,8 +187,8 @@ class Runner:
         return self.rc_state.info
 
     def _close(self):
+        # the publisher should have already been closed in `_run_base`
         self.rc_state.shutdown()
-        self.publisher.shutdown()
         detach_logging_handlers()
         delete_globals()
         # by deleting all of the state variables we are ensuring that the next time we create a runner it is fresh


### PR DESCRIPTION
We had a duplicate reference to the shutdown sequence, this was leading to the warning seen in #169. I have deleted it and wrote a helpful comment to avoid further confusion.
