### PR TITLE
Remove migrate command and associated functionality from CLI

### DIFF
--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -7,7 +7,6 @@ Usage: railtracks [command]
 Commands:
   init    Initialize railtracks environment (setup directories, download UI)
   viz     Start the railtracks development server
-  migrate Verify and migrate the structure of .railtracks/ directory
 
 - Checks to see if there is a .railtracks directory
 - If not, it creates one (and adds it to the .gitignore)
@@ -19,7 +18,6 @@ For testing purposes, you can add `alias railtracks="python railtracks.py"` to y
 
 import json
 import os
-import shutil
 import socket
 import sys
 import tempfile
@@ -249,60 +247,6 @@ def update_railtracks():
     print_status("Updating frontend UI to the latest version...")
     download_and_extract_ui()
     print_success("Frontend UI updated successfully!")
-
-
-def migrate_railtracks():
-    """Migrate and verify the structure of .railtracks directory"""
-    print_status("Verifying .railtracks directory structure...")
-
-    # Get the .railtracks directory path
-    railtracks_dir = Path(cli_directory)
-
-    # Verify/create .railtracks directory
-    if not railtracks_dir.exists():
-        print_status(f"Creating {cli_directory} directory...")
-        railtracks_dir.mkdir(exist_ok=True)
-        print_success(f"Created {cli_directory} directory")
-
-    # Verify/create .railtracks/data directory
-    data_dir = railtracks_dir / "data"
-    if not data_dir.exists():
-        print_status("Creating .railtracks/data directory...")
-        data_dir.mkdir(parents=True, exist_ok=True)
-        print_success("Created .railtracks/data directory")
-
-    # Verify/create .railtracks/data/evaluations directory
-    evaluations_dir = data_dir / "evaluations"
-    if not evaluations_dir.exists():
-        print_status("Creating .railtracks/data/evaluations directory...")
-        evaluations_dir.mkdir(parents=True, exist_ok=True)
-        print_success("Created .railtracks/data/evaluations directory")
-
-    # Verify/create .railtracks/data/sessions directory
-    sessions_dir = data_dir / "sessions"
-    if not sessions_dir.exists():
-        print_status("Creating .railtracks/data/sessions directory...")
-        sessions_dir.mkdir(parents=True, exist_ok=True)
-        print_success("Created .railtracks/data/sessions directory")
-
-    # Find all JSON files in .railtracks root only (not recursive, not in subdirectories)
-    json_files = list(railtracks_dir.glob("*.json"))
-
-    if json_files:
-        print_status(
-            f"Found {len(json_files)} JSON file(s) in .railtracks root to migrate..."
-        )
-        for json_file in json_files:
-            destination = sessions_dir / json_file.name
-            shutil.move(str(json_file), str(destination))
-            print_success(f"Migrated {json_file.name} to .railtracks/data/sessions/")
-        print_success(
-            f"Migration completed: {len(json_files)} file(s) moved to .railtracks/data/sessions/"
-        )
-    else:
-        print_status("No JSON files found in .railtracks root to migrate")
-
-    print_success("Directory structure verification and migration completed!")
 
 
 # FastAPI endpoints
@@ -619,7 +563,6 @@ def _print_help():
     )
     print(cmd("update", "Update the frontend UI to the latest version"))
     print(cmd("viz", f"Start the {cli_name} development server"))
-    print(cmd("migrate", f"Verify and migrate the structure of .{cli_name}/ directory"))
     print(
         cmd(
             "add",
@@ -630,12 +573,6 @@ def _print_help():
     print(f"  {bold}Examples:{rst}")
     print(example(f"{cli_name} init", "Initialize visualizer environment"))
     print(example(f"{cli_name} viz", "Start visualizer web app"))
-    print(
-        example(
-            f"{cli_name} migrate",
-            f"Verify and migrate .{cli_name}/ directory structure",
-        )
-    )
     print(
         example(
             f"{cli_name} add claude:agent-builder",
@@ -686,8 +623,6 @@ def main():
         # Start server
         server = RailtracksServer()
         server.start()
-    elif command == "migrate":
-        migrate_railtracks()
     elif command == "add":
         args = sys.argv[2:]
         if not args or args[0].startswith("-"):
@@ -700,9 +635,7 @@ def main():
         add_skill(spec, force=force)
     else:
         print(f"{Fore.RED}Unknown command: {command}{Style.RESET_ALL}")
-        print(
-            f"{Style.DIM}Available commands: init, update, viz, migrate, add{Style.RESET_ALL}"
-        )
+        print(f"{Style.DIM}Available commands: init, update, viz, add{Style.RESET_ALL}")
         sys.exit(1)
 
 

--- a/packages/railtracks/tests/unit_tests/cli/test_cli.py
+++ b/packages/railtracks/tests/unit_tests/cli/test_cli.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 import socket
-import sys
 import tempfile
 import threading
 import unittest
@@ -26,7 +25,6 @@ from railtracks.cli import (
     get_script_directory,
     get_stored_ui_version,
     is_port_in_use,
-    migrate_railtracks,
     print_error,
     print_status,
     print_success,
@@ -348,7 +346,7 @@ class TestPortChecking(unittest.TestCase):
                 mock_sys_exit.assert_not_called()  # Not called yet
 
                 # Simulate the actual error handling
-                mock_print_error(f"Port 3030 is already in use!")
+                mock_print_error("Port 3030 is already in use!")
                 mock_print_warning("You already have a railtracks viz server running.")
                 mock_print_status("Please stop the existing server or use a different port.")
                 mock_sys_exit(1)
@@ -426,249 +424,6 @@ class TestPortChecking(unittest.TestCase):
 
         result = is_port_in_use(3030)
         self.assertTrue(result)  # Should return True when socket fails to bind
-
-
-class TestMigrateRailtracks(unittest.TestCase):
-    """Test migrate_railtracks function"""
-
-    def setUp(self):
-        """Set up temporary directory for testing"""
-        self.test_dir = tempfile.mkdtemp()
-        self.original_cwd = os.getcwd()
-        os.chdir(self.test_dir)
-
-    def tearDown(self):
-        """Clean up temporary directory"""
-        os.chdir(self.original_cwd)
-        shutil.rmtree(self.test_dir)
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_creates_all_directories(self, mock_success, mock_status):
-        """Test that all required directories are created when they don't exist"""
-        # Ensure .railtracks doesn't exist
-        railtracks_dir = Path(".railtracks")
-        self.assertFalse(railtracks_dir.exists())
-
-        migrate_railtracks()
-
-        # Verify all directories exist
-        self.assertTrue(railtracks_dir.exists())
-        self.assertTrue(railtracks_dir.is_dir())
-
-        data_dir = railtracks_dir / "data"
-        self.assertTrue(data_dir.exists())
-        self.assertTrue(data_dir.is_dir())
-
-        evaluations_dir = data_dir / "evaluations"
-        self.assertTrue(evaluations_dir.exists())
-        self.assertTrue(evaluations_dir.is_dir())
-
-        sessions_dir = data_dir / "sessions"
-        self.assertTrue(sessions_dir.exists())
-        self.assertTrue(sessions_dir.is_dir())
-
-        # Should have called print functions
-        mock_status.assert_called()
-        mock_success.assert_called()
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_with_existing_directories(self, mock_success, mock_status):
-        """Test that existing directories are not recreated (idempotent)"""
-        # Create all directories first
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-        data_dir = railtracks_dir / "data"
-        data_dir.mkdir()
-        evaluations_dir = data_dir / "evaluations"
-        evaluations_dir.mkdir()
-        sessions_dir = data_dir / "sessions"
-        sessions_dir.mkdir()
-
-        # Run migration
-        migrate_railtracks()
-
-        # All directories should still exist
-        self.assertTrue(railtracks_dir.exists())
-        self.assertTrue(data_dir.exists())
-        self.assertTrue(evaluations_dir.exists())
-        self.assertTrue(sessions_dir.exists())
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_moves_json_files_from_root(self, mock_success, mock_status):
-        """Test moving JSON files from .railtracks root to .railtracks/data/sessions/"""
-        # Create .railtracks directory
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-
-        # Create JSON files in root
-        test_file1 = railtracks_dir / "test1.json"
-        test_file2 = railtracks_dir / "test2.json"
-
-        with open(test_file1, "w") as f:
-            json.dump({"test": "data1"}, f)
-        with open(test_file2, "w") as f:
-            json.dump({"test": "data2"}, f)
-
-        # Run migration
-        migrate_railtracks()
-
-        # Files should be moved to data/sessions/
-        sessions_dir = railtracks_dir / "data" / "sessions"
-        self.assertTrue((sessions_dir / "test1.json").exists())
-        self.assertTrue((sessions_dir / "test2.json").exists())
-
-        # Files should no longer be in root
-        self.assertFalse(test_file1.exists())
-        self.assertFalse(test_file2.exists())
-
-        # Verify file contents
-        with open(sessions_dir / "test1.json") as f:
-            content1 = json.load(f)
-            self.assertEqual(content1, {"test": "data1"})
-
-        with open(sessions_dir / "test2.json") as f:
-            content2 = json.load(f)
-            self.assertEqual(content2, {"test": "data2"})
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_does_not_move_subdirectory_json(self, mock_success, mock_status):
-        """Test that JSON files in subdirectories are NOT moved"""
-        # Create .railtracks directory structure
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-
-        # Create JSON file in root
-        root_file = railtracks_dir / "root.json"
-        with open(root_file, "w") as f:
-            json.dump({"location": "root"}, f)
-
-        # Create subdirectories with JSON files
-        ui_dir = railtracks_dir / "ui"
-        ui_dir.mkdir()
-        ui_file = ui_dir / "ui.json"
-        with open(ui_file, "w") as f:
-            json.dump({"location": "ui"}, f)
-
-        data_dir = railtracks_dir / "data"
-        data_dir.mkdir()
-        data_file = data_dir / "data.json"
-        with open(data_file, "w") as f:
-            json.dump({"location": "data"}, f)
-
-        # Run migration
-        migrate_railtracks()
-
-        # Root file should be moved
-        sessions_dir = railtracks_dir / "data" / "sessions"
-        self.assertTrue((sessions_dir / "root.json").exists())
-        self.assertFalse(root_file.exists())
-
-        # Subdirectory files should NOT be moved
-        self.assertTrue(ui_file.exists())
-        self.assertTrue(data_file.exists())
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_no_json_files(self, mock_success, mock_status):
-        """Test handling when no JSON files exist in root"""
-        # Create .railtracks directory
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-
-        # Run migration
-        migrate_railtracks()
-
-        # Directories should be created
-        sessions_dir = railtracks_dir / "data" / "sessions"
-        self.assertTrue(sessions_dir.exists())
-
-        # Should have printed appropriate message
-        calls = [str(call) for call in mock_status.call_args_list]
-        self.assertTrue(any("No JSON files" in str(call) for call in calls))
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_console_output(self, mock_success, mock_status):
-        """Test console output messages"""
-        # Create .railtracks directory with JSON file
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-
-        test_file = railtracks_dir / "migration_test.json"
-        with open(test_file, "w") as f:
-            json.dump({"test": "data"}, f)
-
-        # Run migration
-        migrate_railtracks()
-
-        # Check that status messages were called
-        mock_status.assert_called()
-        mock_success.assert_called()
-
-        # Check for specific migration message
-        success_calls = [str(call) for call in mock_success.call_args_list]
-        self.assertTrue(any("Migrated migration_test.json" in str(call) for call in success_calls))
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_multiple_files(self, mock_success, mock_status):
-        """Test migration of multiple JSON files"""
-        # Create .railtracks directory
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-
-        # Create multiple JSON files
-        files = ["file1.json", "file2.json", "file3.json"]
-        for filename in files:
-            test_file = railtracks_dir / filename
-            with open(test_file, "w") as f:
-                json.dump({"file": filename}, f)
-
-        # Run migration
-        migrate_railtracks()
-
-        # All files should be moved
-        sessions_dir = railtracks_dir / "data" / "sessions"
-        for filename in files:
-            self.assertTrue((sessions_dir / filename).exists())
-            self.assertFalse((railtracks_dir / filename).exists())
-
-        # Check migration summary message
-        success_calls = [str(call) for call in mock_success.call_args_list]
-        self.assertTrue(any("3 file(s) moved" in str(call) for call in success_calls))
-
-    @patch('railtracks.cli.print_status')
-    @patch('railtracks.cli.print_success')
-    def test_migrate_partial_directory_structure(self, mock_success, mock_status):
-        """Test migration when some directories already exist"""
-        # Create .railtracks and data directories
-        railtracks_dir = Path(".railtracks")
-        railtracks_dir.mkdir()
-        data_dir = railtracks_dir / "data"
-        data_dir.mkdir()
-
-        # Create JSON file in root
-        test_file = railtracks_dir / "test.json"
-        with open(test_file, "w") as f:
-            json.dump({"test": "data"}, f)
-
-        # Run migration
-        migrate_railtracks()
-
-        # Missing directories should be created
-        evaluations_dir = data_dir / "evaluations"
-        sessions_dir = data_dir / "sessions"
-        self.assertTrue(evaluations_dir.exists())
-        self.assertTrue(sessions_dir.exists())
-
-        # File should be moved
-        self.assertTrue((sessions_dir / "test.json").exists())
-        self.assertFalse(test_file.exists())
-
 
 class TestUIVersionTracking(unittest.TestCase):
     """Test UI version persistence and update-check logic"""
@@ -812,10 +567,10 @@ class TestUIVersionTracking(unittest.TestCase):
         mock_urlopen.return_value = mock_response
 
         captured_paths = []
-        real_NamedTemporaryFile = tempfile.NamedTemporaryFile
+        real_named_temporary_file = tempfile.NamedTemporaryFile
 
         def capturing_ntf(**kwargs):
-            f = real_NamedTemporaryFile(**kwargs)
+            f = real_named_temporary_file(**kwargs)
             captured_paths.append(f.name)
             return f
 
@@ -841,12 +596,12 @@ class TestUIVersionTracking(unittest.TestCase):
         """viz command runs check_for_ui_update in a daemon thread, not blocking main"""
         thread_kwargs = {}
 
-        real_Thread = threading.Thread
+        real_thread = threading.Thread
 
         def capturing_thread(**kwargs):
             if kwargs.get('target') is mock_check:
                 thread_kwargs.update(kwargs)
-            return real_Thread(**kwargs)
+            return real_thread(**kwargs)
 
         mock_server_instance = MagicMock()
         mock_server.return_value = mock_server_instance


### PR DESCRIPTION
## What does this add?

Removing `railtracks migrate` which was used to help with data folder reorganization as it's no longer needed.

## Type of changes

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [ ] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [x] 🗑️ Chore (other changes that don't modify src or test files)

