### PR TITLE
Update release workflow to publish to Azure Artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,24 +49,3 @@ jobs:
           FLIT_PASSWORD: ${{ secrets.AZURE_ARTIFACTS_PAT }}
         run: |
           flit publish
-
-      # Publish CLI package first (required dependency for railtracks[cli])
-      # - name: Publish railtracks-cli to PyPI
-      #   env:
-      #     FLIT_INDEX_URL: 'https://pypi.org/pypi'
-      #     FLIT_USERNAME: '__token__'
-      #     FLIT_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      #   run: |
-      #     cd railtracks-cli
-      #     flit publish
-      #     echo "Published railtracks-cli to PyPI"
-
-      # Then publish main package (which references railtracks-cli in optional dependencies)
-      # - name: Publish railtracks to PyPI
-      #   env:
-      #     FLIT_INDEX_URL: 'https://pypi.org/pypi'
-      #     FLIT_USERNAME: '__token__'
-      #     FLIT_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      #   run: |
-      #     flit publish
-      #     echo "Published railtracks to PyPI"


### PR DESCRIPTION
The release workflow has been modified to publish packages to Azure Artifacts instead of PyPI. This change includes the removal of commented-out code related to publishing to PyPI and updates the environment variables to use Azure credentials. Co-authored by Jaime Bueza.