### PR TITLE
Fixing broken actions link

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ jobs:
           python-version: "${{ env.PYTHON_VERSION }}"
 
       - name: Install dependencies
-        uses: ./.github/workflows/install_deps.yaml
+        uses: ./.github/actions/install-deps
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 


### PR DESCRIPTION
This PR addresses CI/CD issues with a wrong link to a non-existent github action