### PR TITLE
Update mkdocs dependency version constraint to prevent breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Railtracks is developed in the open. Contributions, bug reports, and feature req
   <a href="https://railtownai.github.io/railtracks/quickstart/quickstart/">
     <img src="https://img.shields.io/badge/Quick_Start-4285F4?style=for-the-badge&logo=rocket&logoColor=white" alt="Quick Start" />
   </a>
-  <a href="https://railtownai.github.io/railtracks/">
+  <a href="https://docs.railtracks.org/">
     <img src="https://img.shields.io/badge/Documentation-00D4AA?style=for-the-badge&logo=gitbook&logoColor=white" alt="Documentation" />
   </a>
   <a href="https://github.com/RailtownAI/railtracks/tree/main/examples">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ members = [
 
 [dependency-groups]
 docs = [
-    "mkdocs>=1.6.1",
+    "mkdocs>=1.6.1,<2.0.0",
     "mkdocs-material>=9.6.15",
     "mkdocs-material-extensions>=1.3.1",
     "mkdocs-mermaid2-plugin>=1.2.1",


### PR DESCRIPTION
Following: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

While the last release of mkdocs for version 1.X is from Aug 30, 2024, this PR pins our version with the hopes of an update to 1.X and also pins it so we won't automatically update to the incompatible 2.X.