### PR TITLE
Fix RailTracks CLI server when retrieving file names that are urlencoded

### DIFF
--- a/packages/railtracks-cli/src/railtracks_cli/__init__.py
+++ b/packages/railtracks-cli/src/railtracks_cli/__init__.py
@@ -30,7 +30,7 @@ import webbrowser
 import zipfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse, unquote
+from urllib.parse import unquote, urlparse
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer

--- a/packages/railtracks-cli/src/railtracks_cli/__init__.py
+++ b/packages/railtracks-cli/src/railtracks_cli/__init__.py
@@ -30,7 +30,7 @@ import webbrowser
 import zipfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, unquote
 
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
@@ -284,8 +284,10 @@ class RailtracksHTTPHandler(BaseHTTPRequestHandler):
     def handle_api_json(self, path):
         """Handle /api/json/{filename} endpoint - load specific JSON file"""
         try:
-            # Extract filename from path
+            # Extract filename from path and URL decode it
             filename = path.replace("/api/json/", "")
+            # URL decode the filename to handle spaces and special characters
+            filename = unquote(filename)
             if not filename.endswith(".json"):
                 filename += ".json"
 


### PR DESCRIPTION
The endpoint that returns file content doesn't handle url-encoded file names (`my%20cool%20agent%20session.json`) with whitespace.

An example of this is when a user creates an agent with an agent session name with white space in it. After successfully running it, it will create a JSON on file name that is valid with a space in it but when the visualizer front-end requests the content for that particular agent session, it will return to 404.


https://github.com/user-attachments/assets/f274304b-0d60-44c9-9dc9-343371c58329




## Type of changes

Please check the type of change your PR introduces:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)
 


## Checklist for Author 

### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Documentation
- [x] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [x] Breaking changes are documented
- [x] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)
 
