### PR TITLE
fix tool_calling_llm type hints in node_builder

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -7,14 +7,14 @@ from typing import (
     Coroutine,
     Dict,
     Generic,
+    Iterable,
     ParamSpec,
     Set,
     Type,
     TypeVar,
+    Union,
     cast,
     overload,
-    Iterable,
-    Union,
 )
 
 from pydantic import BaseModel
@@ -126,7 +126,9 @@ class NodeBuilder(Generic[_TNode]):
         self._with_override("output_schema", classmethod(lambda cls: schema))
 
     def tool_calling_llm(
-        self, connected_nodes: Iterable[Union[Type[Node], Callable]], max_tool_calls: int | None = None
+        self,
+        connected_nodes: Iterable[Union[Type[Node], Callable]],
+        max_tool_calls: int | None = None,
     ):
         """
         Configure the node subclass to have a tool_nodes method and max_tool_calls method.


### PR DESCRIPTION
connected nodes now expects iterables instead of sets and max_tool_calls accepts None as well as int

## What does this add?

<!-- Provide a clear and concise description of what this PR adds, changes, or fixes. Include the problem this solves and how it solves it. -->

## Type of changes

Please check the type of change your PR introduces:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [x] 🗑️ Chore (other changes that don't modify src or test files)


### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Git & PR Management
- [x] PR title clearly describes the change

