### PR TITLE
Skip live llm tests

### DIFF
--- a/packages/railtracks/tests/llm_live_tests/test_basic.py
+++ b/packages/railtracks/tests/llm_live_tests/test_basic.py
@@ -40,6 +40,7 @@ test_cases = [
     }
 ]
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 async def test_terminal_llm(llm):
@@ -58,6 +59,7 @@ async def test_terminal_llm(llm):
 
         assert '54321' in response.content
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 @pytest.mark.parametrize("test_case", test_cases, ids=[case["case_id"] for case in test_cases])

--- a/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
+++ b/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 import railtracks as rt
 
 import sys
@@ -7,6 +9,7 @@ import sys
 from railtracks.rt_mcp.main import MCPHttpParams, MCPStdioParams
 
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 def test_from_mcp_server_with_llm():
     time_server = rt.connect_mcp(
         MCPStdioParams(
@@ -37,6 +40,7 @@ def test_from_mcp_server_with_llm():
     assert response.content != "It didn't work!"
 
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 def test_from_mcp_server_with_http():
     time_server = rt.connect_mcp(MCPHttpParams(url="https://mcp.deepwiki.com/sse"))
     parent_tool = rt.agent_node(

--- a/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
+++ b/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
@@ -4,6 +4,7 @@ import railtracks as rt
 from pydantic import BaseModel, Field
 from typing import Optional
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 async def test_function_as_tool(llm):
@@ -39,6 +40,7 @@ async def test_function_as_tool(llm):
         assert rt.context.get("magic_number_called")
         assert rt.context.get("magic_operator_called")
 
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 async def test_realistic_scenario(llm):
@@ -89,7 +91,8 @@ async def test_realistic_scenario(llm):
     assert DB["John"]["phone"] == "5555"
     assert DB["Jane"]["role"] == "Developer"
     assert DB["Jane"]["phone"] == "0987654321"
-    
+
+@pytest.mark.skip(reason="Skipped due to LLM stochasticity")
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 async def test_agents_as_tools(llm):


### PR DESCRIPTION
This PR simply skips the live llm tests since they are frequently causing tests to fail. It needs to be reconsidered how we test llms.