### PR TITLE
Warning added for the deprecation of the `railtracks-cli` package

### DIFF
--- a/packages/railtracks-cli/README.md
+++ b/packages/railtracks-cli/README.md
@@ -1,5 +1,8 @@
 # Railtracks CLI
 
+> [!WARNING]
+> **This package is no longer maintained.** `railtracks-cli` has been archived and will not receive further updates or bug fixes. The visualization functionality is now built directly into the [`railtracks`](https://pypi.org/project/railtracks/) package. Please migrate to `railtracks` for continued support.
+
 [![PyPI version](https://img.shields.io/pypi/v/railtracks-cli)](https://github.com/RailtownAI/railtracks/releases)
 [![Python Versions](https://img.shields.io/pypi/pyversions/railtracks-cli?logo=python&)](https://pypi.org/project/railtracks/)
 [![License](https://img.shields.io/pypi/l/railtracks-cli)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
`railtracks-cli` functionality is being moved to the main package `railtracks`. We are deprecating the support for `railracks-cli`. This PR will add the corresponding warning message.

<img width="1262" height="422" alt="image" src="https://github.com/user-attachments/assets/2f73b176-6cba-448f-9111-e6fc2adc064f" />
