### PR TITLE
E2E tests removed from push to main

### DIFF
--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -111,8 +111,8 @@ jobs:
         run: |
           python scripts/check_dependencies_sorted.py
 
-  all_tests:
-    name: All Tests
+  tests:
+    name: Tests
     runs-on: windows-latest
     needs:
       - ruff-lint
@@ -131,6 +131,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
+
       - name: Install dependencies
         uses: ./.github/actions/install-deps
         with:
@@ -138,14 +139,8 @@ jobs:
 
       - name: Run tests
         shell: bash
-        env:
-          OPENAI_API_KEY: ${{ secrets.E2E_TESTS_OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.E2E_TESTS_ANTHROPIC_API_KEY }}
-          HF_TOKEN: ${{ secrets.E2E_TESTS_HUGGINGFACE_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.E2E_TESTS_GEMINI_API_KEY }}
-          COHERE_API_KEY: ${{ secrets.E2E_TESTS_COHERE_API_KEY }}
         run: |
-          pytest -s -v --junit-xml=all-test-results.xml --ignore=packages/railtracks-cli 
+          pytest -s -v --junit-xml=unit-test-results.xml packages/railtracks/tests/unit_tests/ packages/railtracks/tests/integration_tests/
 
   build-railtracks-cli:
     name: Test Railtracks CLI


### PR DESCRIPTION
## What does this add?

It was discovered that upon forking the repo, tests would fail on syncing the fork due to not having the relevant api keys in the fork repo. We have decided to remove the E2E testing on pushing to main since they will already be tested before pr approval by maintainers running the workflow manually.

## Type of changes

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [x] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Additional Notes
cc: @jbueza 