### PR TITLE
Implement PIIEntity enhancements and streamline guardrail evaluations

### DIFF
--- a/docs/guardrails/builtin_guardrails.md
+++ b/docs/guardrails/builtin_guardrails.md
@@ -1,0 +1,95 @@
+# Built-in guardrails
+
+This page describes guardrails shipped with Railtracks, how they are organized, and how to try them in isolation with `evaluate()`. For attaching rails to agents and the `Guard` container, see [Overview](overview.md) and [Quickstart](quickstart.md).
+
+## Introduction
+
+**Where they live.** Core types (`Guard`, `InputGuard`, `OutputGuard`, `LLMGuardrailEvent`, `GuardrailDecision`, …) live in the `railtracks.guardrails` package. Built-in LLM guard *implementations* (today: PII redaction) live under `railtracks.guardrails.llm` and are re-exported from that module for a single import path.
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:core_imports"
+```
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:llm_builtin_imports"
+```
+
+**`evaluate()`.** `InputGuard` and `OutputGuard` define `evaluate(...)` so you can run a guard without building an `LLMGuardrailEvent` by hand. For input guards, a `str` is treated as a single user message. For output guards, a `str` becomes the assistant message under inspection. You can also pass `Message`, `MessageHistory`, or a full `LLMGuardrailEvent`. On a match, inspect `GuardrailDecision.messages` (input guard) or `GuardrailDecision.output_message` (output guard) for the rewritten content.
+
+PII guards return `TRANSFORM` when they rewrite text, with redacted content on `decision.messages` (input) or `decision.output_message` (output). They return `ALLOW` when there is nothing to change.
+
+## Contributing a built-in guardrail
+
+1. Implement the guard in `packages/railtracks/src/railtracks/guardrails/llm/` (e.g. `input/` and `output/` modules, shared logic in a private subpackage such as `_pii/`).
+2. Subclass `InputGuard` or `OutputGuard`, implement `__call__(self, event: LLMGuardrailEvent) -> GuardrailDecision`, and rely on `evaluate()` from the base class for ad hoc testing.
+3. Export public names from `railtracks/guardrails/llm/__init__.py` (and submodules’ `__init__.py` if you split them).
+4. Add unit tests under `packages/railtracks/tests/unit_tests/guardrails/`.
+5. Extend `docs/scripts/builtin_guardrails_examples.py` with snippet regions and document the guard in this file under **Guardrails**.
+
+Keep dependencies optional or zero unless the feature truly needs them; document behavior, limits, and false-positive/false-negative tradeoffs briefly.
+
+## Guardrails
+
+### PII redaction
+
+`PIIRedactInputGuard` and `PIIRedactOutputGuard` scan **string** message content with regex. Matches are replaced by placeholders such as `[EMAIL_ADDRESS]`. The input guard scans user and system messages; assistant and tool messages are left unchanged. The output guard scans the model’s output message. Non-string content is passed through unchanged.
+
+Detection uses a fixed priority when patterns overlap (for example, email and URL win over the broader phone pattern). `CREDIT_CARD` and `CA_SIN` matches are accepted only when they pass a Luhn checksum check.
+
+#### Entities
+
+Built-in entity enum `PIIEntity` includes:
+
+| Entity | Notes |
+|--------|--------|
+| `EMAIL_ADDRESS` | Common email shapes |
+| `PHONE_NUMBER` | `+country`, parentheses, dots, dashes; 7–10 digit core |
+| `CREDIT_CARD` | 13–16 digit groups, Luhn-validated |
+| `US_SSN` | `###-##-####` with word boundaries |
+| `CA_SIN` | Canadian SIN `###-###-###`, Luhn-validated |
+| `IP_ADDRESS` | IPv4 |
+| `URL` | `http://` or `https://` only |
+| `IBAN_CODE` | IBAN with optional spaces |
+
+Discover names and short descriptions at runtime:
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:pii_available"
+```
+
+#### Configuration
+
+`PIIRedactConfig` is a **frozen** Pydantic model: default `entities` is the full list above; `custom_patterns` defaults to empty. Each `PIICustomPattern` has a `name` (used in the placeholder) and a `regex` string.
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:pii_configured_demo"
+```
+
+!!! example "Sample `result.messages`"
+    ```text
+    user: My name is Alice and my email is [EMAIL_ADDRESS] and my SIN is [CA_SIN]
+    ```
+
+#### Custom patterns
+
+You are not limited to `PIIEntity` values. Add `PIICustomPattern(name=..., regex=...)` entries to `custom_patterns`; each `name` becomes the placeholder label (for example `EMPLOYEE_ID` produces `[EMPLOYEE_ID]`). Use them alone or together with any built-in entities in the same `PIIRedactConfig`.
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:pii_custom_patterns"
+```
+
+!!! example "Illustrative redacted line"
+    For the sample string in the snippet above, the user message content may look like: `My ID is [EMPLOYEE_ID]; contact [EMAIL_ADDRESS] internally.`
+
+Use the same `PIIRedactConfig` instance for both input and output guards if you want identical rules.
+
+#### Agent usage
+
+Attach like any other guard:
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:agent_guard_attachment"
+```
+
+!!! note "Scope"
+    This PII layer is regex-only: no NER/Presidio, no `MASK` mode, no streaming-specific API, and no redaction inside tool calls yet. Those may arrive in later releases.

--- a/docs/guardrails/builtin_guardrails.md
+++ b/docs/guardrails/builtin_guardrails.md
@@ -36,6 +36,8 @@ Keep dependencies optional or zero unless the feature truly needs them; document
 
 Detection uses a fixed priority when patterns overlap (for example, email and URL win over the broader phone pattern). `CREDIT_CARD` and `CA_SIN` matches are accepted only when they pass a Luhn checksum check.
 
+---
+
 #### Entities
 
 Built-in entity enum `PIIEntity` includes:
@@ -57,6 +59,8 @@ Discover names and short descriptions at runtime:
 --8<-- "docs/scripts/builtin_guardrails_examples.py:pii_available"
 ```
 
+---
+
 #### Configuration
 
 `PIIRedactConfig` is a **frozen** Pydantic model: default `entities` is the full list above; `custom_patterns` defaults to empty. Each `PIICustomPattern` has a `name` (used in the placeholder) and a `regex` string.
@@ -70,6 +74,8 @@ Discover names and short descriptions at runtime:
     user: My name is Alice and my email is [EMAIL_ADDRESS] and my SIN is [CA_SIN]
     ```
 
+---
+
 #### Custom patterns
 
 You are not limited to `PIIEntity` values. Add `PIICustomPattern(name=..., regex=...)` entries to `custom_patterns`; each `name` becomes the placeholder label (for example `EMPLOYEE_ID` produces `[EMPLOYEE_ID]`). Use them alone or together with any built-in entities in the same `PIIRedactConfig`.
@@ -82,6 +88,8 @@ You are not limited to `PIIEntity` values. Add `PIICustomPattern(name=..., regex
     For the sample string in the snippet above, the user message content may look like: `My ID is [EMPLOYEE_ID]; contact [EMAIL_ADDRESS] internally.`
 
 Use the same `PIIRedactConfig` instance for both input and output guards if you want identical rules.
+
+---
 
 #### Agent usage
 

--- a/docs/guardrails/builtin_guardrails.md
+++ b/docs/guardrails/builtin_guardrails.md
@@ -1,6 +1,6 @@
 # Built-in guardrails
 
-This page describes guardrails shipped with Railtracks, how they are organized, and how to try them in isolation with `evaluate()`. For attaching rails to agents and the `Guard` container, see [Overview](overview.md) and [Quickstart](quickstart.md).
+This page describes guardrails shipped with Railtracks, how they are organized, and how to try them in isolation with `decide()`. For attaching rails to agents and the `Guard` container, see [Overview](overview.md) and [Quickstart](quickstart.md).
 
 ## Introduction
 
@@ -14,14 +14,14 @@ This page describes guardrails shipped with Railtracks, how they are organized, 
 --8<-- "docs/scripts/builtin_guardrails_examples.py:llm_builtin_imports"
 ```
 
-**`evaluate()`.** `InputGuard` and `OutputGuard` define `evaluate(...)` so you can run a guard without building an `LLMGuardrailEvent` by hand. For input guards, a `str` is treated as a single user message. For output guards, a `str` becomes the assistant message under inspection. You can also pass `Message`, `MessageHistory`, or a full `LLMGuardrailEvent`. On a match, inspect `GuardrailDecision.messages` (input guard) or `GuardrailDecision.output_message` (output guard) for the rewritten content.
+**`decide()`.** `InputGuard` and `OutputGuard` define `decide(...)` so you can run a guard without building an `LLMGuardrailEvent` by hand. For input guards, a `str` is treated as a single user message. For output guards, a `str` becomes the assistant message under inspection. You can also pass `Message`, `MessageHistory`, or a full `LLMGuardrailEvent`. On a match, inspect `GuardrailDecision.messages` (input guard) or `GuardrailDecision.output_message` (output guard) for the rewritten content.
 
 PII guards return `TRANSFORM` when they rewrite text, with redacted content on `decision.messages` (input) or `decision.output_message` (output). They return `ALLOW` when there is nothing to change.
 
 ## Contributing a built-in guardrail
 
 1. Implement the guard in `packages/railtracks/src/railtracks/guardrails/llm/` (e.g. `input/` and `output/` modules, shared logic in a private subpackage such as `_pii/`).
-2. Subclass `InputGuard` or `OutputGuard`, implement `__call__(self, event: LLMGuardrailEvent) -> GuardrailDecision`, and rely on `evaluate()` from the base class for ad hoc testing.
+2. Subclass `InputGuard` or `OutputGuard`, implement `__call__(self, event: LLMGuardrailEvent) -> GuardrailDecision`, and rely on `decide()` from the base class for ad hoc testing.
 3. Export public names from `railtracks/guardrails/llm/__init__.py` (and submodules’ `__init__.py` if you split them).
 4. Add unit tests under `packages/railtracks/tests/unit_tests/guardrails/`.
 5. Extend `docs/scripts/builtin_guardrails_examples.py` with snippet regions and document the guard in this file under **Guardrails**.

--- a/docs/scripts/builtin_guardrails_examples.py
+++ b/docs/scripts/builtin_guardrails_examples.py
@@ -1,0 +1,96 @@
+"""
+Examples for docs/guardrails/builtin_guardrails.md.
+
+Snippet markers (--8<-- [start:name]) are consumed by MkDocs snippets;
+run from repo root: uv run python docs/scripts/builtin_guardrails_examples.py
+"""
+
+from __future__ import annotations
+
+# --8<-- [start:core_imports]
+from railtracks.guardrails import (
+    Guard,
+    GuardrailDecision,
+    InputGuard,
+    LLMGuardrailEvent,
+    OutputGuard,
+)
+# --8<-- [end:core_imports]
+
+# --8<-- [start:llm_builtin_imports]
+from railtracks.guardrails.llm import (
+    PIICustomPattern,
+    PIIEntity,
+    PIIRedactConfig,
+    PIIRedactInputGuard,
+    PIIRedactOutputGuard,
+)
+# --8<-- [end:llm_builtin_imports]
+
+# --8<-- [start:pii_available]
+names_to_help = PIIEntity.available()
+# e.g. {"EMAIL_ADDRESS": "Email addresses (e.g. alice@example.com)", ...}
+# --8<-- [end:pii_available]
+
+# --8<-- [start:pii_configured_demo]
+config = PIIRedactConfig(
+    entities=[
+        PIIEntity.EMAIL_ADDRESS,
+        PIIEntity.CA_SIN,
+    ]
+)
+
+redact_input = PIIRedactInputGuard(config=config, name="RedactEmail")
+
+msg = (
+    "My name is Alice and my email is alice@example.com "
+    "and my SIN is 163-180-003"
+)
+result = redact_input.evaluate(msg)
+# result.messages — redacted user message(s)
+# --8<-- [end:pii_configured_demo]
+
+# --8<-- [start:pii_custom_patterns]
+custom_config = PIIRedactConfig(
+    entities=[PIIEntity.EMAIL_ADDRESS],
+    custom_patterns=[
+        PIICustomPattern(name="EMPLOYEE_ID", regex=r"\bEMP-\d{6}\b"),
+    ],
+)
+
+guard_with_custom = PIIRedactInputGuard(config=custom_config)
+
+result = guard_with_custom.evaluate(
+    "My ID is EMP-123456; contact hr@company.example internally."
+)
+# result.messages — redacted user message(s), e.g. [EMPLOYEE_ID] and [EMAIL_ADDRESS]
+# --8<-- [end:pii_custom_patterns]
+
+# --8<-- [start:agent_guard_attachment]
+import railtracks as rt
+
+Agent = rt.agent_node(
+    name="pii-redact-demo",
+    llm=rt.llm.GeminiLLM("gemini-2.5-flash"),
+    system_message="You are a concise assistant.",
+    guardrails=Guard(
+        input=[PIIRedactInputGuard()],
+        output=[PIIRedactOutputGuard()],
+    ),
+)
+# --8<-- [end:agent_guard_attachment]
+
+
+def main() -> None:
+    print("PIIEntity.available() keys:", sorted(PIIEntity.available().keys()))
+    cfg = PIIRedactConfig(entities=[PIIEntity.EMAIL_ADDRESS, PIIEntity.CA_SIN])
+    demo_guard = PIIRedactInputGuard(config=cfg, name="RedactEmail")
+    demo_msg = (
+        "My name is Alice and my email is alice@example.com "
+        "and my SIN is 163-180-003"
+    )
+    print(demo_guard.evaluate(demo_msg).messages)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/builtin_guardrails_examples.py
+++ b/docs/scripts/builtin_guardrails_examples.py
@@ -46,7 +46,7 @@ msg = (
     "My name is Alice and my email is alice@example.com "
     "and my SIN is 163-180-003"
 )
-result = redact_input.evaluate(msg)
+result = redact_input.decide(msg)
 # result.messages — redacted user message(s)
 # --8<-- [end:pii_configured_demo]
 
@@ -60,7 +60,7 @@ custom_config = PIIRedactConfig(
 
 guard_with_custom = PIIRedactInputGuard(config=custom_config)
 
-result = guard_with_custom.evaluate(
+result = guard_with_custom.decide(
     "My ID is EMP-123456; contact hr@company.example internally."
 )
 # result.messages — redacted user message(s), e.g. [EMPLOYEE_ID] and [EMAIL_ADDRESS]
@@ -89,7 +89,7 @@ def main() -> None:
         "My name is Alice and my email is alice@example.com "
         "and my SIN is 163-180-003"
     )
-    print(demo_guard.evaluate(demo_msg).messages)
+    print(demo_guard.decide(demo_msg).messages)
 
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
   - Guardrails:
       - Overview: guardrails/overview.md
       - Quickstart: guardrails/quickstart.md
+      - Built-in guardrails: guardrails/builtin_guardrails.md
 
   - Evaluations:
       - Preface: evaluations/preface.md

--- a/packages/railtracks/src/railtracks/guardrails/core/config.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/config.py
@@ -15,6 +15,17 @@ class Guard(BaseModel):
     The runner expects each rail to be callable with :class:`LLMGuardrailEvent` and
     return a :class:`GuardrailDecision`. For output rails, the guarded assistant
     message is ``event.output_message`` (see :class:`~railtracks.guardrails.core.event.LLMGuardrailEvent`).
+
+    Attributes:
+        input: LLM input guardrails (prompt / message history).
+        output: LLM output guardrails (model response).
+        tool_call: Reserved for future tool-call guardrails (not yet wired).
+        tool_response: Reserved for future tool-response guardrails (not yet wired).
+        fail_open: If True, a rail exception, bad transform, or unknown action is
+            recorded but does not stop the chain; if False, the runner stops and
+            returns a blocking decision.
+        trace: Reserved to toggle whether nodes attach per-rail traces (e.g. to
+            ``details``); the mixin currently always collects traces when rails run.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/packages/railtracks/src/railtracks/guardrails/core/decision.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/decision.py
@@ -9,12 +9,31 @@ from railtracks.llm import Message, MessageHistory
 
 
 class GuardrailAction(str, Enum):
+    """What the runner should do after a guardrail returns.
+
+    Members:
+        ALLOW: Keep the current input or output unchanged.
+        TRANSFORM: Replace input messages or the output message from the decision.
+        BLOCK: Stop and treat the interaction as blocked.
+    """
+
     ALLOW = "allow"
     TRANSFORM = "transform"
     BLOCK = "block"
 
 
 class GuardrailDecision(BaseModel):
+    """Result of one guardrail invocation.
+
+    Which fields are set depends on :attr:`action`:
+
+    * ``ALLOW``: only :attr:`reason` and optional :attr:`meta` are typically used.
+    * ``TRANSFORM``: for input phase, :attr:`messages` holds the new history; for
+      output phase, :attr:`output_message` holds the new assistant message.
+    * ``BLOCK``: :attr:`user_facing_message` and :attr:`meta` may carry details for
+      callers or UIs.
+    """
+
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     action: GuardrailAction
@@ -28,6 +47,15 @@ class GuardrailDecision(BaseModel):
     def allow(
         cls, reason: str = "Allowed by guardrail.", meta: dict[str, Any] | None = None
     ) -> "GuardrailDecision":
+        """Build an ``ALLOW`` decision with no content changes.
+
+        Args:
+            reason: Explanation for traces and debugging.
+            meta: Optional extra fields for observability.
+
+        Returns:
+            A decision with :attr:`action` ``ALLOW``.
+        """
         return cls(action=GuardrailAction.ALLOW, reason=reason, meta=meta)
 
     @classmethod
@@ -37,6 +65,16 @@ class GuardrailDecision(BaseModel):
         user_facing_message: str | None = None,
         meta: dict[str, Any] | None = None,
     ) -> "GuardrailDecision":
+        """Build a ``BLOCK`` decision.
+
+        Args:
+            reason: Explanation for logs, traces, and raised errors.
+            user_facing_message: Optional message safe to show to end users.
+            meta: Optional extra fields (e.g. exception details).
+
+        Returns:
+            A decision with :attr:`action` ``BLOCK``.
+        """
         return cls(
             action=GuardrailAction.BLOCK,
             reason=reason,
@@ -51,6 +89,16 @@ class GuardrailDecision(BaseModel):
         reason: str,
         meta: dict[str, Any] | None = None,
     ) -> "GuardrailDecision":
+        """Build a ``TRANSFORM`` decision for LLM input (message history).
+
+        Args:
+            messages: Replacement conversation history for the model call.
+            reason: Explanation for traces and debugging.
+            meta: Optional extra fields (e.g. redaction counts).
+
+        Returns:
+            A decision with :attr:`action` ``TRANSFORM`` and :attr:`messages` set.
+        """
         return cls(
             action=GuardrailAction.TRANSFORM,
             reason=reason,
@@ -65,6 +113,17 @@ class GuardrailDecision(BaseModel):
         reason: str,
         meta: dict[str, Any] | None = None,
     ) -> "GuardrailDecision":
+        """Build a ``TRANSFORM`` decision for LLM output (assistant message).
+
+        Args:
+            output_message: Replacement assistant message to return.
+            reason: Explanation for traces and debugging.
+            meta: Optional extra fields (e.g. redaction counts).
+
+        Returns:
+            A decision with :attr:`action` ``TRANSFORM`` and :attr:`output_message`
+            set.
+        """
         return cls(
             action=GuardrailAction.TRANSFORM,
             reason=reason,

--- a/packages/railtracks/src/railtracks/guardrails/core/errors.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/errors.py
@@ -27,6 +27,19 @@ class GuardrailBlockedError(NodeInvocationError):
         notes: list[str] | None = None,
         fatal: bool = False,
     ):
+        """Create a block error with optional trace and user-facing context.
+
+        Args:
+            rail_name: Name of the rail that blocked, if known.
+            reason: Machine-oriented explanation (also embedded in the base message).
+            user_facing_message: Optional short text for clients or UIs.
+            traces: Optional list of :class:`~railtracks.guardrails.core.trace.GuardrailTrace`
+                from the failed run.
+            meta: Optional structured details copied from the blocking decision.
+            notes: Extra debug lines forwarded to :class:`NodeInvocationError`.
+            fatal: Passed through to :class:`NodeInvocationError` (whether the run is
+                considered unrecoverable).
+        """
         self.rail_name = rail_name
         self.reason = reason
         self.user_facing_message = user_facing_message

--- a/packages/railtracks/src/railtracks/guardrails/core/event.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/event.py
@@ -11,18 +11,32 @@ from railtracks.llm.message import Message
 
 
 class LLMGuardrailPhase(str, Enum):
+    """Which side of the LLM call a guardrail observes.
+
+    Members:
+        INPUT: Before the model (prompt / history), value ``llm_input``.
+        OUTPUT: After the model (assistant message), value ``llm_output``.
+    """
+
     INPUT = "llm_input"
     OUTPUT = "llm_output"
 
 
 class LLMGuardrailEvent(BaseModel):
-    """
-    Event passed to LLM guardrails.
+    """Payload for LLM input and output guardrails.
 
-    - ``messages``: conversation context (usually the history *before* the current
-      assistant reply is appended to the node).
-    - ``output_message``: for ``phase == OUTPUT``, the assistant ``Message`` being
-      guarded this turn; ``None`` for INPUT phase or when not applicable.
+    Attributes:
+        phase: Whether this is an input-phase or output-phase check.
+        messages: Conversation context, usually the history before the current
+            assistant reply is appended by the node.
+        output_message: For ``OUTPUT`` phase, the assistant :class:`~railtracks.llm.message.Message`
+            under inspection; ``None`` for input phase or when not applicable.
+        node_name: Optional node label for observability.
+        node_uuid: Optional stable node id for observability.
+        run_id: Optional run correlation id.
+        model_name: Optional resolved model name for observability.
+        model_provider: Optional provider string for observability.
+        tags: Optional key/value metadata (e.g. ``agent_kind`` from the mixin).
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Protocol
 
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.message import AssistantMessage, Message, UserMessage
+
 from .decision import GuardrailDecision
 from .event import LLMGuardrailEvent, LLMGuardrailPhase
 
@@ -43,10 +46,47 @@ class BaseLLMGuardrail(BaseGuardrail):
         pass
 
 
+def _coerce_to_message_history(
+    input: str | Any | MessageHistory,
+) -> MessageHistory:
+    """Convert str, Message, or MessageHistory to a MessageHistory."""
+    if isinstance(input, MessageHistory):
+        return input
+    if isinstance(input, str):
+        return MessageHistory([UserMessage(input)])
+    if isinstance(input, Message):
+        return MessageHistory([input])
+    raise TypeError(
+        f"Expected str, Message, MessageHistory, or LLMGuardrailEvent, "
+        f"got {type(input).__name__}"
+    )
+
+
 class InputGuard(BaseLLMGuardrail):
     """Base for guardrails that run on LLM input (e.g. prompt / message history)."""
 
     phase = LLMGuardrailPhase.INPUT
+
+    def evaluate(
+        self,
+        input: str | Any | MessageHistory | LLMGuardrailEvent,
+    ) -> GuardrailDecision:
+        """
+        Convenience method to run the guardrail without constructing an
+        ``LLMGuardrailEvent`` manually.
+
+        Accepts ``str``, ``Message``, ``MessageHistory``, or a full
+        ``LLMGuardrailEvent`` and delegates to ``__call__``.
+        """
+        if isinstance(input, LLMGuardrailEvent):
+            return self(input)
+
+        messages = _coerce_to_message_history(input)
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.INPUT,
+            messages=messages,
+        )
+        return self(event)
 
 
 class OutputGuard(BaseLLMGuardrail):
@@ -58,3 +98,41 @@ class OutputGuard(BaseLLMGuardrail):
     """
 
     phase = LLMGuardrailPhase.OUTPUT
+
+    def evaluate(
+        self,
+        output: str | Any | MessageHistory | LLMGuardrailEvent,
+    ) -> GuardrailDecision:
+        """
+        Convenience method to run the guardrail without constructing an
+        ``LLMGuardrailEvent`` manually.
+
+        Accepts ``str``, ``Message``, ``MessageHistory``, or a full
+        ``LLMGuardrailEvent`` and delegates to ``__call__``.
+        """
+        if isinstance(output, LLMGuardrailEvent):
+            return self(output)
+
+        if isinstance(output, str):
+            output_message = AssistantMessage(output)
+            messages = MessageHistory()
+        elif isinstance(output, Message):
+            output_message = output
+            messages = MessageHistory()
+        elif isinstance(output, MessageHistory):
+            if not output:
+                raise ValueError("Cannot evaluate an empty MessageHistory.")
+            output_message = output[-1]
+            messages = MessageHistory(output[:-1])
+        else:
+            raise TypeError(
+                f"Expected str, Message, MessageHistory, or LLMGuardrailEvent, "
+                f"got {type(output).__name__}"
+            )
+
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=messages,
+            output_message=output_message,
+        )
+        return self(event)

--- a/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
@@ -67,7 +67,7 @@ class InputGuard(BaseLLMGuardrail):
 
     phase = LLMGuardrailPhase.INPUT
 
-    def evaluate(
+    def decide(
         self,
         input: str | Any | MessageHistory | LLMGuardrailEvent,
     ) -> GuardrailDecision:
@@ -99,7 +99,7 @@ class OutputGuard(BaseLLMGuardrail):
 
     phase = LLMGuardrailPhase.OUTPUT
 
-    def evaluate(
+    def decide(
         self,
         output: str | Any | MessageHistory | LLMGuardrailEvent,
     ) -> GuardrailDecision:
@@ -121,7 +121,7 @@ class OutputGuard(BaseLLMGuardrail):
             messages = MessageHistory()
         elif isinstance(output, MessageHistory):
             if not output:
-                raise ValueError("Cannot evaluate an empty MessageHistory.")
+                raise ValueError("Cannot decide with an empty MessageHistory.")
             output_message = output[-1]
             messages = MessageHistory(output[:-1])
         else:

--- a/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
@@ -29,6 +29,11 @@ class BaseGuardrail(ABC):
     name: str
 
     def __init__(self, name: str | None = None):
+        """Initialize the guardrail.
+
+        Args:
+            name: Rail name for traces and debugging; defaults to the class name.
+        """
         self.name = name or self.__class__.__name__
 
     @abstractmethod
@@ -37,7 +42,12 @@ class BaseGuardrail(ABC):
 
 
 class BaseLLMGuardrail(BaseGuardrail):
-    """Abstract base class for guardrails that run on LLM input or output."""
+    """Abstract base class for guardrails that run on LLM input or output.
+
+    Attributes:
+        phase: Whether this rail expects :class:`LLMGuardrailPhase` ``INPUT`` or
+            ``OUTPUT`` events.
+    """
 
     phase: LLMGuardrailPhase
 
@@ -63,7 +73,11 @@ def _coerce_to_message_history(
 
 
 class InputGuard(BaseLLMGuardrail):
-    """Base for guardrails that run on LLM input (e.g. prompt / message history)."""
+    """Base for guardrails that run on LLM input (e.g. prompt / message history).
+
+    Attributes:
+        phase: Always :attr:`LLMGuardrailPhase.INPUT`.
+    """
 
     phase = LLMGuardrailPhase.INPUT
 
@@ -71,12 +85,19 @@ class InputGuard(BaseLLMGuardrail):
         self,
         input: str | Any | MessageHistory | LLMGuardrailEvent,
     ) -> GuardrailDecision:
-        """
-        Convenience method to run the guardrail without constructing an
-        ``LLMGuardrailEvent`` manually.
+        """Run this guard without building an :class:`LLMGuardrailEvent` by hand.
 
-        Accepts ``str``, ``Message``, ``MessageHistory``, or a full
-        ``LLMGuardrailEvent`` and delegates to ``__call__``.
+        Args:
+            input: A :class:`LLMGuardrailEvent` (passed through), a ``str`` (treated
+                as a single user message), a :class:`~railtracks.llm.message.Message`,
+                or a :class:`~railtracks.llm.history.MessageHistory`.
+
+        Returns:
+            The :class:`GuardrailDecision` from :meth:`__call__`.
+
+        Raises:
+            TypeError: If ``input`` is not a ``str``, ``Message``, ``MessageHistory``,
+                or :class:`LLMGuardrailEvent`.
         """
         if isinstance(input, LLMGuardrailEvent):
             return self(input)
@@ -90,11 +111,13 @@ class InputGuard(BaseLLMGuardrail):
 
 
 class OutputGuard(BaseLLMGuardrail):
-    """
-    Base for guardrails that run on LLM output (e.g. model response).
+    """Base for guardrails that run on LLM output (e.g. model response).
 
     Inspect ``event.output_message`` for the assistant message produced this turn.
     ``event.messages`` is conversation context and may not yet include that reply.
+
+    Attributes:
+        phase: Always :attr:`LLMGuardrailPhase.OUTPUT`.
     """
 
     phase = LLMGuardrailPhase.OUTPUT
@@ -103,12 +126,22 @@ class OutputGuard(BaseLLMGuardrail):
         self,
         output: str | Any | MessageHistory | LLMGuardrailEvent,
     ) -> GuardrailDecision:
-        """
-        Convenience method to run the guardrail without constructing an
-        ``LLMGuardrailEvent`` manually.
+        """Run this guard without building an :class:`LLMGuardrailEvent` by hand.
 
-        Accepts ``str``, ``Message``, ``MessageHistory``, or a full
-        ``LLMGuardrailEvent`` and delegates to ``__call__``.
+        Args:
+            output: A :class:`LLMGuardrailEvent` (passed through), a ``str`` (becomes
+                the assistant message with empty prior history), a
+                :class:`~railtracks.llm.message.Message`, or a non-empty
+                :class:`~railtracks.llm.history.MessageHistory` (last message is the
+                output under test; earlier entries become ``event.messages``).
+
+        Returns:
+            The :class:`GuardrailDecision` from :meth:`__call__`.
+
+        Raises:
+            ValueError: If ``output`` is an empty :class:`~railtracks.llm.history.MessageHistory`.
+            TypeError: If ``output`` is not a ``str``, ``Message``, ``MessageHistory``,
+                or :class:`LLMGuardrailEvent`.
         """
         if isinstance(output, LLMGuardrailEvent):
             return self(output)

--- a/packages/railtracks/src/railtracks/guardrails/core/runner.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/runner.py
@@ -69,6 +69,14 @@ def _extract_transform_value(
 
 
 class GuardRunner:
+    """Runs LLM input and output guardrail chains for a :class:`Guard` configuration.
+
+    For each rail, records a :class:`GuardrailTrace`. If a rail raises, returns invalid
+    output types, or uses an unknown action, behavior depends on ``guard.fail_open``:
+    when True, processing continues with the last good value; when False, the chain
+    stops and the third return value is a blocking :class:`GuardrailDecision`.
+    """
+
     def __init__(self, guard: Guard):
         self.guard = guard
 
@@ -229,6 +237,24 @@ class GuardRunner:
     def run_llm_input(
         self, event: LLMGuardrailEvent
     ) -> tuple[MessageHistory, list[GuardrailTrace], GuardrailDecision | None]:
+        """Run all input rails on ``event.messages``.
+
+        Normalizes ``event`` to input phase and clears ``output_message`` so input
+        guards see a consistent :class:`LLMGuardrailEvent`.
+
+        Args:
+            event: Any LLM guardrail event; phase may be coerced to ``INPUT`` and
+                ``output_message`` cleared before running the chain.
+
+        Returns:
+            A tuple ``(messages, traces, decision)``. ``messages`` is the possibly
+            transformed :class:`~railtracks.llm.history.MessageHistory`. ``traces``
+            lists each rail outcome, including ``action="error"`` when a rail raised
+            or returned an invalid result (if ``fail_open`` allowed continuation).
+            ``decision`` is ``None`` when the chain completed without a stop.
+            Otherwise it is a :class:`GuardrailDecision` with action ``block`` produced
+            when ``fail_open`` is False (rail exception, bad transform, unknown action).
+        """
         input_event = (
             event
             if event.phase == LLMGuardrailPhase.INPUT
@@ -247,6 +273,25 @@ class GuardRunner:
     def run_llm_output(
         self, event: LLMGuardrailEvent, output: Message
     ) -> tuple[Message, list[GuardrailTrace], GuardrailDecision | None]:
+        """Run all output rails on ``output`` with ``event`` as context.
+
+        Ensures ``event.phase`` is ``OUTPUT`` and sets ``event.output_message`` to
+        ``output`` before running the chain.
+
+        Args:
+            event: Conversation context for the guardrail call; phase may be coerced to
+                ``OUTPUT``.
+            output: The assistant :class:`~railtracks.llm.message.Message` to guard.
+
+        Returns:
+            A tuple ``(message, traces, decision)``. ``message`` is the possibly
+            transformed assistant message. ``traces`` lists each rail outcome, including
+            ``action="error"`` when a rail raised or returned an invalid result (if
+            ``fail_open`` allowed continuation). ``decision`` is ``None`` when the
+            chain completed without a stop. Otherwise it is a blocking
+            :class:`GuardrailDecision` when ``fail_open`` is False (rail exception,
+            bad transform, unknown action).
+        """
         output_event = (
             event
             if event.phase == LLMGuardrailPhase.OUTPUT

--- a/packages/railtracks/src/railtracks/guardrails/core/trace.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/trace.py
@@ -6,6 +6,18 @@ from pydantic import BaseModel
 
 
 class GuardrailTrace(BaseModel):
+    """One guardrail step recorded during a run (for logging or debugging).
+
+    Attributes:
+        rail_name: The guard's :attr:`~railtracks.guardrails.core.interfaces.BaseGuardrail.name`
+            or class name if unset.
+        phase: ``LLMGuardrailPhase`` value string (e.g. ``llm_input``).
+        action: ``allow``, ``transform``, ``block``, or ``error`` when the runner
+            caught an exception, invalid return type, or unknown action.
+        reason: Short explanation, or a fixed message for error traces.
+        meta: Optional details (e.g. :attr:`GuardrailDecision.meta` or exception info).
+    """
+
     rail_name: str
     phase: str
     action: str

--- a/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
@@ -1,4 +1,16 @@
 from . import input, output
+from ._pii.config import PIICustomPattern, PIIEntity, PIIRedactConfig
+from .input.pii_redact import PIIRedactInputGuard
 from .mixin import LLMGuardrailsMixin
+from .output.pii_redact import PIIRedactOutputGuard
 
-__all__ = ["input", "output", "LLMGuardrailsMixin"]
+__all__ = [
+    "input",
+    "output",
+    "LLMGuardrailsMixin",
+    "PIICustomPattern",
+    "PIIEntity",
+    "PIIRedactConfig",
+    "PIIRedactInputGuard",
+    "PIIRedactOutputGuard",
+]

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/__init__.py
@@ -1,0 +1,10 @@
+from .config import PIICustomPattern, PIIEntity, PIIRedactConfig
+from .engine import PIIEngine, RedactionRecord
+
+__all__ = [
+    "PIICustomPattern",
+    "PIIEntity",
+    "PIIRedactConfig",
+    "PIIEngine",
+    "RedactionRecord",
+]

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
@@ -12,9 +12,27 @@ class PIIEntity(str, Enum):
     PHONE_NUMBER = "PHONE_NUMBER"
     CREDIT_CARD = "CREDIT_CARD"
     US_SSN = "US_SSN"
+    CA_SIN = "CA_SIN"
     IP_ADDRESS = "IP_ADDRESS"
     URL = "URL"
     IBAN_CODE = "IBAN_CODE"
+
+    @classmethod
+    def available(cls) -> dict[str, str]:
+        """Return a mapping of entity name to a human-readable description."""
+        return {e.value: _ENTITY_DESCRIPTIONS[e] for e in cls}
+
+
+_ENTITY_DESCRIPTIONS: dict[PIIEntity, str] = {
+    PIIEntity.EMAIL_ADDRESS: "Email addresses (e.g. alice@example.com)",
+    PIIEntity.PHONE_NUMBER: "Phone numbers in common formats (e.g. +1 555-867-5309)",
+    PIIEntity.CREDIT_CARD: "Credit/debit card numbers validated with Luhn checksum",
+    PIIEntity.US_SSN: "US Social Security Numbers (e.g. 123-45-6789)",
+    PIIEntity.CA_SIN: "Canadian Social Insurance Numbers (e.g. 046-454-286)",
+    PIIEntity.IP_ADDRESS: "IPv4 addresses (e.g. 192.168.1.1)",
+    PIIEntity.URL: "URLs starting with http:// or https://",
+    PIIEntity.IBAN_CODE: "International Bank Account Numbers (e.g. GB29 NWBK 6016 1331 9268 19)",
+}
 
 
 class PIICustomPattern(BaseModel):

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
@@ -19,7 +19,11 @@ class PIIEntity(str, Enum):
 
     @classmethod
     def available(cls) -> dict[str, str]:
-        """Return a mapping of entity name to a human-readable description."""
+        """Return built-in entity codes and short descriptions for UI or docs.
+
+        Returns:
+            Mapping from entity value string (e.g. ``EMAIL_ADDRESS``) to description.
+        """
         return {e.value: _ENTITY_DESCRIPTIONS[e] for e in cls}
 
 
@@ -41,6 +45,10 @@ class PIICustomPattern(BaseModel):
 
     ``name`` becomes the placeholder label: e.g. ``"EMPLOYEE_ID"`` yields
     ``[EMPLOYEE_ID]`` in redacted text.
+
+    Attributes:
+        name: Label used in placeholders and metadata.
+        regex: Pattern passed to :func:`re.compile` for matching.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -55,6 +63,10 @@ class PIIRedactConfig(BaseModel):
 
     Frozen so a single instance can safely be shared between input and output
     guard instances.
+
+    Attributes:
+        entities: Built-in :class:`PIIEntity` kinds to detect; defaults to all members.
+        custom_patterns: Extra :class:`PIICustomPattern` rows merged into detection.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PIIEntity(str, Enum):
+    """Built-in PII entity types with reliable regex detection."""
+
+    EMAIL_ADDRESS = "EMAIL_ADDRESS"
+    PHONE_NUMBER = "PHONE_NUMBER"
+    CREDIT_CARD = "CREDIT_CARD"
+    US_SSN = "US_SSN"
+    IP_ADDRESS = "IP_ADDRESS"
+    URL = "URL"
+    IBAN_CODE = "IBAN_CODE"
+
+
+class PIICustomPattern(BaseModel):
+    """
+    User-defined PII pattern.
+
+    ``name`` becomes the placeholder label: e.g. ``"EMPLOYEE_ID"`` yields
+    ``[EMPLOYEE_ID]`` in redacted text.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    regex: str
+
+
+class PIIRedactConfig(BaseModel):
+    """
+    Configuration for PII redaction guardrails.
+
+    Frozen so a single instance can safely be shared between input and output
+    guard instances.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    entities: list[PIIEntity] = list(PIIEntity)
+    custom_patterns: list[PIICustomPattern] = []

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from .config import PIICustomPattern, PIIEntity, PIIRedactConfig
+from .config import PIIEntity, PIIRedactConfig
 
 _BUILTIN_PATTERNS: dict[PIIEntity, str] = {
     PIIEntity.EMAIL_ADDRESS: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
@@ -20,6 +20,7 @@ _BUILTIN_PATTERNS: dict[PIIEntity, str] = {
     ),
     PIIEntity.CREDIT_CARD: r"\b(?:\d[ \-]?){13,16}\b",
     PIIEntity.US_SSN: r"\b\d{3}-\d{2}-\d{4}\b",
+    PIIEntity.CA_SIN: r"\b\d{3}-\d{3}-\d{3}\b",
     PIIEntity.IP_ADDRESS: r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
     PIIEntity.URL: r"https?://[^\s<>\"']+",
     PIIEntity.IBAN_CODE: r"\b[A-Z]{2}\d{2}[\s]?[\dA-Z]{4}[\s]?(?:[\dA-Z]{4}[\s]?){1,7}[\dA-Z]{1,4}\b",
@@ -31,9 +32,18 @@ _PATTERN_PRIORITY: list[PIIEntity] = [
     PIIEntity.CREDIT_CARD,
     PIIEntity.IBAN_CODE,
     PIIEntity.US_SSN,
+    PIIEntity.CA_SIN,
     PIIEntity.IP_ADDRESS,
     PIIEntity.PHONE_NUMBER,
 ]
+
+
+_LUHN_VALIDATED: frozenset[str] = frozenset(
+    {
+        PIIEntity.CREDIT_CARD.value,
+        PIIEntity.CA_SIN.value,
+    }
+)
 
 
 def _passes_luhn(digits: str) -> bool:
@@ -89,13 +99,9 @@ class PIIEngine:
             raw = _BUILTIN_PATTERNS.get(entity)
             if raw is None:
                 continue
-            self._patterns.append(
-                (re.compile(raw), entity.value, f"[{entity.value}]")
-            )
+            self._patterns.append((re.compile(raw), entity.value, f"[{entity.value}]"))
         for cp in config.custom_patterns:
-            self._patterns.append(
-                (re.compile(cp.regex), cp.name, f"[{cp.name}]")
-            )
+            self._patterns.append((re.compile(cp.regex), cp.name, f"[{cp.name}]"))
 
     def redact(self, text: str) -> tuple[str, list[RedactionRecord]]:
         spans = self._detect(text)
@@ -127,7 +133,7 @@ class PIIEngine:
         spans: list[_Span] = []
         for priority, (pattern, entity_type, placeholder) in enumerate(self._patterns):
             for m in pattern.finditer(text):
-                if entity_type == PIIEntity.CREDIT_CARD.value:
+                if entity_type in _LUHN_VALIDATED:
                     digits = re.sub(r"\D", "", m.group())
                     if not _passes_luhn(digits):
                         continue

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
@@ -8,8 +8,15 @@ from pydantic import BaseModel
 
 from .config import PIIEntity, PIIRedactConfig
 
+# Insertion order defines overlap precedence (earlier = wins in _merge_spans).
 _BUILTIN_PATTERNS: dict[PIIEntity, str] = {
     PIIEntity.EMAIL_ADDRESS: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+    PIIEntity.URL: r"https?://[^\s<>\"']+",
+    PIIEntity.CREDIT_CARD: r"\b(?:\d[ \-]?){13,16}\b",
+    PIIEntity.IBAN_CODE: r"\b[A-Z]{2}\d{2}[\s]?[\dA-Z]{4}[\s]?(?:[\dA-Z]{4}[\s]?){1,7}[\dA-Z]{1,4}\b",
+    PIIEntity.US_SSN: r"\b\d{3}-\d{2}-\d{4}\b",
+    PIIEntity.CA_SIN: r"\b\d{3}-\d{3}-\d{3}\b",
+    PIIEntity.IP_ADDRESS: r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
     PIIEntity.PHONE_NUMBER: (
         r"(?<![.\d/])"
         r"(?:\+\d{1,3}[\s\-.]?)?"
@@ -18,24 +25,7 @@ _BUILTIN_PATTERNS: dict[PIIEntity, str] = {
         r"(?!\d)"
         r"(?!\.\d)"
     ),
-    PIIEntity.CREDIT_CARD: r"\b(?:\d[ \-]?){13,16}\b",
-    PIIEntity.US_SSN: r"\b\d{3}-\d{2}-\d{4}\b",
-    PIIEntity.CA_SIN: r"\b\d{3}-\d{3}-\d{3}\b",
-    PIIEntity.IP_ADDRESS: r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
-    PIIEntity.URL: r"https?://[^\s<>\"']+",
-    PIIEntity.IBAN_CODE: r"\b[A-Z]{2}\d{2}[\s]?[\dA-Z]{4}[\s]?(?:[\dA-Z]{4}[\s]?){1,7}[\dA-Z]{1,4}\b",
 }
-
-_PATTERN_PRIORITY: list[PIIEntity] = [
-    PIIEntity.EMAIL_ADDRESS,
-    PIIEntity.URL,
-    PIIEntity.CREDIT_CARD,
-    PIIEntity.IBAN_CODE,
-    PIIEntity.US_SSN,
-    PIIEntity.CA_SIN,
-    PIIEntity.IP_ADDRESS,
-    PIIEntity.PHONE_NUMBER,
-]
 
 
 _LUHN_VALIDATED: frozenset[str] = frozenset(
@@ -91,8 +81,6 @@ class RedactionRecord(BaseModel):
 class _Span:
     """Internal mutable span used during detection before merging."""
 
-    __slots__ = ("start", "end", "entity_type", "placeholder", "priority")
-
     def __init__(
         self, start: int, end: int, entity_type: str, placeholder: str, priority: int
     ):
@@ -113,12 +101,10 @@ class PIIEngine:
     def __init__(self, config: PIIRedactConfig) -> None:
         self._patterns: list[tuple[re.Pattern[str], str, str]] = []
         entity_set = set(config.entities)
-        for entity in _PATTERN_PRIORITY:
+        for entity in _BUILTIN_PATTERNS:
             if entity not in entity_set:
                 continue
-            raw = _BUILTIN_PATTERNS.get(entity)
-            if raw is None:
-                continue
+            raw = _BUILTIN_PATTERNS[entity]
             self._patterns.append((re.compile(raw), entity.value, f"[{entity.value}]"))
         for cp in config.custom_patterns:
             self._patterns.append((re.compile(cp.regex), cp.name, f"[{cp.name}]"))

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
@@ -47,6 +47,19 @@ _LUHN_VALIDATED: frozenset[str] = frozenset(
 
 
 def _passes_luhn(digits: str) -> bool:
+    """Return whether ``digits`` satisfies the Luhn (mod 10) checksum.
+
+    See: https://en.wikipedia.org/wiki/Luhn_algorithm
+
+    Used to cut false positives on credit-card and Canadian SIN patterns.
+
+    Args:
+        digits: Only decimal digit characters (non-digits should be stripped by the
+            caller).
+
+    Returns:
+        True if the Luhn check passes.
+    """
     total = 0
     reverse = digits[::-1]
     for i, ch in enumerate(reverse):
@@ -60,7 +73,14 @@ def _passes_luhn(digits: str) -> bool:
 
 
 class RedactionRecord(BaseModel):
-    """A single redacted span (no raw value stored)."""
+    """One redacted substring (placeholder only; original text is not stored).
+
+    Attributes:
+        entity_type: Detector label (built-in entity value or custom pattern name).
+        placeholder: Replacement text inserted into the string (e.g. ``[EMAIL_ADDRESS]``).
+        start: Start offset in the original string.
+        end: End offset (exclusive) in the original string.
+    """
 
     entity_type: str
     placeholder: str
@@ -104,6 +124,15 @@ class PIIEngine:
             self._patterns.append((re.compile(cp.regex), cp.name, f"[{cp.name}]"))
 
     def redact(self, text: str) -> tuple[str, list[RedactionRecord]]:
+        """Replace detected spans with placeholders, merging overlaps by priority.
+
+        Args:
+            text: Input string to scan.
+
+        Returns:
+            The redacted string and a list of :class:`RedactionRecord` entries for
+            each placeholder segment (offsets refer to ``text``).
+        """
         spans = self._detect(text)
         if not spans:
             return text, []
@@ -167,7 +196,16 @@ def _merge_spans(spans: list[_Span]) -> list[_Span]:
 def build_redaction_meta(
     records: list[RedactionRecord], messages_affected: int | None = None
 ) -> dict[str, Any]:
-    """Build the ``meta`` dict for ``GuardrailDecision``."""
+    """Build the ``meta`` dict for :class:`~railtracks.guardrails.core.decision.GuardrailDecision`.
+
+    Args:
+        records: Redaction rows from :meth:`PIIEngine.redact`.
+        messages_affected: For input guards, how many messages contained redactions.
+
+    Returns:
+        A dict with ``redacted_entities`` (counts per entity type) and optionally
+        ``messages_affected``.
+    """
     counts: Counter[str] = Counter()
     for r in records:
         counts[r.entity_type] += 1

--- a/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/_pii/engine.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Any
+
+from pydantic import BaseModel
+
+from .config import PIICustomPattern, PIIEntity, PIIRedactConfig
+
+_BUILTIN_PATTERNS: dict[PIIEntity, str] = {
+    PIIEntity.EMAIL_ADDRESS: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+    PIIEntity.PHONE_NUMBER: (
+        r"(?<![.\d/])"
+        r"(?:\+\d{1,3}[\s\-.]?)?"
+        r"(?:\(?\d{3}\)?[\s\-.]?)?"
+        r"\d{3}[\s\-.]?\d{4}"
+        r"(?!\d)"
+        r"(?!\.\d)"
+    ),
+    PIIEntity.CREDIT_CARD: r"\b(?:\d[ \-]?){13,16}\b",
+    PIIEntity.US_SSN: r"\b\d{3}-\d{2}-\d{4}\b",
+    PIIEntity.IP_ADDRESS: r"\b(?:\d{1,3}\.){3}\d{1,3}\b",
+    PIIEntity.URL: r"https?://[^\s<>\"']+",
+    PIIEntity.IBAN_CODE: r"\b[A-Z]{2}\d{2}[\s]?[\dA-Z]{4}[\s]?(?:[\dA-Z]{4}[\s]?){1,7}[\dA-Z]{1,4}\b",
+}
+
+_PATTERN_PRIORITY: list[PIIEntity] = [
+    PIIEntity.EMAIL_ADDRESS,
+    PIIEntity.URL,
+    PIIEntity.CREDIT_CARD,
+    PIIEntity.IBAN_CODE,
+    PIIEntity.US_SSN,
+    PIIEntity.IP_ADDRESS,
+    PIIEntity.PHONE_NUMBER,
+]
+
+
+def _passes_luhn(digits: str) -> bool:
+    total = 0
+    reverse = digits[::-1]
+    for i, ch in enumerate(reverse):
+        n = int(ch)
+        if i % 2 == 1:
+            n *= 2
+            if n > 9:
+                n -= 9
+        total += n
+    return total % 10 == 0
+
+
+class RedactionRecord(BaseModel):
+    """A single redacted span (no raw value stored)."""
+
+    entity_type: str
+    placeholder: str
+    start: int
+    end: int
+
+
+class _Span:
+    """Internal mutable span used during detection before merging."""
+
+    __slots__ = ("start", "end", "entity_type", "placeholder", "priority")
+
+    def __init__(
+        self, start: int, end: int, entity_type: str, placeholder: str, priority: int
+    ):
+        self.start = start
+        self.end = end
+        self.entity_type = entity_type
+        self.placeholder = placeholder
+        self.priority = priority
+
+
+class PIIEngine:
+    """
+    Regex-based PII detection and redaction engine.
+
+    Compile patterns once at construction time; call ``redact()`` for each text.
+    """
+
+    def __init__(self, config: PIIRedactConfig) -> None:
+        self._patterns: list[tuple[re.Pattern[str], str, str]] = []
+        entity_set = set(config.entities)
+        for entity in _PATTERN_PRIORITY:
+            if entity not in entity_set:
+                continue
+            raw = _BUILTIN_PATTERNS.get(entity)
+            if raw is None:
+                continue
+            self._patterns.append(
+                (re.compile(raw), entity.value, f"[{entity.value}]")
+            )
+        for cp in config.custom_patterns:
+            self._patterns.append(
+                (re.compile(cp.regex), cp.name, f"[{cp.name}]")
+            )
+
+    def redact(self, text: str) -> tuple[str, list[RedactionRecord]]:
+        spans = self._detect(text)
+        if not spans:
+            return text, []
+
+        merged = _merge_spans(spans)
+        records: list[RedactionRecord] = []
+        parts: list[str] = []
+        cursor = 0
+
+        for span in merged:
+            parts.append(text[cursor : span.start])
+            parts.append(span.placeholder)
+            records.append(
+                RedactionRecord(
+                    entity_type=span.entity_type,
+                    placeholder=span.placeholder,
+                    start=span.start,
+                    end=span.end,
+                )
+            )
+            cursor = span.end
+
+        parts.append(text[cursor:])
+        return "".join(parts), records
+
+    def _detect(self, text: str) -> list[_Span]:
+        spans: list[_Span] = []
+        for priority, (pattern, entity_type, placeholder) in enumerate(self._patterns):
+            for m in pattern.finditer(text):
+                if entity_type == PIIEntity.CREDIT_CARD.value:
+                    digits = re.sub(r"\D", "", m.group())
+                    if not _passes_luhn(digits):
+                        continue
+                spans.append(
+                    _Span(m.start(), m.end(), entity_type, placeholder, priority)
+                )
+        return spans
+
+
+def _merge_spans(spans: list[_Span]) -> list[_Span]:
+    """
+    Sort by start offset, then by priority (lower = higher priority).
+    When spans overlap, keep the higher-priority one; break ties by length.
+    """
+    spans.sort(key=lambda s: (s.start, s.priority))
+    merged: list[_Span] = []
+    for span in spans:
+        if merged and span.start < merged[-1].end:
+            prev = merged[-1]
+            if span.priority < prev.priority:
+                merged[-1] = span
+            elif span.priority == prev.priority and (span.end - span.start) > (
+                prev.end - prev.start
+            ):
+                merged[-1] = span
+        else:
+            merged.append(span)
+    return merged
+
+
+def build_redaction_meta(
+    records: list[RedactionRecord], messages_affected: int | None = None
+) -> dict[str, Any]:
+    """Build the ``meta`` dict for ``GuardrailDecision``."""
+    counts: Counter[str] = Counter()
+    for r in records:
+        counts[r.entity_type] += 1
+    meta: dict[str, Any] = {
+        "redacted_entities": [
+            {"entity_type": et, "count": c} for et, c in counts.items()
+        ],
+    }
+    if messages_affected is not None:
+        meta["messages_affected"] = messages_affected
+    return meta

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
@@ -1,1 +1,3 @@
-__all__: list[str] = []
+from .pii_redact import PIIRedactInputGuard
+
+__all__ = ["PIIRedactInputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/pii_redact.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/pii_redact.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import InputGuard
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.message import Message, Role
+
+from .._pii.config import PIIRedactConfig
+from .._pii.engine import PIIEngine, RedactionRecord, build_redaction_meta
+
+_SCANNABLE_ROLES = frozenset({Role.user, Role.system})
+
+
+class PIIRedactInputGuard(InputGuard):
+    """
+    Input guardrail that redacts PII from user and system messages before
+    they reach the LLM.
+    """
+
+    def __init__(
+        self,
+        config: PIIRedactConfig | None = None,
+        *,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        self._config = config or PIIRedactConfig()
+        self._engine = PIIEngine(self._config)
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        all_records: list[RedactionRecord] = []
+        new_messages: list[Message] = []
+        messages_affected = 0
+
+        for msg in event.messages:
+            if msg.role not in _SCANNABLE_ROLES or not isinstance(msg.content, str):
+                new_messages.append(msg)
+                continue
+
+            redacted_text, records = self._engine.redact(msg.content)
+            if records:
+                all_records.extend(records)
+                messages_affected += 1
+                clone = deepcopy(msg)
+                clone._content = redacted_text
+                new_messages.append(clone)
+            else:
+                new_messages.append(msg)
+
+        if not all_records:
+            return GuardrailDecision.allow(reason="No PII detected in input.")
+
+        return GuardrailDecision.transform_messages(
+            messages=MessageHistory(new_messages),
+            reason=f"Redacted {len(all_records)} PII span(s) from input messages.",
+            meta=build_redaction_meta(all_records, messages_affected=messages_affected),
+        )

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/pii_redact.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/pii_redact.py
@@ -15,10 +15,7 @@ _SCANNABLE_ROLES = frozenset({Role.user, Role.system})
 
 
 class PIIRedactInputGuard(InputGuard):
-    """
-    Input guardrail that redacts PII from user and system messages before
-    they reach the LLM.
-    """
+    """Redacts PII from user and system string messages before they reach the LLM."""
 
     def __init__(
         self,
@@ -26,11 +23,25 @@ class PIIRedactInputGuard(InputGuard):
         *,
         name: str | None = None,
     ) -> None:
+        """Initialize the input PII redactor.
+
+        Args:
+            config: Redaction settings; defaults to all built-in entity kinds and no
+                custom patterns (see :class:`~railtracks.guardrails.llm.PIIRedactConfig`).
+            name: Optional rail name for traces (see :class:`InputGuard`).
+        """
         super().__init__(name=name)
         self._config = config or PIIRedactConfig()
         self._engine = PIIEngine(self._config)
 
     def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        """Scan user/system string content and redact matches.
+
+        Returns:
+            ``ALLOW`` when no PII is found, or ``TRANSFORM`` with rewritten messages on
+            :attr:`~railtracks.guardrails.core.decision.GuardrailDecision.messages`
+            and redaction metadata in ``meta``.
+        """
         all_records: list[RedactionRecord] = []
         new_messages: list[Message] = []
         messages_affected = 0

--- a/packages/railtracks/src/railtracks/guardrails/llm/mixin.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/mixin.py
@@ -21,9 +21,19 @@ from ..core.trace import GuardrailTrace
 
 
 class LLMGuardrailsMixin:
-    """
-    Mixin for nodes that invoke an LLM. Overrides _pre_invoke and _post_invoke to run
-    input and output guardrails. Set guardrails= when building the node.
+    """Mixin for nodes that invoke an LLM.
+
+    Overrides ``_pre_invoke`` and ``_post_invoke`` to run input and output guardrails.
+    Set ``guardrails=`` when building the node. Expects ``self._details`` to contain a
+    ``guard_details`` list; each run extends it with :class:`~railtracks.guardrails.core.trace.GuardrailTrace`
+    rows when rails execute.
+
+    Output rails run only when ``_post_invoke`` receives a :class:`~railtracks.llm.response.Response`;
+    other result types are returned unchanged.
+
+    Raises:
+        GuardrailBlockedError: When a rail returns ``BLOCK`` (runner stops the chain
+            with a blocking decision).
     """
 
     guardrails: Guard | None = None

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
@@ -1,1 +1,3 @@
-__all__: list[str] = []
+from .pii_redact import PIIRedactOutputGuard
+
+__all__ = ["PIIRedactOutputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/pii_redact.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/pii_redact.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import OutputGuard
+
+from .._pii.config import PIIRedactConfig
+from .._pii.engine import PIIEngine, build_redaction_meta
+
+
+class PIIRedactOutputGuard(OutputGuard):
+    """
+    Output guardrail that redacts PII from the assistant's response after
+    LLM generation.
+    """
+
+    def __init__(
+        self,
+        config: PIIRedactConfig | None = None,
+        *,
+        name: str | None = None,
+    ) -> None:
+        super().__init__(name=name)
+        self._config = config or PIIRedactConfig()
+        self._engine = PIIEngine(self._config)
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        msg = event.output_message
+        if msg is None or not isinstance(msg.content, str):
+            return GuardrailDecision.allow(reason="No string output to scan.")
+
+        redacted_text, records = self._engine.redact(msg.content)
+        if not records:
+            return GuardrailDecision.allow(reason="No PII detected in output.")
+
+        clone = deepcopy(msg)
+        clone._content = redacted_text
+        return GuardrailDecision.transform_output(
+            output_message=clone,
+            reason=f"Redacted {len(records)} PII span(s) from output.",
+            meta=build_redaction_meta(records),
+        )

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/pii_redact.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/pii_redact.py
@@ -11,10 +11,7 @@ from .._pii.engine import PIIEngine, build_redaction_meta
 
 
 class PIIRedactOutputGuard(OutputGuard):
-    """
-    Output guardrail that redacts PII from the assistant's response after
-    LLM generation.
-    """
+    """Redacts PII from the assistant string response after LLM generation."""
 
     def __init__(
         self,
@@ -22,11 +19,26 @@ class PIIRedactOutputGuard(OutputGuard):
         *,
         name: str | None = None,
     ) -> None:
+        """Initialize the output PII redactor.
+
+        Args:
+            config: Which built-in entities and custom patterns to apply; defaults to
+                all built-in entity kinds.
+            name: Optional rail name for traces (see :class:`OutputGuard`).
+        """
         super().__init__(name=name)
         self._config = config or PIIRedactConfig()
         self._engine = PIIEngine(self._config)
 
     def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        """Redact PII from string assistant content on ``event.output_message``.
+
+        Returns:
+            ``ALLOW`` when there is nothing to scan or no PII, or ``TRANSFORM`` with the
+            rewritten message on
+            :attr:`~railtracks.guardrails.core.decision.GuardrailDecision.output_message`
+            and redaction metadata in ``meta``.
+        """
         msg = event.output_message
         if msg is None or not isinstance(msg.content, str):
             return GuardrailDecision.allow(reason="No string output to scan.")

--- a/packages/railtracks/tests/unit_tests/guardrails/test_decide.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_decide.py
@@ -1,4 +1,4 @@
-"""Tests for InputGuard.evaluate() and OutputGuard.evaluate() convenience methods."""
+"""Tests for InputGuard.decide() and OutputGuard.decide() convenience methods."""
 
 from __future__ import annotations
 
@@ -30,114 +30,114 @@ def output_guard() -> PIIRedactOutputGuard:
     )
 
 
-class TestInputGuardEvaluateStr:
+class TestInputGuardDecideStr:
     def test_str_with_pii(self, input_guard: PIIRedactInputGuard) -> None:
-        decision = input_guard.evaluate("my email is alice@example.com")
+        decision = input_guard.decide("my email is alice@example.com")
         assert decision.action == GuardrailAction.TRANSFORM
         assert decision.messages is not None
         assert "[EMAIL_ADDRESS]" in decision.messages[0].content
 
     def test_str_clean(self, input_guard: PIIRedactInputGuard) -> None:
-        decision = input_guard.evaluate("hello world")
+        decision = input_guard.decide("hello world")
         assert decision.action == GuardrailAction.ALLOW
 
 
-class TestInputGuardEvaluateMessage:
+class TestInputGuardDecideMessage:
     def test_user_message(self, input_guard: PIIRedactInputGuard) -> None:
-        decision = input_guard.evaluate(UserMessage("SSN: 123-45-6789"))
+        decision = input_guard.decide(UserMessage("SSN: 123-45-6789"))
         assert decision.action == GuardrailAction.TRANSFORM
         assert "[US_SSN]" in decision.messages[0].content
 
     def test_system_message(self, input_guard: PIIRedactInputGuard) -> None:
-        decision = input_guard.evaluate(SystemMessage("admin@corp.com is the admin"))
+        decision = input_guard.decide(SystemMessage("admin@corp.com is the admin"))
         assert decision.action == GuardrailAction.TRANSFORM
 
 
-class TestInputGuardEvaluateMessageHistory:
+class TestInputGuardDecideMessageHistory:
     def test_history_with_pii(self, input_guard: PIIRedactInputGuard) -> None:
         history = MessageHistory([
             SystemMessage("You are helpful"),
             UserMessage("Email me at alice@example.com"),
         ])
-        decision = input_guard.evaluate(history)
+        decision = input_guard.decide(history)
         assert decision.action == GuardrailAction.TRANSFORM
         assert len(decision.messages) == 2
 
     def test_history_clean(self, input_guard: PIIRedactInputGuard) -> None:
         history = MessageHistory([UserMessage("hello")])
-        decision = input_guard.evaluate(history)
+        decision = input_guard.decide(history)
         assert decision.action == GuardrailAction.ALLOW
 
 
-class TestInputGuardEvaluateEvent:
+class TestInputGuardDecideEvent:
     def test_passthrough(self, input_guard: PIIRedactInputGuard) -> None:
         event = LLMGuardrailEvent(
             phase=LLMGuardrailPhase.INPUT,
             messages=MessageHistory([UserMessage("alice@example.com")]),
         )
-        decision = input_guard.evaluate(event)
+        decision = input_guard.decide(event)
         assert decision.action == GuardrailAction.TRANSFORM
 
 
-class TestInputGuardEvaluateTypeError:
+class TestInputGuardDecideTypeError:
     def test_invalid_type(self, input_guard: PIIRedactInputGuard) -> None:
         with pytest.raises(TypeError, match="Expected str"):
-            input_guard.evaluate(42)  # type: ignore[arg-type]
+            input_guard.decide(42)  # type: ignore[arg-type]
 
 
-class TestOutputGuardEvaluateStr:
+class TestOutputGuardDecideStr:
     def test_str_with_pii(self, output_guard: PIIRedactOutputGuard) -> None:
-        decision = output_guard.evaluate("Contact alice@example.com")
+        decision = output_guard.decide("Contact alice@example.com")
         assert decision.action == GuardrailAction.TRANSFORM
         assert decision.output_message is not None
         assert "[EMAIL_ADDRESS]" in decision.output_message.content
 
     def test_str_clean(self, output_guard: PIIRedactOutputGuard) -> None:
-        decision = output_guard.evaluate("Here is your answer.")
+        decision = output_guard.decide("Here is your answer.")
         assert decision.action == GuardrailAction.ALLOW
 
 
-class TestOutputGuardEvaluateMessage:
+class TestOutputGuardDecideMessage:
     def test_assistant_message(self, output_guard: PIIRedactOutputGuard) -> None:
-        decision = output_guard.evaluate(
+        decision = output_guard.decide(
             AssistantMessage("Your SSN is 123-45-6789.")
         )
         assert decision.action == GuardrailAction.TRANSFORM
         assert "[US_SSN]" in decision.output_message.content
 
 
-class TestOutputGuardEvaluateMessageHistory:
+class TestOutputGuardDecideMessageHistory:
     def test_last_message_is_output(self, output_guard: PIIRedactOutputGuard) -> None:
         history = MessageHistory([
             UserMessage("What is my email?"),
             AssistantMessage("It is alice@example.com."),
         ])
-        decision = output_guard.evaluate(history)
+        decision = output_guard.decide(history)
         assert decision.action == GuardrailAction.TRANSFORM
         assert "[EMAIL_ADDRESS]" in decision.output_message.content
 
     def test_single_message_history(self, output_guard: PIIRedactOutputGuard) -> None:
         history = MessageHistory([AssistantMessage("alice@example.com")])
-        decision = output_guard.evaluate(history)
+        decision = output_guard.decide(history)
         assert decision.action == GuardrailAction.TRANSFORM
 
     def test_empty_history_raises(self, output_guard: PIIRedactOutputGuard) -> None:
         with pytest.raises(ValueError, match="empty"):
-            output_guard.evaluate(MessageHistory())
+            output_guard.decide(MessageHistory())
 
 
-class TestOutputGuardEvaluateEvent:
+class TestOutputGuardDecideEvent:
     def test_passthrough(self, output_guard: PIIRedactOutputGuard) -> None:
         event = LLMGuardrailEvent(
             phase=LLMGuardrailPhase.OUTPUT,
             messages=MessageHistory([UserMessage("hi")]),
             output_message=AssistantMessage("alice@example.com"),
         )
-        decision = output_guard.evaluate(event)
+        decision = output_guard.decide(event)
         assert decision.action == GuardrailAction.TRANSFORM
 
 
-class TestOutputGuardEvaluateTypeError:
+class TestOutputGuardDecideTypeError:
     def test_invalid_type(self, output_guard: PIIRedactOutputGuard) -> None:
         with pytest.raises(TypeError, match="Expected str"):
-            output_guard.evaluate(42)  # type: ignore[arg-type]
+            output_guard.decide(42)  # type: ignore[arg-type]

--- a/packages/railtracks/tests/unit_tests/guardrails/test_evaluate.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_evaluate.py
@@ -1,0 +1,143 @@
+"""Tests for InputGuard.evaluate() and OutputGuard.evaluate() convenience methods."""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm import (
+    PIIEntity,
+    PIIRedactConfig,
+    PIIRedactInputGuard,
+    PIIRedactOutputGuard,
+)
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, SystemMessage, UserMessage
+
+
+@pytest.fixture
+def input_guard() -> PIIRedactInputGuard:
+    return PIIRedactInputGuard(
+        config=PIIRedactConfig(entities=[PIIEntity.EMAIL_ADDRESS, PIIEntity.US_SSN])
+    )
+
+
+@pytest.fixture
+def output_guard() -> PIIRedactOutputGuard:
+    return PIIRedactOutputGuard(
+        config=PIIRedactConfig(entities=[PIIEntity.EMAIL_ADDRESS, PIIEntity.US_SSN])
+    )
+
+
+class TestInputGuardEvaluateStr:
+    def test_str_with_pii(self, input_guard: PIIRedactInputGuard) -> None:
+        decision = input_guard.evaluate("my email is alice@example.com")
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.messages is not None
+        assert "[EMAIL_ADDRESS]" in decision.messages[0].content
+
+    def test_str_clean(self, input_guard: PIIRedactInputGuard) -> None:
+        decision = input_guard.evaluate("hello world")
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestInputGuardEvaluateMessage:
+    def test_user_message(self, input_guard: PIIRedactInputGuard) -> None:
+        decision = input_guard.evaluate(UserMessage("SSN: 123-45-6789"))
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[US_SSN]" in decision.messages[0].content
+
+    def test_system_message(self, input_guard: PIIRedactInputGuard) -> None:
+        decision = input_guard.evaluate(SystemMessage("admin@corp.com is the admin"))
+        assert decision.action == GuardrailAction.TRANSFORM
+
+
+class TestInputGuardEvaluateMessageHistory:
+    def test_history_with_pii(self, input_guard: PIIRedactInputGuard) -> None:
+        history = MessageHistory([
+            SystemMessage("You are helpful"),
+            UserMessage("Email me at alice@example.com"),
+        ])
+        decision = input_guard.evaluate(history)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert len(decision.messages) == 2
+
+    def test_history_clean(self, input_guard: PIIRedactInputGuard) -> None:
+        history = MessageHistory([UserMessage("hello")])
+        decision = input_guard.evaluate(history)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestInputGuardEvaluateEvent:
+    def test_passthrough(self, input_guard: PIIRedactInputGuard) -> None:
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.INPUT,
+            messages=MessageHistory([UserMessage("alice@example.com")]),
+        )
+        decision = input_guard.evaluate(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+
+
+class TestInputGuardEvaluateTypeError:
+    def test_invalid_type(self, input_guard: PIIRedactInputGuard) -> None:
+        with pytest.raises(TypeError, match="Expected str"):
+            input_guard.evaluate(42)  # type: ignore[arg-type]
+
+
+class TestOutputGuardEvaluateStr:
+    def test_str_with_pii(self, output_guard: PIIRedactOutputGuard) -> None:
+        decision = output_guard.evaluate("Contact alice@example.com")
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.output_message is not None
+        assert "[EMAIL_ADDRESS]" in decision.output_message.content
+
+    def test_str_clean(self, output_guard: PIIRedactOutputGuard) -> None:
+        decision = output_guard.evaluate("Here is your answer.")
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestOutputGuardEvaluateMessage:
+    def test_assistant_message(self, output_guard: PIIRedactOutputGuard) -> None:
+        decision = output_guard.evaluate(
+            AssistantMessage("Your SSN is 123-45-6789.")
+        )
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[US_SSN]" in decision.output_message.content
+
+
+class TestOutputGuardEvaluateMessageHistory:
+    def test_last_message_is_output(self, output_guard: PIIRedactOutputGuard) -> None:
+        history = MessageHistory([
+            UserMessage("What is my email?"),
+            AssistantMessage("It is alice@example.com."),
+        ])
+        decision = output_guard.evaluate(history)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[EMAIL_ADDRESS]" in decision.output_message.content
+
+    def test_single_message_history(self, output_guard: PIIRedactOutputGuard) -> None:
+        history = MessageHistory([AssistantMessage("alice@example.com")])
+        decision = output_guard.evaluate(history)
+        assert decision.action == GuardrailAction.TRANSFORM
+
+    def test_empty_history_raises(self, output_guard: PIIRedactOutputGuard) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            output_guard.evaluate(MessageHistory())
+
+
+class TestOutputGuardEvaluateEvent:
+    def test_passthrough(self, output_guard: PIIRedactOutputGuard) -> None:
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("hi")]),
+            output_message=AssistantMessage("alice@example.com"),
+        )
+        decision = output_guard.evaluate(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+
+
+class TestOutputGuardEvaluateTypeError:
+    def test_invalid_type(self, output_guard: PIIRedactOutputGuard) -> None:
+        with pytest.raises(TypeError, match="Expected str"):
+            output_guard.evaluate(42)  # type: ignore[arg-type]

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
@@ -1,0 +1,190 @@
+"""Tests for the PII detection and redaction engine."""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.llm._pii.config import (
+    PIICustomPattern,
+    PIIEntity,
+    PIIRedactConfig,
+)
+from railtracks.guardrails.llm._pii.engine import PIIEngine, RedactionRecord
+
+
+@pytest.fixture
+def all_entities_engine() -> PIIEngine:
+    return PIIEngine(PIIRedactConfig())
+
+
+class TestEmailRedaction:
+    def test_email_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "Contact alice@example.com for details."
+        result, records = all_entities_engine.redact(text)
+        assert result == "Contact [EMAIL_ADDRESS] for details."
+        assert len(records) == 1
+        assert records[0].entity_type == "EMAIL_ADDRESS"
+
+    def test_multiple_emails(self, all_entities_engine: PIIEngine) -> None:
+        text = "From alice@example.com to bob@test.org"
+        result, records = all_entities_engine.redact(text)
+        assert "[EMAIL_ADDRESS]" in result
+        assert result.count("[EMAIL_ADDRESS]") == 2
+        assert len(records) == 2
+
+
+class TestPhoneRedaction:
+    def test_us_phone_with_country_code(self, all_entities_engine: PIIEngine) -> None:
+        text = "Call +1 555-867-5309 now."
+        result, records = all_entities_engine.redact(text)
+        assert "[PHONE_NUMBER]" in result
+        assert len(records) == 1
+
+    def test_phone_with_parens(self, all_entities_engine: PIIEngine) -> None:
+        text = "Call (555) 867-5309 now."
+        result, records = all_entities_engine.redact(text)
+        assert "[PHONE_NUMBER]" in result
+
+    def test_phone_with_dots(self, all_entities_engine: PIIEngine) -> None:
+        text = "Call 555.867.5309 now."
+        result, records = all_entities_engine.redact(text)
+        assert "[PHONE_NUMBER]" in result
+
+
+class TestCreditCardRedaction:
+    def test_valid_luhn(self, all_entities_engine: PIIEngine) -> None:
+        text = "Card: 4111 1111 1111 1111 on file."
+        result, records = all_entities_engine.redact(text)
+        assert "[CREDIT_CARD]" in result
+        assert len(records) == 1
+
+    def test_invalid_luhn_not_redacted(self, all_entities_engine: PIIEngine) -> None:
+        config = PIIRedactConfig(entities=[PIIEntity.CREDIT_CARD])
+        engine = PIIEngine(config)
+        text = "Number: 1234 5678 9012 3456 here."
+        result, records = engine.redact(text)
+        assert "1234 5678 9012 3456" in result
+        assert not any(r.entity_type == "CREDIT_CARD" for r in records)
+
+    def test_visa_no_spaces(self, all_entities_engine: PIIEngine) -> None:
+        text = "Card: 4111111111111111 on file."
+        result, records = all_entities_engine.redact(text)
+        assert "[CREDIT_CARD]" in result
+
+
+class TestSSNRedaction:
+    def test_ssn_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "SSN is 123-45-6789 here."
+        result, records = all_entities_engine.redact(text)
+        assert result == "SSN is [US_SSN] here."
+        assert len(records) == 1
+        assert records[0].entity_type == "US_SSN"
+
+
+class TestIPAddressRedaction:
+    def test_ipv4_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "Server at 192.168.1.1 is down."
+        result, records = all_entities_engine.redact(text)
+        assert result == "Server at [IP_ADDRESS] is down."
+        assert len(records) == 1
+
+
+class TestURLRedaction:
+    def test_https_url_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "Visit https://internal.corp/api/v2 for docs."
+        result, records = all_entities_engine.redact(text)
+        assert "[URL]" in result
+        assert len(records) == 1
+
+    def test_http_url_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "See http://example.com/page?q=1"
+        result, records = all_entities_engine.redact(text)
+        assert "[URL]" in result
+
+
+class TestIBANRedaction:
+    def test_iban_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "Transfer to GB29 NWBK 6016 1331 9268 19 please."
+        result, records = all_entities_engine.redact(text)
+        assert "[IBAN_CODE]" in result
+        assert len(records) == 1
+
+    def test_iban_no_spaces(self, all_entities_engine: PIIEngine) -> None:
+        text = "IBAN: GB29NWBK60161331926819 here."
+        result, records = all_entities_engine.redact(text)
+        assert "[IBAN_CODE]" in result
+
+
+class TestCustomPattern:
+    def test_custom_pattern_fires(self) -> None:
+        config = PIIRedactConfig(
+            entities=[],
+            custom_patterns=[
+                PIICustomPattern(name="EMPLOYEE_ID", regex=r"\bEMP-\d{6}\b"),
+            ],
+        )
+        engine = PIIEngine(config)
+        text = "Employee EMP-123456 reported the issue."
+        result, records = engine.redact(text)
+        assert result == "Employee [EMPLOYEE_ID] reported the issue."
+        assert len(records) == 1
+        assert records[0].entity_type == "EMPLOYEE_ID"
+        assert records[0].placeholder == "[EMPLOYEE_ID]"
+
+
+class TestSpanMerging:
+    def test_overlap_keeps_longer_span(self) -> None:
+        config = PIIRedactConfig(
+            entities=[PIIEntity.US_SSN],
+            custom_patterns=[
+                PIICustomPattern(name="WIDE_DIGITS", regex=r"\d{3}-\d{2}-\d{4}\b"),
+            ],
+        )
+        engine = PIIEngine(config)
+        text = "Value: 123-45-6789 done."
+        result, records = engine.redact(text)
+        assert result.count("[") == 1
+        assert len(records) == 1
+
+
+class TestCleanText:
+    def test_no_pii_returns_original(self, all_entities_engine: PIIEngine) -> None:
+        text = "Hello, this is a perfectly clean message."
+        result, records = all_entities_engine.redact(text)
+        assert result == text
+        assert records == []
+
+
+class TestMultipleEntities:
+    def test_email_and_phone_in_same_text(
+        self, all_entities_engine: PIIEngine
+    ) -> None:
+        text = "Email alice@example.com or call +1 555-867-5309."
+        result, records = all_entities_engine.redact(text)
+        assert "[EMAIL_ADDRESS]" in result
+        assert "[PHONE_NUMBER]" in result
+        assert len(records) == 2
+
+
+class TestRecordFields:
+    def test_record_has_correct_fields(self, all_entities_engine: PIIEngine) -> None:
+        text = "SSN is 123-45-6789 here."
+        _, records = all_entities_engine.redact(text)
+        assert len(records) == 1
+        r = records[0]
+        assert r.entity_type == "US_SSN"
+        assert r.placeholder == "[US_SSN]"
+        assert r.start == 7
+        assert r.end == 18
+        assert isinstance(r, RedactionRecord)
+
+    def test_record_does_not_store_raw_value(
+        self, all_entities_engine: PIIEngine
+    ) -> None:
+        text = "SSN is 123-45-6789 here."
+        _, records = all_entities_engine.redact(text)
+        r = records[0]
+        dumped = r.model_dump()
+        for v in dumped.values():
+            if isinstance(v, str):
+                assert "123-45-6789" not in v

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
@@ -81,6 +81,23 @@ class TestSSNRedaction:
         assert records[0].entity_type == "US_SSN"
 
 
+class TestCASINRedaction:
+    def test_valid_sin_redacted(self, all_entities_engine: PIIEngine) -> None:
+        text = "My SIN is 046-454-286 on file."
+        result, records = all_entities_engine.redact(text)
+        assert result == "My SIN is [CA_SIN] on file."
+        assert len(records) == 1
+        assert records[0].entity_type == "CA_SIN"
+
+    def test_invalid_luhn_sin_not_redacted(self) -> None:
+        config = PIIRedactConfig(entities=[PIIEntity.CA_SIN])
+        engine = PIIEngine(config)
+        text = "Number 111-222-333 here."
+        result, records = engine.redact(text)
+        assert "111-222-333" in result
+        assert not any(r.entity_type == "CA_SIN" for r in records)
+
+
 class TestIPAddressRedaction:
     def test_ipv4_redacted(self, all_entities_engine: PIIEngine) -> None:
         text = "Server at 192.168.1.1 is down."

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_input_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_input_guard.py
@@ -1,0 +1,164 @@
+"""Tests for PIIRedactInputGuard."""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm import (
+    PIICustomPattern,
+    PIIEntity,
+    PIIRedactConfig,
+    PIIRedactInputGuard,
+)
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import (
+    AssistantMessage,
+    Role,
+    SystemMessage,
+    UserMessage,
+)
+
+
+def _make_input_event(messages: MessageHistory) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.INPUT,
+        messages=messages,
+    )
+
+
+@pytest.fixture
+def guard() -> PIIRedactInputGuard:
+    return PIIRedactInputGuard()
+
+
+class TestAllow:
+    def test_clean_history(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(MessageHistory([UserMessage("Hello world")]))
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_empty_history(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(MessageHistory())
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestTransformUserMessage:
+    def test_email_in_user_message(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(
+            MessageHistory([UserMessage("My email is alice@example.com")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.messages is not None
+        assert len(decision.messages) == 1
+        assert "[EMAIL_ADDRESS]" in decision.messages[0].content
+
+    def test_phone_in_user_message(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(
+            MessageHistory([UserMessage("Call me at +1 555-867-5309")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[PHONE_NUMBER]" in decision.messages[0].content
+
+
+class TestTransformSystemMessage:
+    def test_pii_in_system_message(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(
+            MessageHistory([SystemMessage("Admin email: admin@corp.com")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[EMAIL_ADDRESS]" in decision.messages[0].content
+
+
+class TestSkippedRoles:
+    def test_assistant_message_not_touched(self, guard: PIIRedactInputGuard) -> None:
+        msg = AssistantMessage("Contact alice@example.com")
+        event = _make_input_event(MessageHistory([msg]))
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestMetaSummary:
+    def test_meta_contains_redacted_entities(
+        self, guard: PIIRedactInputGuard
+    ) -> None:
+        event = _make_input_event(
+            MessageHistory([UserMessage("SSN: 123-45-6789")])
+        )
+        decision = guard(event)
+        assert decision.meta is not None
+        assert "redacted_entities" in decision.meta
+        entities = decision.meta["redacted_entities"]
+        assert any(e["entity_type"] == "US_SSN" for e in entities)
+
+    def test_meta_has_messages_affected(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(
+            MessageHistory([
+                UserMessage("SSN: 123-45-6789"),
+                UserMessage("Hello world"),
+            ])
+        )
+        decision = guard(event)
+        assert decision.meta is not None
+        assert decision.meta["messages_affected"] == 1
+
+    def test_meta_does_not_contain_raw_value(
+        self, guard: PIIRedactInputGuard
+    ) -> None:
+        event = _make_input_event(
+            MessageHistory([UserMessage("SSN: 123-45-6789")])
+        )
+        decision = guard(event)
+        meta_str = str(decision.meta)
+        assert "123-45-6789" not in meta_str
+
+
+class TestMultipleMessages:
+    def test_pii_across_several_messages(self, guard: PIIRedactInputGuard) -> None:
+        event = _make_input_event(
+            MessageHistory([
+                UserMessage("Email: alice@example.com"),
+                SystemMessage("Server: 192.168.1.1"),
+                UserMessage("Clean message"),
+            ])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.messages is not None
+        assert len(decision.messages) == 3
+        assert "[EMAIL_ADDRESS]" in decision.messages[0].content
+        assert "[IP_ADDRESS]" in decision.messages[1].content
+        assert decision.messages[2].content == "Clean message"
+        assert decision.meta["messages_affected"] == 2
+
+
+class TestCustomPatternInGuard:
+    def test_custom_pattern_fires(self) -> None:
+        config = PIIRedactConfig(
+            entities=[PIIEntity.EMAIL_ADDRESS],
+            custom_patterns=[
+                PIICustomPattern(name="EMPLOYEE_ID", regex=r"\bEMP-\d{6}\b"),
+            ],
+        )
+        guard = PIIRedactInputGuard(config=config)
+        event = _make_input_event(
+            MessageHistory([UserMessage("Employee EMP-123456 here")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[EMPLOYEE_ID]" in decision.messages[0].content
+
+
+class TestGuardName:
+    def test_default_name(self) -> None:
+        guard = PIIRedactInputGuard()
+        assert guard.name == "PIIRedactInputGuard"
+
+    def test_custom_name(self) -> None:
+        guard = PIIRedactInputGuard(name="pii_input")
+        assert guard.name == "pii_input"

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_output_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_output_guard.py
@@ -1,0 +1,93 @@
+"""Tests for PIIRedactOutputGuard."""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm import PIIRedactOutputGuard
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, UserMessage
+
+
+def _make_output_event(output_content: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.OUTPUT,
+        messages=MessageHistory([UserMessage("hi")]),
+        output_message=AssistantMessage(output_content),
+    )
+
+
+@pytest.fixture
+def guard() -> PIIRedactOutputGuard:
+    return PIIRedactOutputGuard()
+
+
+class TestAllow:
+    def test_clean_output(self, guard: PIIRedactOutputGuard) -> None:
+        event = _make_output_event("Here is your answer.")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_no_output_message(self, guard: PIIRedactOutputGuard) -> None:
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("hi")]),
+            output_message=None,
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestTransformOutput:
+    def test_email_in_output(self, guard: PIIRedactOutputGuard) -> None:
+        event = _make_output_event("Contact alice@example.com for help.")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.output_message is not None
+        assert "[EMAIL_ADDRESS]" in decision.output_message.content
+        assert "alice@example.com" not in decision.output_message.content
+
+    def test_ssn_in_output(self, guard: PIIRedactOutputGuard) -> None:
+        event = _make_output_event("Your SSN is 123-45-6789.")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert "[US_SSN]" in decision.output_message.content
+
+
+class TestMetaSummary:
+    def test_meta_present(self, guard: PIIRedactOutputGuard) -> None:
+        event = _make_output_event("Email: alice@example.com")
+        decision = guard(event)
+        assert decision.meta is not None
+        assert "redacted_entities" in decision.meta
+        entities = decision.meta["redacted_entities"]
+        assert any(e["entity_type"] == "EMAIL_ADDRESS" for e in entities)
+
+    def test_meta_has_no_messages_affected(self, guard: PIIRedactOutputGuard) -> None:
+        event = _make_output_event("Email: alice@example.com")
+        decision = guard(event)
+        assert "messages_affected" not in decision.meta
+
+    def test_meta_does_not_contain_raw_value(
+        self, guard: PIIRedactOutputGuard
+    ) -> None:
+        event = _make_output_event("SSN: 123-45-6789")
+        decision = guard(event)
+        meta_str = str(decision.meta)
+        assert "123-45-6789" not in meta_str
+
+
+class TestNonStringOutput:
+    def test_non_string_content_skipped(self, guard: PIIRedactOutputGuard) -> None:
+        from railtracks.llm.message import AssistantMessage as AM
+
+        msg = AM(content=[])
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("hi")]),
+            output_message=msg,
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW


### PR DESCRIPTION
## What does this add?
Closes https://github.com/RailtownAI/railtracks/issues/1058

This PR adds **built-in PII redaction guardrails** for LLM input and output (`PIIRedactInputGuard`, `PIIRedactOutputGuard`), backed by a regex + Luhn engine with configurable `PIIEntity` types, optional `PIICustomPattern` rules, and a frozen `PIIRedactConfig`.

It also **streamlines guardrail evaluation** by adding **`decide()`** on the `InputGuard` and `OutputGuard` base classes so callers can run any LLM guardrail against a `str`, `Message`, `MessageHistory`, or existing `LLMGuardrailEvent` without hand-building events—useful for demos, tests, and ad hoc checks.

**PIIEntity enhancements:** `PIIEntity.available()` returns a map of entity names to short human-readable descriptions for discovery and UI/docs tooling.

**Documentation:** Adds a **Built-in guardrails** page (PII section + contribution notes) and a single examples script under `docs/scripts/`.

## Type of changes

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Background context

Tracks work toward **regex-based PII redaction** in the guardrails pipeline (see e.g. [#1058](https://github.com/RailtownAI/railtracks/issues/1058) / internal plan). Input guards redact user/system string content; output guards redact the model’s string reply. Overlapping spans use a fixed entity priority; credit cards and Canadian SINs require Luhn validation. Scope stays intentionally narrow: no Presidio/NER, no tool-call redaction, no streaming-specific API in this change.

## Checklist for Author

### Code Quality
- [ ] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [ ] Code is commented, particularly in hard-to-understand areas

### Testing
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Test coverage maintained

### Documentation
- [ ] Documentation updated if needed (bot will verify)

### Git & PR Management
- [ ] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

---

## Final Product

**Discover entities and configure guards**

```python
from railtracks.guardrails.llm import (
    PIIEntity,
    PIIRedactConfig,
    PIIRedactInputGuard,
    PIIRedactOutputGuard,
)

PIIEntity.available()  # name -> description

guard = PIIRedactInputGuard(
    config=PIIRedactConfig(entities=[PIIEntity.EMAIL_ADDRESS, PIIEntity.CA_SIN]),
)
decision = guard.decide("Contact alice@example.com …")  # no LLMGuardrailEvent boilerplate
# decision.messages — redacted history when action is TRANSFORM