### PR TITLE
env Test removed

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,7 +13,6 @@ env:
 jobs:
   end_to_end_tests:
     runs-on: ubuntu-latest
-    environment: Test 
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Quick fix for removing the env Test manual approval from the dispatch workflow