### PR TITLE
claude-3-sonnet-20240229 deprecated, changing the instance to claude-…

### DIFF
--- a/tests/unit_tests/llm/models/api_providers/test_anthropic.py
+++ b/tests/unit_tests/llm/models/api_providers/test_anthropic.py
@@ -7,7 +7,7 @@ def test_llm_correct_init():
     """
     Test that AnthropicLLM initializes correctly with a valid model name.
     """
-    model = AnthropicLLM("claude-3-sonnet-20240229")
+    model = AnthropicLLM("claude-3-5-sonnet-20240620")
     assert model is not None
 
 def test_llm_no_function_calling():

--- a/tests/unit_tests/llm/models/api_providers/test_openai.py
+++ b/tests/unit_tests/llm/models/api_providers/test_openai.py
@@ -25,4 +25,4 @@ def test_llm_invalid_model_name():
     Test that OpenAI raises an error for an invalid model name.
     """
     with pytest.raises(LLMError, match="Invalid model name"):
-        _ = OpenAILLM("claude-3-sonnet-20240229")
+        _ = OpenAILLM("claude-3-5-sonnet-20240620")


### PR DESCRIPTION
"claude-3-sonnet-20240229" is deprecated by Anthropic [link](https://docs.anthropic.com/en/docs/about-claude/model-deprecations) so our tests needed to be updated. 

Soln:
updated "claude-3-sonnet-20240229" to "claude-3-5-sonnet-20240620"

Also tracking an issue related to this fix here for further refactoring: #364 
