### PR TITLE
Capital T removed from Railtracks mentions across the repo

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -1,5 +1,5 @@
-name: 'Install RailTracks Dependencies'
-description: 'Install all RailTracks dependencies for testing and development'
+name: 'Install Railtracks Dependencies'
+description: 'Install all Railtracks dependencies for testing and development'
 
 inputs:
   python-version:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
-# RailTracks Development Instructions
+# Railtracks Development Instructions
 
 **Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
 
 ## Repository Overview
 
-RailTracks is a Python framework for building agentic systems. This is a monorepo with two packages:
+Railtracks is a Python framework for building agentic systems. This is a monorepo with two packages:
 - `packages/railtracks/` - Core SDK with optional LLM, MCP, and integration features
 - `packages/railtracks-cli/` - Command-line visualization and development tools
 
@@ -102,7 +102,7 @@ railtracks viz
 
 ### Core Functionality Validation
 
-#### Test Basic RailTracks Operations
+#### Test Basic Railtracks Operations
 ```bash
 # Test basic function nodes
 python -c "

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to RailTracks
+# Contributing to Railtracks
 
-Thank you for your interest in contributing to RailTracks! This guide will help you get set up for development.
+Thank you for your interest in contributing to Railtracks! This guide will help you get set up for development.
 
 ## Repository Structure
 
@@ -160,4 +160,4 @@ If you run into issues:
 3. Reach out the maintainers on discord
 4. Create a new issue with detailed information about your problem
 
-Thank you for contributing to RailTracks! 🚂
+Thank you for contributing to Railtracks! 🚂

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RailTracks
+# Railtracks
 
 <p align="center">
     <img alt="Railtracks Logo" src="docs/assets/logo.svg" width="50%">
@@ -21,9 +21,9 @@
 
 ## Overview
 
-**RailTracks** is a lightweight framework for building agentic systems—modular, intelligent agents that can work together to solve complex tasks more effectively than any single module could.
+**Railtracks** is a lightweight framework for building agentic systems—modular, intelligent agents that can work together to solve complex tasks more effectively than any single module could.
 
-**Railtracks-CLI** is a command-line tool designed to visualize your RailTracks runs. It's lightweight and can be run locally with **no sign-up required**.
+**Railtracks-CLI** is a command-line tool designed to visualize your Railtracks runs. It's lightweight and can be run locally with **no sign-up required**.
 
 ---
 
@@ -43,18 +43,18 @@ We welcome contributions of all kinds! Get started by checking out our [contribu
 
 ---
 
-## Why RailTracks?
+## Why Railtracks?
 
 Many frameworks for building LLM-powered applications focus on pipelines, chains, or prompt orchestration. While effective for simple use cases, they can become brittle or overly complex when handling asynchronous tasks, multi-step reasoning, and heterogeneous agents.
 
-**RailTracks is designed with developers in mind to support real-world agentic systems** with an emphasis on:
+**Railtracks is designed with developers in mind to support real-world agentic systems** with an emphasis on:
 
-* **Programmatic structure without rigidity** – Unlike declarative workflows (e.g., LangChain), RailTracks encourages clean, Pythonic control flow.
-* **Agent-first abstraction** – Inspired by real-world coordination, RailTracks focuses on defining smart agents that collaborate via tools, not just chaining LLM calls.
+* **Programmatic structure without rigidity** – Unlike declarative workflows (e.g., LangChain), Railtracks encourages clean, Pythonic control flow.
+* **Agent-first abstraction** – Inspired by real-world coordination, Railtracks focuses on defining smart agents that collaborate via tools, not just chaining LLM calls.
 * **Automatic Parallelism** – Executions are automatically parallelized when possible, freeing you from managing threading or async manually.
 * **Transparent Execution** – Integrated logging, history tracing, and built-in visualizations show exactly how your system behaves.
 * **Minimal API** – The small, configurable API simplifies your workflow compared to other tools. No magic.
 * **Visual Insights** – Graph-based visualizations help you understand data flow and agent interactions at a glance.
 * **Pluggable Models** – Use any LLM provider: OpenAI, open-weight models, or your own local inference engine.
 
-While frameworks like LangGraph emphasize pipelines, RailTracks aims to strike the perfect balance: powerful enough for complex systems, yet simple enough to understand, extend, and debug.
+While frameworks like LangGraph emphasize pipelines, Railtracks aims to strike the perfect balance: powerful enough for complex systems, yet simple enough to understand, extend, and debug.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Policy
 
-This SECURITY.md describes safe usage, best practices, risk management and how to report vulnerabilities for the RailTracks project.
+This SECURITY.md describes safe usage, best practices, risk management and how to report vulnerabilities for the Railtracks project.
 
-RailTracks is a lightweight, modular framework for building agentic systems. It orchestrates agents, tools, and LLM calls but does not itself provide infrastructure hardening, network egress controls, or secret management.
+Railtracks is a lightweight, modular framework for building agentic systems. It orchestrates agents, tools, and LLM calls but does not itself provide infrastructure hardening, network egress controls, or secret management.
 
 ## Audience
 
@@ -14,7 +14,7 @@ RailTracks is a lightweight, modular framework for building agentic systems. It 
 ## Scope
 
 - In scope:
-  - RailTracks core (PyPI: railtracks)
+  - Railtracks core (PyPI: railtracks)
   - Optional CLI (railtracks-cli) and visualization features
   - First-party example/demo tools and MCP tools included in this repository
 - Out of scope:
@@ -23,14 +23,14 @@ RailTracks is a lightweight, modular framework for building agentic systems. It 
   - Your runtime and hosting environment (OS, containers, Kubernetes, serverless)
   - Organization-specific data policies and compliance obligations
 
-## What RailTracks Is and Is Not
+## What Railtracks Is and Is Not
 
 - Is: a framework to compose agents, call tools, and interact with Machine Learning Models; provides logging, execution history, debugging tools, and a API with optional CLI and visualization.
-- Is not: a security sandbox, a secrets manager, a network firewall, a model training framework or a data loss prevention system. RailTracks does not enforce allow/deny-lists for network/filesystem access and does not implement provider-side data privacy controls.
+- Is not: a security sandbox, a secrets manager, a network firewall, a model training framework or a data loss prevention system. Railtracks does not enforce allow/deny-lists for network/filesystem access and does not implement provider-side data privacy controls.
 
 ## Remote Artifacts and Remote Code
 
-- Models and providers: RailTracks can work with many providers (via your selected model or service). If your chosen stack relies on third-party artifacts (models/weights), prefer formats designed to prevent arbitrary code execution (for example, safetensors) and avoid loading unsafe formats (for example, pickle) from untrusted sources.
+- Models and providers: Railtracks can work with many providers (via your selected model or service). If your chosen stack relies on third-party artifacts (models/weights), prefer formats designed to prevent arbitrary code execution (for example, safetensors) and avoid loading unsafe formats (for example, pickle) from untrusted sources.
 - Remote code execution: Do not execute untrusted code or install untrusted tools/plugins. If you import tools or components from external repositories, review their source and supply chain before enabling them in agents. This extends to model-generated code.
 
 ## LLM/Provider Considerations
@@ -48,7 +48,7 @@ RailTracks is a lightweight, modular framework for building agentic systems. It 
 ## Configuration and Data Handling
 
 - Execution state directory:
-  - RailTracks can persist execution data to a local `.railtracks` directory to aid debugging and visualization.
+  - Railtracks can persist execution data to a local `.railtracks` directory to aid debugging and visualization.
   - This data may include inputs/outputs, prompts/responses, intermediate messages, tool inputs/outputs, runtime traces, and potentially secrets/tokens if passed through messages or tool params.
   - This directory is not automatically cleaned or redacted.
   - Recommendations:
@@ -58,7 +58,7 @@ RailTracks is a lightweight, modular framework for building agentic systems. It 
   - Local logging may capture sensitive information (including prompts, tool I/O, and environment-derived values).
   - The CLI offers optional configuration to forward logs/execution data. Only enable forwarding when you have appropriate agreements and controls for the destination.
 - Not a secret store:
-  - Do not rely on RailTracks to protect secrets.
+  - Do not rely on Railtracks to protect secrets.
   - Inject provider/API keys via secure means (for example, environment variables or a proper secret manager).
   - Avoid printing or embedding secrets into logs, messages, or persisted state.
   - Avoid executing user or generated code in the same environment that has access to sensitive files or credentials.
@@ -71,7 +71,7 @@ Defaults (consult docs for the exact version you use; defaults may change):
 
 ## Network Egress and Environment Security
 
-- RailTracks does not enforce network allow/deny-lists. Control egress at your network, container, or host layer (for example, proxies, firewall rules, VPC egress controls).
+- Railtracks does not enforce network allow/deny-lists. Control egress at your network, container, or host layer (for example, proxies, firewall rules, VPC egress controls).
 - Run untrusted or experimental tools in isolated environments (containers/VMs) with:
   - Non-root users and minimal filesystem access
   - Limited outbound network access (only required endpoints)
@@ -117,9 +117,9 @@ Defaults (consult docs for the exact version you use; defaults may change):
 
 ## In-Scope for Security Reports
 
-Vulnerabilities in the RailTracks core library, CLI, and first-party tools included in this repository that could lead to:
-- Code execution, privilege escalation, or sandbox escape within the RailTracks process
-- Unauthorized access or disclosure of data persisted by RailTracks (for example, `.railtracks`) when used as documented
+Vulnerabilities in the Railtracks core library, CLI, and first-party tools included in this repository that could lead to:
+- Code execution, privilege escalation, or sandbox escape within the Railtracks process
+- Unauthorized access or disclosure of data persisted by Railtracks (for example, `.railtracks`) when used as documented
 - Integrity issues that allow an attacker to subvert tool invocation or agent routing without user authorization
 - Documentation inaccuracies that materially mislead users about security behavior
 
@@ -128,7 +128,7 @@ Vulnerabilities in the RailTracks core library, CLI, and first-party tools inclu
 - Misuse or insecure configuration of third-party tools, services, or providers
 - Vulnerabilities in external LLM/model providers or MCP servers not maintained by this project
 - Risks arising from user-authored tools or example code not included in this repository
-- Insecure host or network environments, missing OS patches, or lack of hardening outside RailTracks
+- Insecure host or network environments, missing OS patches, or lack of hardening outside Railtracks
 - Findings that require unrealistic attacker capabilities or non-default, undocumented configurations
 
 ## Open Source and Licensing Notice
@@ -139,7 +139,7 @@ This repository is open source and accepts public contributions. All code, issue
 
 ## Privacy and Compliance
 
-RailTracks does not itself provide compliance guarantees. Deployers are responsible for meeting regulatory obligations, including data minimization, retention, and residency. If you forward logs or store execution data, ensure your usage aligns with applicable laws and your provider agreements.
+Railtracks does not itself provide compliance guarantees. Deployers are responsible for meeting regulatory obligations, including data minimization, retention, and residency. If you forward logs or store execution data, ensure your usage aligns with applicable laws and your provider agreements.
 
 ## Safe-by-Practice Checklist
 
@@ -154,7 +154,7 @@ RailTracks does not itself provide compliance guarantees. Deployers are responsi
 ## Contact
 
 - Security contact: [Security Email](mailto:security.railtracks@railtown.ai)
-- Please include "[RailTracks Security]" in the subject line.
+- Please include "[Railtracks Security]" in the subject line.
 - If you require an encrypted channel, please indicate so in your initial email. We can coordinate an alternative secure method of communication.
 
 ## Changes to This Policy

--- a/docs/advanced_usage/context.md
+++ b/docs/advanced_usage/context.md
@@ -1,6 +1,6 @@
 # Global Context
 
-RailTracks includes a concept of global context, letting you store and retrieve shared information across the lifecycle of a run. This makes it easy to coordinate data like config settings, environment flags, or shared resources.
+Railtracks includes a concept of global context, letting you store and retrieve shared information across the lifecycle of a run. This makes it easy to coordinate data like config settings, environment flags, or shared resources.
 
 ## What is Global Context?
 
@@ -24,7 +24,7 @@ Here’s how you can use context during a run:
 ```
 
 !!! tip "Context in a Node"
-    The context can be accessed from within **any node** in your RailTracks workflow, regardless of where the node is defined or how it's called:
+    The context can be accessed from within **any node** in your Railtracks workflow, regardless of where the node is defined or how it's called:
     
     ```python
     --8<-- "docs/scripts/context.py:context_in_node"

--- a/docs/advanced_usage/node_builder.md
+++ b/docs/advanced_usage/node_builder.md
@@ -1,13 +1,13 @@
 # Custom Class Building with NodeBuilder
 
-RailTracks' `define_agent` provides a robust foundation for configuring agent classes with predefined parameters that handle most use cases. However, when you need agents or nodes with specialized functionality beyond these standard configurations, the **NodeBuilder** class offers the flexibility to create custom implementations while maintaining the core RailTracks functionality.
+Railtracks' `define_agent` provides a robust foundation for configuring agent classes with predefined parameters that handle most use cases. However, when you need agents or nodes with specialized functionality beyond these standard configurations, the **NodeBuilder** class offers the flexibility to create custom implementations while maintaining the core Railtracks functionality.
 
 ## Overview
 
 NodeBuilder enables you to:
-- Inherit from existing RailTracks node classes
+- Inherit from existing Railtracks node classes
 - Add custom class methods and attributes
-- Maintain compatibility with the RailTracks ecosystem
+- Maintain compatibility with the Railtracks ecosystem
 - Create specialized agents tailored to your specific requirements
 
 ---
@@ -26,7 +26,7 @@ Begin by selecting the appropriate base node class for inheritance.
 
 When initializing NodeBuilder, you'll specify both a `name` and `class_name`:
 - **`name`**: User-friendly identifier for differentiation in multi-node scenarios
-- **`class_name`**: Internal identifier used by RailTracks and Python
+- **`class_name`**: Internal identifier used by Railtracks and Python
 
 ```python
 builder = NodeBuilder[StructuredLLM[_TOutput]](

--- a/docs/advanced_usage/session.md
+++ b/docs/advanced_usage/session.md
@@ -1,10 +1,10 @@
 # Session Management
 
-Sessions in RailTracks manage the execution environment for your flows. The recommended approach is using the `@rt.session` decorator for clean, automatic session management.
+Sessions in Railtracks manage the execution environment for your flows. The recommended approach is using the `@rt.session` decorator for clean, automatic session management.
 
 ## The `@rt.session` Decorator
 
-The decorator automatically wraps your __top level__ async functions with a RailTracks session:
+The decorator automatically wraps your __top level__ async functions with a Railtracks session:
 
 ```python
 --8<-- "docs/scripts/session.py:empty_session_dec"

--- a/docs/background/agents.md
+++ b/docs/background/agents.md
@@ -1,7 +1,7 @@
 # What is an Agent?
 
 The news around AI terms can be pretty overwhelming and sound more like a buzzword than something useful. Before we dive
-deep into how you can build agents in **RailTracks**, let's first understand what an agent is.
+deep into how you can build agents in **Railtracks**, let's first understand what an agent is.
 
 An agent is a self-contained unit that can perform a specific task or set of tasks autonomously. It has the ability to
 make decisions, take actions, and act within its environment to achieve its goals.
@@ -51,8 +51,8 @@ Agents are already being used in real world applications such as:
 
 ## Build Your Own
 
-We have build **RailTracks** with developers in mind; with just a simple prompt and a bit of Python, you’re
-already well on your way to building your first agent. Get started [Building with RailTracks](../tutorials/byfa.md)
+We have build **Railtracks** with developers in mind; with just a simple prompt and a bit of Python, you’re
+already well on your way to building your first agent. Get started [Building with Railtracks](../tutorials/byfa.md)
 
 
 

--- a/docs/deployments/docker.md
+++ b/docs/deployments/docker.md
@@ -1,10 +1,10 @@
 # Deployment Guide
 
-This guide covers deploying RailTracks AI agents as dockerized containers. Agents can be deployed for various use cases including web APIs, batch processing, scheduled tasks, and one-time runs.
+This guide covers deploying Railtracks AI agents as dockerized containers. Agents can be deployed for various use cases including web APIs, batch processing, scheduled tasks, and one-time runs.
 
 ## Overview
 
-RailTracks agents are Python applications that can be containerized and deployed in multiple patterns:
+Railtracks agents are Python applications that can be containerized and deployed in multiple patterns:
 
 - **API Services**: Expose agents as REST APIs for real-time interactions
 - **Batch Processing**: Run agents on datasets or queues
@@ -63,7 +63,7 @@ from pydantic import BaseModel
 import railtracks as rt
 from agent_file_name import MyAgent  # Your agent definition
 
-app = FastAPI(title="RailTracks Agent API")
+app = FastAPI(title="Railtracks Agent API")
 
 class AgentRequest(BaseModel):
     prompt: str

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,13 +6,13 @@ hide:
 
 
 <div style="text-align: center;">
-  <img src="assets/logo.svg" alt="RailTracks Logo" width="300">
-  <h1> RailTracks Agentic Framework</h1>
+  <img src="assets/logo.svg" alt="Railtracks Logo" width="300">
+  <h1> Railtracks Agentic Framework</h1>
 </div>
 
 
-RailTracks is a streamlined agentic workflow creation tool that allows users to quickly prototype, test, and 
-deploy agentic workflows. The foundational principles of RailTracks were designed to make the process of
+Railtracks is a streamlined agentic workflow creation tool that allows users to quickly prototype, test, and 
+deploy agentic workflows. The foundational principles of Railtracks were designed to make the process of
 creating agents an exercise in writing code, not writing a configuration file.
 
 <p style="text-align:center">
@@ -22,10 +22,10 @@ creating agents an exercise in writing code, not writing a configuration file.
   <a href="https://github.com/RailtownAI/railtracks/blob/main/CONTRIBUTING.md" class="md-button" style="margain:1px">Contributing</a>
 </p>
 
-## Why RailTracks?
+## Why Railtracks?
 
 The space of agentic AI frameworks is vast and diverse, with many frameworks offering many features it can be hard to decide which one to use. 
-RailTracks offers a unique approach that focuses on simplicity and developer experience.
+Railtracks offers a unique approach that focuses on simplicity and developer experience.
 
 <div class="grid cards">
     <a href="tutorials/byfa/" class="card" style="color: inherit; text-decoration: none;">
@@ -38,11 +38,11 @@ RailTracks offers a unique approach that focuses on simplicity and developer exp
     </a>
     <a href="tools_mcp/tools_mcp/" class="card" style="color: inherit; text-decoration: none;">
         <h3>Tool Ecosystem</h3>
-        <p>RailTracks is modular to its core. Your tools and components should be reusable for any system.</p>
+        <p>Railtracks is modular to its core. Your tools and components should be reusable for any system.</p>
     </a>
     <a href="tutorials/flows/" class="card" style="color: inherit; text-decoration: none;">
         <h3>Multi Agent Flows</h3>
-        <p>For complex applications, RailTracks provides a simple interface for coordinating multiple agents with built-in logging.</p>
+        <p>For complex applications, Railtracks provides a simple interface for coordinating multiple agents with built-in logging.</p>
     </a>
 </div>
 

--- a/docs/llm_support/prompts.md
+++ b/docs/llm_support/prompts.md
@@ -1,15 +1,15 @@
 # Prompts and Context Injection
 
-Prompts are a fundamental part of working with LLMs in the RailTracks framework. This guide explains how to create dynamic prompts that use our context injection feature to make your prompts more flexible and powerful.
+Prompts are a fundamental part of working with LLMs in the Railtracks framework. This guide explains how to create dynamic prompts that use our context injection feature to make your prompts more flexible and powerful.
 
-## Understanding Prompts in RailTracks
+## Understanding Prompts in Railtracks
 
-In RailTracks, prompts are provided as system messages or user messages when interacting with LLMs. These messages guide the LLM's behavior and responses.
+In Railtracks, prompts are provided as system messages or user messages when interacting with LLMs. These messages guide the LLM's behavior and responses.
 
 
 ## Context Injection
 
-RailTracks provides a powerful feature called "context injection" (also referred to as "prompt injection") that allows you to dynamically insert values from the global context into your prompts. This makes your prompts more flexible and reusable across different scenarios.
+Railtracks provides a powerful feature called "context injection" (also referred to as "prompt injection") that allows you to dynamically insert values from the global context into your prompts. This makes your prompts more flexible and reusable across different scenarios.
 
 ### What is Context Injection?
 
@@ -20,7 +20,7 @@ Passing prompt details up the chain can be expensive in both **tokens** and **la
 ### How Context Injection Works
 
 1. Define placeholders in your prompts using curly braces: `{variable_name}`
-2. Set values in the RailTracks context (see [Context Management](../advanced_usage/context.md) for details)
+2. Set values in the Railtracks context (see [Context Management](../advanced_usage/context.md) for details)
 3. When the prompt is processed, the placeholders are replaced with the corresponding values from the context
 
 ### Basic Example

--- a/docs/llm_support/providers.md
+++ b/docs/llm_support/providers.md
@@ -16,7 +16,7 @@ Take a look at the examples below to see how using different providers look for 
 
 === "OpenAI"
     !!! info "Environment Variables Configuration"
-        Make sure you set the appropriate environment variable keys for your specific provider. By default, RailTracks uses the `dotenv` framework to load environment variables from a `.env` file.
+        Make sure you set the appropriate environment variable keys for your specific provider. By default, Railtracks uses the `dotenv` framework to load environment variables from a `.env` file.
         Variable name for the API key: `OPENAI_API_KEY`
     
     ```python
@@ -25,7 +25,7 @@ Take a look at the examples below to see how using different providers look for 
 
 === "Anthropic"
     !!! info "Environment Variables Configuration"
-        Make sure you set the appropriate environment variable keys for your specific provider. By default, RailTracks uses the `dotenv` framework to load environment variables from a `.env` file.
+        Make sure you set the appropriate environment variable keys for your specific provider. By default, Railtracks uses the `dotenv` framework to load environment variables from a `.env` file.
         Variable name for the API key: `ANTHROPIC_API_KEY`
 
     ```python
@@ -34,7 +34,7 @@ Take a look at the examples below to see how using different providers look for 
 
 === "Gemini"
     !!! info "Environment Variables Configuration"
-        Make sure you set the appropriate environment variable keys for your specific provider. By default, RailTracks uses the `dotenv` framework to load environment variables from a `.env` file.
+        Make sure you set the appropriate environment variable keys for your specific provider. By default, Railtracks uses the `dotenv` framework to load environment variables from a `.env` file.
         Variable name for the API key: `GEMINI_API_KEY`
 
     ```python
@@ -55,7 +55,7 @@ Take a look at the examples below to see how using different providers look for 
 
 === "HuggingFace"
     !!! info "Environment Variables Configuration"
-        Make sure you set the appropriate environment variable keys for your specific provider. By default, RailTracks uses the `dotenv` framework to load environment variables from a `.env` file.
+        Make sure you set the appropriate environment variable keys for your specific provider. By default, Railtracks uses the `dotenv` framework to load environment variables from a `.env` file.
         Variable name for the API key: `HF_TOKEN`
 
     !!! caution "Tool Calling Support"

--- a/docs/observability/chat.md
+++ b/docs/observability/chat.md
@@ -1,5 +1,5 @@
 ## Overview
-Conversational interactions with agents is currently one of the most common methods. This guide will go over how to quickly visualize and come up with a proof of concept assessing how the potential user experience would look using `RailTracks`.
+Conversational interactions with agents is currently one of the most common methods. This guide will go over how to quickly visualize and come up with a proof of concept assessing how the potential user experience would look using `Railtracks`.
 
 ```python
 import random

--- a/docs/observability/error_handling.md
+++ b/docs/observability/error_handling.md
@@ -1,10 +1,10 @@
 # Error Handling
 
-RailTracks (RT) provides a comprehensive error handling system designed to give developers clear, actionable feedback when things go wrong. The framework uses a hierarchy of specialized exceptions that help you understand exactly what went wrong and where.
+Railtracks (RT) provides a comprehensive error handling system designed to give developers clear, actionable feedback when things go wrong. The framework uses a hierarchy of specialized exceptions that help you understand exactly what went wrong and where.
 
 ## Error Hierarchy
 
-All RailTracks errors inherit from the base `RTError` class, which provides colored console output and structured error reporting.
+All Railtracks errors inherit from the base `RTError` class, which provides colored console output and structured error reporting.
 
 ```
 RTError (base)
@@ -20,7 +20,7 @@ RTError (base)
 
 ### Internally Raised Errors
 
-These errors are automatically raised by RailTracks when issues occur during execution. All inherit from `RTError` and provide colored terminal output with debugging information.
+These errors are automatically raised by Railtracks when issues occur during execution. All inherit from `RTError` and provide colored terminal output with debugging information.
 
 - **`NodeCreationError`** - Raised during node setup and validation
 - **`NodeInvocationError`** - Raised during node execution (has `fatal` flag)
@@ -94,10 +94,10 @@ For detailed logging and monitoring strategies, see [Logging](logging.md).
 
 ## Debugging Tips
 
-1. **Enable Debug Logging**: RailTracks errors include colored output and debugging notes
+1. **Enable Debug Logging**: Railtracks errors include colored output and debugging notes
 2. **Check Error Properties**: Many errors include additional context (notes, message_history, etc.)
 3. **Use Message History**: LLMError includes conversation context for debugging
 4. **Examine Stack Traces**: RT errors preserve the full stack trace for debugging
 5. **Test Error Scenarios**: Write tests that verify your error handling works correctly
 
-The RailTracks error system is designed to fail fast when appropriate, provide clear feedback, and enable robust error recovery strategies.
+The Railtracks error system is designed to fail fast when appropriate, provide clear feedback, and enable robust error recovery strategies.

--- a/docs/observability/visualization.md
+++ b/docs/observability/visualization.md
@@ -1,6 +1,6 @@
 # Visualization
 
-One of the number one complaints when working with LLMs is that they can be a black box. Agentic applications exacerbate this problem by adding even more complexity. RailTracks aims to make it easier than ever to visualize your runs. 
+One of the number one complaints when working with LLMs is that they can be a black box. Agentic applications exacerbate this problem by adding even more complexity. Railtracks aims to make it easier than ever to visualize your runs. 
 
 We support:
 
@@ -9,7 +9,7 @@ We support:
 
 ## Local Development Visualization
 
-RailTracks comes with a built-in visualization tool that runs locally with **no sign up required**.
+Railtracks comes with a built-in visualization tool that runs locally with **no sign up required**.
 
 ### Usage
     

--- a/docs/system_internals/node.md
+++ b/docs/system_internals/node.md
@@ -1,8 +1,8 @@
 ## Overview
 ## Overview
 
-**Nodes** are the main components of **RailTracks** core of our abstractions. Looking at the abstract class, we can see that each Node needs the following methods implemented:
-**Nodes** are the main components of **RailTracks** core of our abstractions. Looking at the abstract class, we can see that each Node needs the following methods implemented:
+**Nodes** are the main components of **Railtracks** core of our abstractions. Looking at the abstract class, we can see that each Node needs the following methods implemented:
+**Nodes** are the main components of **Railtracks** core of our abstractions. Looking at the abstract class, we can see that each Node needs the following methods implemented:
 
 ## Execution Flow
 After the creation of a Node, execution primarily happens through the `call` method, which is responsible for invoking the node's logic and handling its execution flow. The `call` method can be called synchronously or asynchronously, depending on the node's configuration and the execution strategy in use.

--- a/docs/system_internals/overview.md
+++ b/docs/system_internals/overview.md
@@ -1,11 +1,11 @@
-# RailTracks Internal Architecture Overview
+# Railtracks Internal Architecture Overview
 
-Welcome to the internal architecture overview of RailTracks, our framework for building agentic workflows. This document provides a high-level understanding of how the system is structured and how its different components interact with each other.
+Welcome to the internal architecture overview of Railtracks, our framework for building agentic workflows. This document provides a high-level understanding of how the system is structured and how its different components interact with each other.
 
 ## Execution Flow
-# RailTracks Internal Architecture Overview
+# Railtracks Internal Architecture Overview
 
-Welcome to the internal architecture overview of RailTracks, our framework for building agentic workflows. This document provides a high-level understanding of how the system is structured and how its different components interact with each other.
+Welcome to the internal architecture overview of Railtracks, our framework for building agentic workflows. This document provides a high-level understanding of how the system is structured and how its different components interact with each other.
 
 ## Execution Flow
 
@@ -30,7 +30,7 @@ graph TD
 
 ## Developer Journey
 
-1. **Start Here**: [Core Concepts](concepts.md) - Understand the mental model behind RailTracks
+1. **Start Here**: [Core Concepts](concepts.md) - Understand the mental model behind Railtracks
 2. **Core Components**
     - [Session](session.md)
     - [PubSub System](pubsub.md)

--- a/docs/system_internals/pubsub.md
+++ b/docs/system_internals/pubsub.md
@@ -3,7 +3,7 @@
 <script src="/system_internals/js/class_diagram.js"></script>
 ## Overview
 
-The PubSub (Publisher-Subscriber) system is a messaging pattern that allows different parts of the **RailTracks** system to communicate asynchronously. Think of it like a radio station: publishers broadcast messages (like radio shows), and subscribers listen for messages they're interested in (like tuning into specific stations).
+The PubSub (Publisher-Subscriber) system is a messaging pattern that allows different parts of the **Railtracks** system to communicate asynchronously. Think of it like a radio station: publishers broadcast messages (like radio shows), and subscribers listen for messages they're interested in (like tuning into specific stations).
 
 ## What is PubSub?
 
@@ -175,12 +175,12 @@ except Exception as error:
     print(f"Failed: {error}")
 ```
 
-## RailTracks Publisher (RTPublisher)
+## Railtracks Publisher (RTPublisher)
 
-`RTPublisher` is a specialized publisher for the RailTracks system that:
+`RTPublisher` is a specialized publisher for the Railtracks system that:
 
 - Automatically logs all messages for debugging
-- Handles RailTracks specific message types
+- Handles Railtracks specific message types
 - Provides built-in error logging with stack traces
 
 ```python

--- a/docs/tools_mcp/guides/python_sandbox.md
+++ b/docs/tools_mcp/guides/python_sandbox.md
@@ -1,5 +1,5 @@
-# Running python code with RailTracks
-This is a simple guide to running Python code with RailTracks, using a Docker container as a sandboxed environment.
+# Running python code with Railtracks
+This is a simple guide to running Python code with Railtracks, using a Docker container as a sandboxed environment.
 Before running the code, make sure you have Docker installed and running on your machine.
 
 ```python

--- a/docs/tools_mcp/mcp/MCP_tools_in_RT.md
+++ b/docs/tools_mcp/mcp/MCP_tools_in_RT.md
@@ -1,26 +1,26 @@
-# Using MCP Tools in RailTracks
+# Using MCP Tools in Railtracks
 
 ## Overview
 
 !!! tip "Quick Summary"
-    RailTracks makes it easy to use any MCP-compatible tool with your agents. Just connect to an MCP server, get the tools, and start using them!
+    Railtracks makes it easy to use any MCP-compatible tool with your agents. Just connect to an MCP server, get the tools, and start using them!
 
-RailTracks supports seamless integration with [Model Context Protocol (MCP)](mcp.md), allowing you to use any MCP-compatible tool as a native RailTracks Tool. This means you can connect your agents to a wide variety of external tools and data sources—without having to implement the tool logic yourself. 
+Railtracks supports seamless integration with [Model Context Protocol (MCP)](mcp.md), allowing you to use any MCP-compatible tool as a native Railtracks Tool. This means you can connect your agents to a wide variety of external tools and data sources—without having to implement the tool logic yourself. 
 
-RailTracks handles the discovery and invocation of MCP tools, so you can focus on building intelligent agents.
+Railtracks handles the discovery and invocation of MCP tools, so you can focus on building intelligent agents.
 
 ## Prerequisites
 
 !!! note "Before You Begin"
     Make sure you have the following set up before using MCP tools:
 
-    - **RailTracks Framework** installed (`pip install railtracks[core]`)
+    - **Railtracks Framework** installed (`pip install railtracks[core]`)
     - **MCP package set up** - Every MCP tool has different requirements (see specific tool documentation)
     - **Authentication credentials** - Many MCP tools require API keys or OAuth tokens
 
 ## Connecting to MCP Server Types
 
-RailTracks supports two types of MCP servers
+Railtracks supports two types of MCP servers
 
 !!! Tip "Remote HTTP Servers"
 
@@ -38,9 +38,9 @@ RailTracks supports two types of MCP servers
     --8<-- "docs/scripts/MCP_tools_in_RT.py:stdio_example"
     ```
 
-## Using MCP Tools with RailTracks Agents
+## Using MCP Tools with Railtracks Agents
 
-Once you've connected to an MCP server, you can use the tools with your RailTracks agents:
+Once you've connected to an MCP server, you can use the tools with your Railtracks agents:
 
 ```python
 --8<-- "docs/scripts/MCP_tools_in_RT.py:stdio_example"
@@ -103,4 +103,4 @@ For detailed setup and usage instructions for specific MCP tools:
 ## Related Topics
 
 - [What is MCP?](mcp.md)
-- [RailTracks to MCP: Exposing RT Tools as MCP Tools](RTtoMCP.md)
+- [Railtracks to MCP: Exposing RT Tools as MCP Tools](RTtoMCP.md)

--- a/docs/tools_mcp/mcp/mcp.md
+++ b/docs/tools_mcp/mcp/mcp.md
@@ -15,20 +15,20 @@ Model Context Protocol (MCP) provides a unified interface, making it easy for LL
 - **Simplified Architecture**: Uniform approach to tool integration reduces complexity
 
 
-## Using MCP Tools in RailTracks
+## Using MCP Tools in Railtracks
 
-RailTracks allows you to convert MCP tools into Tools that can be used by RailTracks agents just like any other Tool. We handle the conversion and server setup for you, so you can focus on building your agents without worrying about the underlying complexities of MCP.
+Railtracks allows you to convert MCP tools into Tools that can be used by Railtracks agents just like any other Tool. We handle the conversion and server setup for you, so you can focus on building your agents without worrying about the underlying complexities of MCP.
 
 !!! example "Quick Example"
     ```python
     --8<-- "docs/scripts/MCP_tools_in_RT.py:http_example"
     ```
 
-For a complete guide and more examples, see [Using MCP Tools in RailTracks](MCP_tools_in_RT.md).
+For a complete guide and more examples, see [Using MCP Tools in Railtracks](MCP_tools_in_RT.md).
 
-## RailTracks to MCP
+## Railtracks to MCP
 
-RailTracks also provides a way to convert RailTracks Tools into MCP tools using FastMCP, allowing you to use your existing RailTracks tools in any MCP-compatible environment.
+Railtracks also provides a way to convert Railtracks Tools into MCP tools using FastMCP, allowing you to use your existing Railtracks tools in any MCP-compatible environment.
 
 This enables you to:
 
@@ -36,11 +36,11 @@ This enables you to:
 - Use your tools in other MCP-compatible frameworks
 - Create a unified toolset across different AI systems
 
-See the [RailTracks to MCP](RTtoMCP.md) page for more details on how to set this up.
+See the [Railtracks to MCP](RTtoMCP.md) page for more details on how to set this up.
 
 ## Available MCP Servers
 
-RailTracks supports pre-built integrations with various MCP servers, including:
+Railtracks supports pre-built integrations with various MCP servers, including:
 
 | MCP Server    | Description | Setup Guide                                 |
 |---------------|-------------|---------------------------------------------|

--- a/docs/tools_mcp/tools_mcp.md
+++ b/docs/tools_mcp/tools_mcp.md
@@ -1,19 +1,19 @@
-# RailTracks Tools
+# Railtracks Tools
 
 !!! tip "Extend Your Agents' Capabilities"
     Tools transform LLMs from chatbots into true agents that can take action in the world.
 
-RailTracks provides a comprehensive suite of tools that extend the capabilities of your agents, allowing them to interact with external systems and services. These tools are the "hands and eyes" of your agents, enabling them to perform actions beyond just generating text.
+Railtracks provides a comprehensive suite of tools that extend the capabilities of your agents, allowing them to interact with external systems and services. These tools are the "hands and eyes" of your agents, enabling them to perform actions beyond just generating text.
 
 ## Ways to Get Tools
 
-RailTracks offers multiple ways to access and create tools:
+Railtracks offers multiple ways to access and create tools:
 
 1. **Built-in Tools** - Use our pre-built tools for common tasks
 2. **[MCP Tools](mcp/mcp.md)** - Connect to Model Context Protocol servers for additional capabilities
 3. **[Create Your Own](tools/tools.md)** - Build custom tools for your specific needs
 
-For a conceptual overview of tools in RailTracks, see the [Tools Guide](tools/tools.md).
+For a conceptual overview of tools in Railtracks, see the [Tools Guide](tools/tools.md).
 
 ## Available Tools
 
@@ -35,7 +35,7 @@ For a conceptual overview of tools in RailTracks, see the [Tools Guide](tools/to
 
 ## Getting Started
 
-To use tools in your RailTracks agents, you'll typically follow these steps:
+To use tools in your Railtracks agents, you'll typically follow these steps:
 
 1. **Import the tools** you want to use
 2. **Create an agent** that can access these tools
@@ -62,7 +62,7 @@ Agent = rt.agent_node(
 with rt.Session():
     result = await rt.call(
         Agent,
-        "Find information about RailTracks"
+        "Find information about Railtracks"
     )
 ```
 

--- a/docs/tutorials/flows.md
+++ b/docs/tutorials/flows.md
@@ -1,6 +1,6 @@
 # Flows
 
-RailTracks makes it easy to create custom agents with access to tools they can call to complete tasks. But what if you want to use agents themselves as tools? In this section, we’ll explore more complex flows and how RailTracks gives you control over them.
+Railtracks makes it easy to create custom agents with access to tools they can call to complete tasks. But what if you want to use agents themselves as tools? In this section, we’ll explore more complex flows and how Railtracks gives you control over them.
 
 To start, let’s look at the simplest case: an agent that uses another agent as a tool.
 
@@ -25,9 +25,9 @@ graph LR
 
 Specialized agents perform better than generalist ones. For the simplest of coding projects, you might use a Top Level Agent for ideation and dialogue, a Coding Agent for the code itself, and a Static Checker for validation. It would be important that once the Static Checker approves code, no agents modify it further though. 
 
-One important aspect of RailTracks is that it handles these complex flows through wrappers. All functions and flows can become nodes that you can run by wrapping them with `function_node`.
+One important aspect of Railtracks is that it handles these complex flows through wrappers. All functions and flows can become nodes that you can run by wrapping them with `function_node`.
 
- In the following example you'll see an example of how RailTracks deals with mid-flow validation.
+ In the following example you'll see an example of how Railtracks deals with mid-flow validation.
 
 ### Example
 ```python
@@ -53,7 +53,7 @@ graph TD
 
 ## Handling More Complex Flows
 While `function_node` works well for linear flows, some scenarios require transferring between different agents like moving from technical support to billing in a customer service system.
-In these cases, you need to pass data directly between agents without mutations or the "telephone game" effect of traditional handoffs. RailTracks solves this with [context](../advanced_usage/context.md), a mechanism for sharing data across agent transfers while preserving integrity.
+In these cases, you need to pass data directly between agents without mutations or the "telephone game" effect of traditional handoffs. Railtracks solves this with [context](../advanced_usage/context.md), a mechanism for sharing data across agent transfers while preserving integrity.
 Let's see how context enables reliable multi-agent workflows.
 
 ### Customer Service Agents

--- a/docs/tutorials/rag_tutorial.md
+++ b/docs/tutorials/rag_tutorial.md
@@ -31,7 +31,7 @@ RAG solves all of these problems by giving your AI access to real, up-to-date in
 
 ## How RAG Works
 
-When you create a RAG node, RailTracks automatically handles these stages for you:
+When you create a RAG node, Railtracks automatically handles these stages for you:
 
 ### RAG Pipeline Steps
 === "1. 📄 Chunk"

--- a/docs/tutorials/ryfa.md
+++ b/docs/tutorials/ryfa.md
@@ -3,7 +3,7 @@
 ## Calling the Agent directly
 Once you have defined your agent class ([Build Your First Agent](byfa.md)) you can then run your workflow and see results!
 
-To begin you just have to use **`call`** method from RailTracks. This is an asynchronous method so you will need to run it in an async context.
+To begin you just have to use **`call`** method from Railtracks. This is an asynchronous method so you will need to run it in an async context.
 
 === "Asynchronous"
     ```python
@@ -32,7 +32,7 @@ To begin you just have to use **`call`** method from RailTracks. This is an asyn
 
 !!! info "Dynamic Runtime Configuration"
 
-    If you pass `llm` to `agent_node` and then a different llm model to `call` function, RailTracks will use the latter one. If you pass `system_message` to `agent_node` and then another `system_message` to `call`, the system messages will be stacked.
+    If you pass `llm` to `agent_node` and then a different llm model to `call` function, Railtracks will use the latter one. If you pass `system_message` to `agent_node` and then another `system_message` to `call`, the system messages will be stacked.
 
     ??? example
         ```python
@@ -44,7 +44,7 @@ To begin you just have to use **`call`** method from RailTracks. This is an asyn
 
             --8<-- "docs/scripts/first_agent.py:dynamic_prompts"
         ```
-        In this example RailTracks will use claude rather than chatgpt and the `system_message` will become
+        In this example Railtracks will use claude rather than chatgpt and the `system_message` will become
         `"You are a helpful assistant that answers weather-related questions. If not specified, the user is talking about Vancouver."`
 
 Just like that you have run your first agent!

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: RailTracks Docs
+site_name: Railtracks Docs
 site_url: https://railtownai.github.io/railtracks/
-site_description: "RailTracks is a framework for building LLM-powered agents and applications."
+site_description: "Railtracks is a framework for building LLM-powered agents and applications."
 
 repo_name: railtracks
 repo_url: https://github.com/RailtownAI/railtracks/

--- a/packages/railtracks/README.md
+++ b/packages/railtracks/README.md
@@ -58,7 +58,7 @@ async def main():
     result = await rt.call(
         TextAnalyzer,
         rt.llm.MessageHistory([
-            rt.llm.UserMessage("Hello world! This is a test of the RailTracks framework.")
+            rt.llm.UserMessage("Hello world! This is a test of the Railtracks framework.")
         ])
     )
     print(result)

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -2,7 +2,7 @@
 #   Copyright (c) Railtown AI. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #   -------------------------------------------------------------
-"""The RailTracks Framework for building resilient agentic systems in simple python"""
+"""The Railtracks Framework for building resilient agentic systems in simple python"""
 
 from __future__ import annotations
 

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -339,7 +339,7 @@ def session(
 ):
     """
     This decorator automatically creates and manages a Session context for the decorated function,
-    allowing async functions to use RailTracks operations without manually managing the session lifecycle.
+    allowing async functions to use Railtracks operations without manually managing the session lifecycle.
 
     Can be used as:
     - @session (without parentheses) - uses default settings

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# RailTracks API Documentation Generator
+# Railtracks API Documentation Generator
 
 set -e  # Exit on any error
 
-echo "Generating RailTracks API Documentation..."
+echo "Generating Railtracks API Documentation..."
 
 # Check if pdoc is installed
 if ! command -v pdoc &> /dev/null; then


### PR DESCRIPTION
Renaming `RailTracks` to `Railtracks` across the repo.