### PR TITLE
Tristan/298/system message override in  llm base

### DIFF
--- a/src/requestcompletion/nodes/library/_llm_base.py
+++ b/src/requestcompletion/nodes/library/_llm_base.py
@@ -91,14 +91,14 @@ class LLMBase(Node[_T], ABC, Generic[_T]):
             message_history
         )  # Ensure we don't modify the original message history
 
-        #If there is a system_message method we add it to message history
+        # If there is a system_message method we add it to message history
         if self.system_message() is not None:
             if not isinstance(self.system_message(), (SystemMessage, str)):
                 raise NodeInvocationError(
                     message=get_message("INVALID_SYSTEM_MESSAGE_MSG"),
                     fatal=True,
                 )
-            #If there is already a SystemMessage in MessageHistory we will tell user both are being used
+            # If there is already a SystemMessage in MessageHistory we will tell user both are being used
             if len([x for x in message_history_copy if x.role == "system"]) > 0:
                 warnings.warn(
                     "System message was passed in message history and defined as a method. We will use both and add model method to message history."


### PR DESCRIPTION
Changed the init logic so that system messages are stacked with methods and parameters passed rather than just choosing one.

## Checklist for Author

- [x] Linked your tickets to this pull request
- [x] Ran tests locally and all pass
