### PR TITLE
Fix/749/check port usage

### DIFF
--- a/packages/railtracks-cli/src/railtracks_cli/__init__.py
+++ b/packages/railtracks-cli/src/railtracks_cli/__init__.py
@@ -590,7 +590,7 @@ def main():
         if is_port_in_use(DEFAULT_PORT):
             print_error(f"Port {DEFAULT_PORT} is already in use!")
             print_warning("You already have a railtracks viz server running.")
-            print_status("Please stop the existing server or use a different port.")
+            print_status("Please stop the existing server.")
             sys.exit(1)
 
         # Setup directories

--- a/packages/railtracks-cli/src/railtracks_cli/__init__.py
+++ b/packages/railtracks-cli/src/railtracks_cli/__init__.py
@@ -20,6 +20,7 @@ import json
 import mimetypes
 import os
 import queue
+import socket
 import sys
 import tempfile
 import threading
@@ -69,6 +70,16 @@ def print_warning(message):
 
 def print_error(message):
     print(f"[{cli_name}] {message}")
+
+
+def is_port_in_use(port):
+    """Check if a port is already in use"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("localhost", port))
+            return False  # Port is available
+        except OSError:
+            return True  # Port is in use
 
 
 def set_stream_queue(stream_queue):
@@ -575,6 +586,13 @@ def main():
     if command == "init":
         init_railtracks()
     elif command == "viz":
+        # Check if port is already in use
+        if is_port_in_use(DEFAULT_PORT):
+            print_error(f"Port {DEFAULT_PORT} is already in use!")
+            print_warning("You already have a railtracks viz server running.")
+            print_status("Please stop the existing server or use a different port.")
+            sys.exit(1)
+
         # Setup directories
         create_railtracks_dir()
 


### PR DESCRIPTION
## What does this add?

Warn the user if they are running multiple railtracks viz servers.

<img width="2293" height="804" alt="image" src="https://github.com/user-attachments/assets/242dbdcf-d6ac-4489-8088-88a5a1cf3a76" />


https://github.com/user-attachments/assets/85b86c5d-f3a8-4036-9135-cc7827705332


## Type of changes

Please check the type of change your PR introduces:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)
 
## Checklist for Author 

### Code Quality
- [ ] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [ ] Code is commented, particularly in hard-to-understand areas

### Testing
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Test coverage maintained

### Documentation
- [ ] Documentation updated if needed (bot will verify)

### Git & PR Management
- [ ] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)
 

Closes #749 
