### PR TITLE
Fixed Live LLM Tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,4 +80,6 @@ lint.mccabe.max-complexity = 10
 asyncio_mode = "auto"
 addopts = [
     "--import-mode=importlib",
+    "--ignore=packages/railtracks/tests/llm_live_tests",
+    "--ignore=packages/railtracks/tests/end_to_end/rag",
 ]


### PR DESCRIPTION
## What does this add?

There were 2 issues with the live llm tests:
1. The tests were ignored at the root in `pyproject.toml` (@Amir-R25 if I get a quick clarification on why that change was made)
2. The tests were broken during the refactor seen in #780 (specifically the method change of model_distrubutor was not properly handled in the refactor)

## Type of changes

Please check the type of change your PR introduces:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Background context
This is not a user facing change purely pipeline work


## Checklist for Author
<!-- Skip sections not relevant to your change type (e.g., skip Testing for docs-only changes) -->

### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Documentation
- [x] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [x] Breaking changes are documented
- [x] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

