### PR TITLE
Basic Logic Logic Update for Insertion Requests

### DIFF
--- a/src/requestcompletion/state/state.py
+++ b/src/requestcompletion/state/state.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 
-import warnings
 from collections import deque
 
 
@@ -267,9 +266,9 @@ class RCState:
         """
 
         # note it is assumed that all of the children id are valid and have already been created.
-        assert all(
-            n in self._node_heap for n in children
-        ), "You cannot add a request for a node which has not yet been added"
+        assert all(n in self._node_heap for n in children), (
+            "You cannot add a request for a node which has not yet been added"
+        )
 
         if request_ids is None:
             request_ids = [None] * len(children)


### PR DESCRIPTION
There was a previous warning which did not make a ton sense that existed that informed the user that the insertion request ID would be overwritten. However, the logic did not overwrite the ID and indeed kept it the same. I have removed that warning and dealt with some awkward logic in the attachment of information to the stamper object. 
