### PR TITLE
llm guardrails for tool calling llms

### DIFF
--- a/docs/guardrails/overview.md
+++ b/docs/guardrails/overview.md
@@ -25,6 +25,12 @@ Guardrails are attached where agents are defined. The main entry point is `agent
 To write a custom rule, subclass `InputGuard` or `OutputGuard` and implement `__call__`. Your implementation receives an `LLMGuardrailEvent` (the messages and, for output guards, the model response) and returns a `GuardrailDecision` with an action: `ALLOW`, `TRANSFORM`, or `BLOCK`.
 
 !!! info "Current Guardrail Support"
-    Railtracks currently supports LLM input and output guardrails for non-tool-calling agents. This covers the `agent_node` path for terminal, streaming terminal, structured, and streaming structured agents. Input rails run before the LLM call; output rails run after. If a guardrail blocks the interaction, Railtracks raises `GuardrailBlockedError` so the outcome stays explicit.
+    Railtracks supports LLM input and output guardrails for all agent types created via `agent_node`, including tool-calling agents (`ToolCallLLM`, `StreamingToolCallLLM`, `StructuredToolCallLLM`). Input rails run once before the first LLM call; output rails run once on the final reply (not on intermediate tool-call turns). If a guardrail blocks the interaction, Railtracks raises `GuardrailBlockedError` so the outcome stays explicit.
+
+    **Limitations:**
+
+    - Output guardrails on streaming tool-calling agents (`StreamingToolCallLLM`) are not yet supported — only input guardrails are wired.
+    - Output guardrails on structured tool-calling agents (`StructuredToolCallLLM`) are not yet supported — only input guardrails are wired.
+    - Tool call and tool response guardrails (`Guard.tool_call`, `Guard.tool_response`) remain future work.
 
 The next section, [Quickstart](quickstart.md), walks through attaching a guard to an agent and seeing a request pass or block in practice.

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/__init__.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/__init__.py
@@ -8,6 +8,9 @@ __all__ = [
     "GuardedStreamingTerminalLLM",
     "GuardedStructuredLLM",
     "GuardedStreamingStructuredLLM",
+    "GuardedToolCallLLM",
+    "GuardedStreamingToolCallLLM",
+    "GuardedStructuredToolCallLLM",
     "StructuredLLM",
     "ToolCallLLM",
     "StructuredToolCallLLM",
@@ -35,8 +38,11 @@ from .function_base import (
 from .guarded_llm import (
     GuardedStreamingStructuredLLM,
     GuardedStreamingTerminalLLM,
+    GuardedStreamingToolCallLLM,
     GuardedStructuredLLM,
+    GuardedStructuredToolCallLLM,
     GuardedTerminalLLM,
+    GuardedToolCallLLM,
 )
 from .response import StringResponse, StructuredResponse
 from .structured_llm_base import StructuredLLM

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
@@ -227,7 +227,9 @@ class OutputLessToolCallLLM(
     ABC,
     Generic[_TCollectedOutput],
 ):
-    async def _handle_tool_calls(self) -> tuple[bool, Message | None]:
+    async def _handle_tool_calls(
+        self,
+    ) -> tuple[bool, Message | None, Response | None]:
         """
         Handles the execution of tool calls for the node, including LLM interaction and message history updates.
 
@@ -237,14 +239,16 @@ class OutputLessToolCallLLM(
         - Handles malformed LLM responses and raises errors as needed.
 
         Returns:
-            bool: True if more tool calls are expected (the tool call loop should continue),
-                  False if the tool call process is finished and a final answer is available.
+            A 3-tuple ``(still_looping, final_message, final_response)``.
+            ``still_looping`` is True when tool calls were dispatched and the
+            caller should loop again, False when the LLM produced a final text
+            reply.  ``final_message`` and ``final_response`` are non-None only
+            when ``still_looping`` is False.
 
         Raises:
             LLMError: If the LLM returns an unexpected message type or the message is malformed.
         """
 
-        # collect the response from the llm model
         response = await asyncio.to_thread(
             self.llm_model.chat_with_tools, self.message_hist, tools=self.tools()
         )
@@ -255,14 +259,28 @@ class OutputLessToolCallLLM(
                 message_history=self.message_hist,
             )
 
-        return await self._handle_response(response.message)
+        is_tool, message = await self._handle_response(response.message)
+        final_response = None if is_tool else response
+        return is_tool, message, final_response
 
     async def invoke(self):
+        context = self._pre_invoke(self.message_hist)
+        self.message_hist = context
+
         message = None
+        final_response = None
         while True:
-            still_tool_calls, message = await self._handle_tool_calls()
+            still_tool_calls, message, final_response = (
+                await self._handle_tool_calls()
+            )
             if not still_tool_calls:
                 break
+
+        if final_response is not None:
+            guarded = self._post_invoke(self.message_hist, final_response)
+            if isinstance(guarded, Response) and guarded is not final_response:
+                message = guarded.message
+                self.message_hist[-1] = message
 
         return self.return_output(message)
 
@@ -326,10 +344,14 @@ class StreamingOutputLessToolCallLLM(
                 )
 
     async def invoke(self):
-        """Makes a call containing the inputted message and system prompt to the llm model and returns the response
-        Returns:
-            (TerminalLLM.Output): The response message from the llm model
+        """Makes a call containing the inputted message and system prompt to the llm model and returns the response.
+
+        Note: only input guardrails are wired here.  Output guardrails on the
+        streaming tool-call path are deferred because the inner generator
+        bypasses ``LLMBase._gen_wrapper`` where ``_post_invoke`` normally runs.
         """
+        context = self._pre_invoke(self.message_hist)
+        self.message_hist = context
 
         while True:
             result = await self._handle_tool_calls()

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
@@ -270,9 +270,7 @@ class OutputLessToolCallLLM(
         message = None
         final_response = None
         while True:
-            still_tool_calls, message, final_response = (
-                await self._handle_tool_calls()
-            )
+            still_tool_calls, message, final_response = await self._handle_tool_calls()
             if not still_tool_calls:
                 break
 

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/guarded_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/guarded_llm.py
@@ -16,7 +16,9 @@ from pydantic import BaseModel
 from railtracks.guardrails.llm.mixin import LLMGuardrailsMixin
 
 from .structured_llm_base import StreamingStructuredLLM, StructuredLLM
+from .structured_tool_call_llm_base import StructuredToolCallLLM
 from .terminal_llm_base import StreamingTerminalLLM, TerminalLLM
+from .tool_call_llm_base import StreamingToolCallLLM, ToolCallLLM
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 
@@ -37,5 +39,19 @@ class GuardedStructuredLLM(
 
 class GuardedStreamingStructuredLLM(
     LLMGuardrailsMixin, StreamingStructuredLLM[_TBaseModel], Generic[_TBaseModel]
+):
+    pass
+
+
+class GuardedToolCallLLM(LLMGuardrailsMixin, ToolCallLLM):
+    pass
+
+
+class GuardedStreamingToolCallLLM(LLMGuardrailsMixin, StreamingToolCallLLM):
+    pass
+
+
+class GuardedStructuredToolCallLLM(
+    LLMGuardrailsMixin, StructuredToolCallLLM[_TBaseModel], Generic[_TBaseModel]
 ):
     pass

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Generic, Literal, TypeVar
+from typing import Any, ClassVar, Generic, Literal, Type, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -14,10 +14,9 @@ from railtracks.llm import (
 )
 
 from ._llm_base import StructuredOutputMixIn
-from ._tool_call_base import (
-    OutputLessToolCallLLM,
-)
+from ._tool_call_base import OutputLessToolCallLLM
 from .response import StructuredResponse
+from .structured_llm_base import StructuredLLM
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 _TStream = TypeVar("_TStream", Literal[True], Literal[False])
@@ -34,6 +33,8 @@ class StructuredToolCallLLM(
     This class is used to define the structure of the tool call and handle the
     structured output.
     """
+
+    structured_resp_node: ClassVar[Type[StructuredLLM[Any]]]
 
     def __init_subclass__(cls):
         system_structured = (
@@ -55,10 +56,17 @@ class StructuredToolCallLLM(
 
         # we only want to verify the output_schema is the class is not abstract
         if not has_abstract_methods:
-            cls.structured_resp_node = structured_llm(
-                cls.output_schema(),
-                system_message=system_structured,
-                llm=None,
+            # structured_llm() is always called with llm=None here, so the
+            # result is always a non-streaming StructuredLLM subclass.  The
+            # cast aligns with the ClassVar annotation and the actual runtime
+            # type; the union in structured_llm's return signature is too wide.
+            cls.structured_resp_node = cast(
+                Type[StructuredLLM[Any]],
+                structured_llm(
+                    cls.output_schema(),
+                    system_message=system_structured,
+                    llm=None,
+                ),
             )
 
         super().__init_subclass__()
@@ -76,6 +84,12 @@ class StructuredToolCallLLM(
         self.structured_output: _TBaseModel | Exception | None = None
 
     async def invoke(self):
+        # Input guardrail runs once before the tool loop.
+        # NOTE: Output guardrails are deferred for StructuredToolCallLLM because the
+        # final AssistantMessage contains a pydantic model, not raw text.
+        context = self._pre_invoke(self.message_hist)
+        self.message_hist = context
+
         await self._handle_tool_calls()
 
         try:
@@ -89,7 +103,6 @@ class StructuredToolCallLLM(
 
             structured_output = response
         except Exception as e:
-            # the original exception will be presented with our wrapped one.
             raise LLMError(
                 reason="Failed to parse assistant response into structured output.",
                 message_history=self.message_hist,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/__init__.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/__init__.py
@@ -1,7 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .agent import agent_node
+    from .function import function_node
+
 __all__ = [
-    "function_node",
     "agent_node",
+    "function_node",
 ]
 
-from .agent import agent_node
-from .function import function_node
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def __getattr__(name: str):
+    if name == "agent_node":
+        from .agent import agent_node
+
+        return agent_node
+    if name == "function_node":
+        from .function import function_node
+
+        return function_node
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -6,8 +6,11 @@ from pydantic import BaseModel
 from railtracks.built_nodes.concrete import (
     GuardedStreamingStructuredLLM,
     GuardedStreamingTerminalLLM,
+    GuardedStreamingToolCallLLM,
     GuardedStructuredLLM,
+    GuardedStructuredToolCallLLM,
     GuardedTerminalLLM,
+    GuardedToolCallLLM,
     RTFunction,
     StructuredLLM,
     StructuredToolCallLLM,
@@ -64,10 +67,6 @@ def _build_dynamic_agent(
     guardrails: Guard | None,
 ):
     if unpacked_tool_nodes is not None and len(unpacked_tool_nodes) > 0:
-        if guardrails is not None:
-            raise NotImplementedError(
-                "Guardrails are not yet supported for tool-calling agents (see https://github.com/RailtownAI/railtracks/issues/1047)."
-            )
         if output_schema is not None:
             return structured_tool_call_llm(
                 tool_nodes=unpacked_tool_nodes,
@@ -77,6 +76,7 @@ def _build_dynamic_agent(
                 system_message=system_message,
                 tool_details=tool_details,
                 tool_params=tool_params,
+                guardrails=guardrails,
             )
         return tool_call_llm(
             tool_nodes=unpacked_tool_nodes,
@@ -85,6 +85,7 @@ def _build_dynamic_agent(
             system_message=system_message,
             tool_details=tool_details,
             tool_params=tool_params,
+            guardrails=guardrails,
         )
     if output_schema is not None:
         return structured_llm(
@@ -106,7 +107,7 @@ def _build_dynamic_agent(
     )
 
 
-# --- Tool-calling overloads (guardrails not supported yet) ---
+# --- Tool-calling overloads (no guardrails) ---
 
 
 @overload
@@ -119,6 +120,7 @@ def agent_node(
     llm: ModelBase[Literal[False]] | None = None,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
+    guardrails: None = None,
 ) -> Type[StructuredToolCallLLM[_TBaseModel]]:
     pass
 
@@ -132,6 +134,7 @@ def agent_node(
     llm: ModelBase[Literal[False]] | None = None,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
+    guardrails: None = None,
 ) -> Type[ToolCallLLM]:
     pass
 
@@ -145,7 +148,54 @@ def agent_node(
     llm: ModelBase[Literal[True]],
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
+    guardrails: None = None,
 ) -> Type[StreamingToolCallLLM]:
+    pass
+
+
+# --- Tool-calling overloads (with guardrails) ---
+
+
+@overload
+def agent_node(
+    name: str | None = None,
+    *,
+    rag: RagConfig | None = None,
+    tool_nodes: Iterable[Type[Node] | Callable | RTFunction],
+    output_schema: Type[_TBaseModel],
+    llm: ModelBase[Literal[False]] | None = None,
+    system_message: SystemMessage | str | None = None,
+    manifest: ToolManifest | None = None,
+    guardrails: Guard,
+) -> Type[GuardedStructuredToolCallLLM[_TBaseModel]]:
+    pass
+
+
+@overload
+def agent_node(
+    name: str | None = None,
+    *,
+    rag: RagConfig | None = None,
+    tool_nodes: Iterable[Type[Node] | Callable | RTFunction],
+    llm: ModelBase[Literal[False]] | None = None,
+    system_message: SystemMessage | str | None = None,
+    manifest: ToolManifest | None = None,
+    guardrails: Guard,
+) -> Type[GuardedToolCallLLM]:
+    pass
+
+
+@overload
+def agent_node(
+    name: str | None = None,
+    *,
+    rag: RagConfig | None = None,
+    tool_nodes: Iterable[Type[Node] | Callable | RTFunction],
+    llm: ModelBase[Literal[True]],
+    system_message: SystemMessage | str | None = None,
+    manifest: ToolManifest | None = None,
+    guardrails: Guard,
+) -> Type[GuardedStreamingToolCallLLM]:
     pass
 
 

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
@@ -3,12 +3,14 @@ from typing import Any, Callable, Iterable, Type, TypeVar
 from pydantic import BaseModel
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import (
+from railtracks.built_nodes.concrete.guarded_llm import (
     GuardedStreamingStructuredLLM,
     GuardedStructuredLLM,
+)
+from railtracks.built_nodes.concrete.structured_llm_base import (
+    StreamingStructuredLLM,
     StructuredLLM,
 )
-from railtracks.built_nodes.concrete.structured_llm_base import StreamingStructuredLLM
 from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Iterable, Type, TypeVar, Union
 
 from pydantic import BaseModel
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import StructuredToolCallLLM
+from railtracks.built_nodes.concrete import (
+    GuardedStructuredToolCallLLM,
+    StructuredToolCallLLM,
+)
+from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
     SystemMessage,
@@ -26,6 +32,7 @@ def structured_tool_call_llm(
     return_into: str | None = None,
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
+    guardrails: Guard | None = None,
 ) -> Type[StructuredToolCallLLM[_TOutput]]:
     """
     Dynamically create a StructuredToolCallLLM node class with custom configuration for tool calling.
@@ -45,13 +52,15 @@ def structured_tool_call_llm(
         return_into (str, optional): The key to store the result of the tool call into context. If not specified, the result will not be put into context.
         format_for_return (Callable[[Any], Any] | None, optional): A function to format the result before returning it, only if return_into is provided. If not specified when while return_into is provided, None will be returned.
         format_for_context (Callable[[Any], Any] | None, optional): A function to format the result before putting it into context, only if return_into is provided. If not provided, the response will be put into context as is.
+        guardrails (Guard or None, optional): Guardrail config. When provided, the node runs input guardrails before the tool-call loop. Output guardrails are deferred for structured tool-call agents.
 
     Returns:
         Type[StructuredToolCallLLM]: The dynamically generated node class with the specified configuration.
     """
+    base_cls = GuardedStructuredToolCallLLM if guardrails is not None else StructuredToolCallLLM
 
     builder = NodeBuilder[StructuredToolCallLLM[_TOutput]](
-        StructuredToolCallLLM,
+        base_cls,
         name=name,
         class_name="EasyStructuredToolCallLLM",
         return_into=return_into,
@@ -65,5 +74,8 @@ def structured_tool_call_llm(
     if tool_details is not None or tool_params is not None:
         builder.tool_callable_llm(tool_details, tool_params)
     builder.structured(output_schema)
+
+    if guardrails is not None:
+        builder.add_attribute("guardrails", guardrails, make_function=False)
 
     return builder.build()

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
@@ -5,7 +5,9 @@ from typing import Any, Callable, Iterable, Type, TypeVar, Union
 from pydantic import BaseModel
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete.structured_tool_call_llm_base import StructuredToolCallLLM
+from railtracks.built_nodes.concrete.structured_tool_call_llm_base import (
+    StructuredToolCallLLM,
+)
 from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
@@ -55,7 +57,10 @@ def structured_tool_call_llm(
         Type[StructuredToolCallLLM]: The dynamically generated node class with the specified configuration.
     """
     if guardrails is not None:
-        from railtracks.built_nodes.concrete.guarded_llm import GuardedStructuredToolCallLLM
+        from railtracks.built_nodes.concrete.guarded_llm import (
+            GuardedStructuredToolCallLLM,
+        )
+
         base_cls = GuardedStructuredToolCallLLM
     else:
         base_cls = StructuredToolCallLLM

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
@@ -5,10 +5,7 @@ from typing import Any, Callable, Iterable, Type, TypeVar, Union
 from pydantic import BaseModel
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import (
-    GuardedStructuredToolCallLLM,
-    StructuredToolCallLLM,
-)
+from railtracks.built_nodes.concrete.structured_tool_call_llm_base import StructuredToolCallLLM
 from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
@@ -57,7 +54,11 @@ def structured_tool_call_llm(
     Returns:
         Type[StructuredToolCallLLM]: The dynamically generated node class with the specified configuration.
     """
-    base_cls = GuardedStructuredToolCallLLM if guardrails is not None else StructuredToolCallLLM
+    if guardrails is not None:
+        from railtracks.built_nodes.concrete.guarded_llm import GuardedStructuredToolCallLLM
+        base_cls = GuardedStructuredToolCallLLM
+    else:
+        base_cls = StructuredToolCallLLM
 
     builder = NodeBuilder[StructuredToolCallLLM[_TOutput]](
         base_cls,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
@@ -5,7 +5,10 @@ from railtracks.built_nodes.concrete.guarded_llm import (
     GuardedStreamingTerminalLLM,
     GuardedTerminalLLM,
 )
-from railtracks.built_nodes.concrete.terminal_llm_base import StreamingTerminalLLM, TerminalLLM
+from railtracks.built_nodes.concrete.terminal_llm_base import (
+    StreamingTerminalLLM,
+    TerminalLLM,
+)
 from railtracks.guardrails.core import Guard
 from railtracks.llm import ModelBase, SystemMessage
 from railtracks.llm.tools import Parameter

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
@@ -1,12 +1,11 @@
 from typing import Any, Callable
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import (
+from railtracks.built_nodes.concrete.guarded_llm import (
     GuardedStreamingTerminalLLM,
     GuardedTerminalLLM,
-    TerminalLLM,
 )
-from railtracks.built_nodes.concrete.terminal_llm_base import StreamingTerminalLLM
+from railtracks.built_nodes.concrete.terminal_llm_base import StreamingTerminalLLM, TerminalLLM
 from railtracks.guardrails.core import Guard
 from railtracks.llm import ModelBase, SystemMessage
 from railtracks.llm.tools import Parameter

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 from typing import Any, Callable, Iterable, Type, Union
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import ToolCallLLM
+from railtracks.built_nodes.concrete import (
+    GuardedStreamingToolCallLLM,
+    GuardedToolCallLLM,
+    ToolCallLLM,
+)
 from railtracks.built_nodes.concrete.tool_call_llm_base import StreamingToolCallLLM
+from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
     SystemMessage,
@@ -22,6 +29,7 @@ def tool_call_llm(
     return_into: str | None = None,
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
+    guardrails: Guard | None = None,
 ) -> Type[ToolCallLLM | StreamingToolCallLLM]:
     """
     Dynamically create a ToolCallLLM node class with custom configuration for tool calling.
@@ -41,12 +49,19 @@ def tool_call_llm(
         return_into (str, optional): The key to store the result of the tool call into context. If not specified, the result will not be put into context.
         format_for_return (Callable[[Any], Any] | None, optional): A function to format the result before returning it, only if return_into is provided. If not specified when while return_into is provided, None will be returned.
         format_for_context (Callable[[Any], Any] | None, optional): A function to format the result before putting it into context, only if return_into is provided. If not provided, the response will be put into context as is.
+        guardrails (Guard or None, optional): Guardrail config. When provided, the node runs input/output guardrails around the tool-call loop.
 
     Returns:
         Type[ToolCallLLM]: The dynamically generated node class with the specified configuration.
     """
+    is_streaming = llm is not None and llm.stream
+    if guardrails is not None:
+        base_cls = GuardedStreamingToolCallLLM if is_streaming else GuardedToolCallLLM
+    else:
+        base_cls = StreamingToolCallLLM if is_streaming else ToolCallLLM
+
     builder = NodeBuilder(
-        StreamingToolCallLLM if llm is not None and llm.stream else ToolCallLLM,
+        base_cls,
         name=name,
         class_name="EasyToolCallLLM",
         return_into=return_into,
@@ -57,5 +72,8 @@ def tool_call_llm(
     builder.tool_calling_llm(tool_nodes)
     if tool_details is not None or tool_params is not None:
         builder.tool_callable_llm(tool_details, tool_params)
+
+    if guardrails is not None:
+        builder.add_attribute("guardrails", guardrails, make_function=False)
 
     return builder.build()

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Type, Union
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete import (
-    GuardedStreamingToolCallLLM,
-    GuardedToolCallLLM,
-    ToolCallLLM,
-)
-from railtracks.built_nodes.concrete.tool_call_llm_base import StreamingToolCallLLM
+from railtracks.built_nodes.concrete.tool_call_llm_base import StreamingToolCallLLM, ToolCallLLM
 from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
@@ -56,6 +51,10 @@ def tool_call_llm(
     """
     is_streaming = llm is not None and llm.stream
     if guardrails is not None:
+        from railtracks.built_nodes.concrete.guarded_llm import (
+            GuardedStreamingToolCallLLM,
+            GuardedToolCallLLM,
+        )
         base_cls = GuardedStreamingToolCallLLM if is_streaming else GuardedToolCallLLM
     else:
         base_cls = StreamingToolCallLLM if is_streaming else ToolCallLLM

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Type, Union
 
 from railtracks.built_nodes._node_builder import NodeBuilder
-from railtracks.built_nodes.concrete.tool_call_llm_base import StreamingToolCallLLM, ToolCallLLM
+from railtracks.built_nodes.concrete.tool_call_llm_base import (
+    StreamingToolCallLLM,
+    ToolCallLLM,
+)
 from railtracks.guardrails.core import Guard
 from railtracks.llm import (
     ModelBase,
@@ -55,6 +58,7 @@ def tool_call_llm(
             GuardedStreamingToolCallLLM,
             GuardedToolCallLLM,
         )
+
         base_cls = GuardedStreamingToolCallLLM if is_streaming else GuardedToolCallLLM
     else:
         base_cls = StreamingToolCallLLM if is_streaming else ToolCallLLM

--- a/packages/railtracks/src/railtracks/guardrails/llm/mixin.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/mixin.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, cast
 from railtracks.llm.message import Message
 from railtracks.llm.model import ModelBase
 from railtracks.llm.response import Response
+from railtracks.nodes.nodes import DebugDetails
 
 from ..core import Guard, GuardrailBlockedError, GuardRunner
 from ..core.decision import GuardrailAction
@@ -37,7 +38,7 @@ class LLMGuardrailsMixin:
     """
 
     guardrails: Guard | None = None
-    _details: dict[str, Any]
+    _details: DebugDetails
     llm_model: ModelBase
     uuid: str
     name: Callable[[], str]
@@ -49,6 +50,10 @@ class LLMGuardrailsMixin:
 
     def _guardrail_agent_kind(self) -> str:
         cls_name = self.__class__.__name__.lower()
+        if "structured" in cls_name and "toolcall" in cls_name:
+            return "structured_tool_call"
+        if "toolcall" in cls_name:
+            return "tool_call"
         if "structured" in cls_name:
             return "structured"
         if "terminal" in cls_name:

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -9,11 +9,15 @@ from pydantic import BaseModel, Field
 from railtracks.built_nodes.concrete import (
     GuardedStreamingStructuredLLM,
     GuardedStreamingTerminalLLM,
+    GuardedStreamingToolCallLLM,
     GuardedStructuredLLM,
+    GuardedStructuredToolCallLLM,
     GuardedTerminalLLM,
+    GuardedToolCallLLM,
 )
 from railtracks.built_nodes.concrete.response import StringResponse, StructuredResponse
 from railtracks.guardrails import Guard, GuardrailBlockedError, GuardrailDecision, InputGuard, LLMGuardrailEvent, OutputGuard
+from railtracks.llm import AssistantMessage
 
 
 class FnInputGuard(InputGuard):
@@ -57,6 +61,18 @@ def _counting_structured(llm: rt.llm.ModelBase):
         return real(messages, schema, **kwargs)
 
     llm._structured = wrapped  # type: ignore[method-assign]
+    return state
+
+
+def _counting_chat_with_tools(llm: rt.llm.ModelBase):
+    state = {"n": 0}
+    real = llm._chat_with_tools
+
+    def wrapped(messages, tools, **kwargs):  # type: ignore[no-untyped-def]
+        state["n"] += 1
+        return real(messages, tools, **kwargs)
+
+    llm._chat_with_tools = wrapped  # type: ignore[method-assign]
     return state
 
 
@@ -230,34 +246,6 @@ async def test_structured_streaming_guardrails(mock_llm, allow_input, stream):
         assert result.structured.text == "s"
 
 
-def test_tool_agent_guardrails_not_implemented(mock_llm):
-    def tool_fn() -> int:
-        return 1
-
-    with pytest.raises(NotImplementedError, match="Guardrails"):
-        rt.agent_node(
-            name="tools",
-            tool_nodes={rt.function_node(tool_fn)},
-            llm=mock_llm(),
-            guardrails=Guard(input=[FnInputGuard(lambda _e: GuardrailDecision.allow())]),
-        )
-
-
-def test_tool_structured_agent_guardrails_not_implemented(mock_llm):
-    class M(BaseModel):
-        v: int = 0
-
-    def tool_fn() -> int:
-        return 1
-
-    with pytest.raises(NotImplementedError, match="Guardrails"):
-        rt.agent_node(
-            name="tools-s",
-            tool_nodes={rt.function_node(tool_fn)},
-            output_schema=M,
-            llm=mock_llm(),
-            guardrails=Guard(input=[FnInputGuard(lambda _e: GuardrailDecision.allow())]),
-        )
 
 
 @pytest.mark.asyncio
@@ -275,3 +263,234 @@ async def test_terminal_output_block(mock_llm, allow_input):
     with rt.Session():
         with pytest.raises(GuardrailBlockedError):
             await rt.call(Agent, user_input="q")
+
+
+# ============================================================
+# ToolCallLLM guardrail tests
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_tool_call_agent_uses_guarded_base(mock_llm, allow_input):
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="g-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=mock_llm(),
+        guardrails=Guard(input=[allow_input]),
+    )
+    assert issubclass(Agent, GuardedToolCallLLM)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_input_block_skips_llm(mock_llm, block_input):
+    def tool_fn() -> str:
+        return "result"
+
+    llm = mock_llm()
+    counts = _counting_chat_with_tools(llm)
+    Agent = rt.agent_node(
+        name="block-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=llm,
+        guardrails=Guard(input=[block_input]),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="hello")
+    assert counts["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_tool_call_input_allow_calls_llm(mock_llm, allow_input):
+    def tool_fn() -> str:
+        return "result"
+
+    llm = mock_llm()
+    counts = _counting_chat_with_tools(llm)
+    Agent = rt.agent_node(
+        name="allow-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=llm,
+        guardrails=Guard(input=[allow_input]),
+    )
+    with rt.Session():
+        out = await rt.call(Agent, user_input="hello")
+    assert counts["n"] >= 1
+    assert isinstance(out, StringResponse)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_output_block(mock_llm, allow_input):
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="out-block-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=mock_llm(),
+        guardrails=Guard(
+            input=[allow_input],
+            output=[FnOutputGuard(lambda _e: GuardrailDecision.block(reason="blocked output"))],
+        ),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="hello")
+
+
+@pytest.mark.asyncio
+async def test_tool_call_output_transform_updates_response_and_history(mock_llm, allow_input):
+    """TRANSFORM: resp.content and resp.message_history[-1].content must both reflect the new message."""
+    TRANSFORMED = "transformed content"
+
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="out-transform-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=mock_llm(),
+        guardrails=Guard(
+            input=[allow_input],
+            output=[FnOutputGuard(lambda _e: GuardrailDecision.transform_output(
+                output_message=AssistantMessage(TRANSFORMED),
+                reason="transform applied",
+            ))],
+        ),
+    )
+    with rt.Session():
+        result = await rt.call(Agent, user_input="hello")
+    assert isinstance(result, StringResponse)
+    assert result.content == TRANSFORMED
+    assert result.message_history[-1].content == TRANSFORMED
+
+
+@pytest.mark.asyncio
+async def test_tool_call_output_guard_fires_once(mock_llm, allow_input):
+    """Output guard fires exactly once — on the final reply, not on intermediate tool-call turns."""
+    @rt.function_node
+    async def weather_tool(city: str) -> str:
+        """Get weather for a city.
+        Args:
+            city (str)
+        """
+        return f"Sunny in {city}"
+
+    fire_count = {"n": 0}
+
+    def _counting_guard(event: LLMGuardrailEvent) -> GuardrailDecision:
+        fire_count["n"] += 1
+        return GuardrailDecision.allow()
+
+    llm = mock_llm(
+        requested_tool_calls=[
+            rt.llm.ToolCall(name="weather_tool", identifier="tc_1", arguments={"city": "NYC"})
+        ]
+    )
+    Agent = rt.agent_node(
+        name="fires-once",
+        tool_nodes={weather_tool},
+        llm=llm,
+        guardrails=Guard(
+            input=[allow_input],
+            output=[FnOutputGuard(_counting_guard)],
+        ),
+    )
+    with rt.Session():
+        await rt.call(Agent, user_input="weather?")
+
+    assert fire_count["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_call_no_guardrails_produces_unguarded_node(mock_llm):
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="no-guard-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=mock_llm(),
+    )
+    assert not issubclass(Agent, GuardedToolCallLLM)
+
+
+# ============================================================
+# StreamingToolCallLLM guardrail tests
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_uses_guarded_base(mock_llm, allow_input):
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="g-stream-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=mock_llm(stream=True),
+        guardrails=Guard(input=[allow_input]),
+    )
+    assert issubclass(Agent, GuardedStreamingToolCallLLM)
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_call_input_block(mock_llm, block_input):
+    def tool_fn() -> str:
+        return "result"
+
+    llm = mock_llm(stream=True)
+    counts = _counting_chat_with_tools(llm)
+    Agent = rt.agent_node(
+        name="block-stream-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        llm=llm,
+        guardrails=Guard(input=[block_input]),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="hello")
+    assert counts["n"] == 0
+
+
+# ============================================================
+# StructuredToolCallLLM guardrail tests
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_structured_tool_call_agent_uses_guarded_base(mock_llm, allow_input):
+    def tool_fn() -> str:
+        return "result"
+
+    Agent = rt.agent_node(
+        name="g-struct-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        output_schema=_Answer,
+        llm=mock_llm(custom_response='{"text": "ok"}'),
+        guardrails=Guard(input=[allow_input]),
+    )
+    assert issubclass(Agent, GuardedStructuredToolCallLLM)
+
+
+@pytest.mark.asyncio
+async def test_structured_tool_call_input_block_skips_llm(mock_llm, block_input):
+    def tool_fn() -> str:
+        return "result"
+
+    llm = mock_llm()
+    counts = _counting_chat_with_tools(llm)
+    Agent = rt.agent_node(
+        name="block-struct-tool",
+        tool_nodes={rt.function_node(tool_fn)},
+        output_schema=_Answer,
+        llm=llm,
+        guardrails=Guard(input=[block_input]),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="q")
+    assert counts["n"] == 0

--- a/packages/railtracks/tests/unit_tests/guardrails/test_mixin.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_mixin.py
@@ -247,3 +247,37 @@ def test_build_output_event_has_output_message():
 def test_guardrail_agent_kind_fallback():
     node = GuardedOtherStub()
     assert node._guardrail_agent_kind() == "llm"
+
+
+class GuardedToolCallStub(_StubWithDetails, LLMGuardrailsMixin):
+    """Class name contains 'toolcall' (but not 'structured') for agent_kind tagging."""
+
+    guardrails: Guard | None = None
+    llm_model = _StubLLM()
+    uuid = "uuid-toolcall"
+
+    @classmethod
+    def name(cls) -> str:
+        return "ToolCall"
+
+
+class GuardedStructuredToolCallStub(_StubWithDetails, LLMGuardrailsMixin):
+    """Class name contains both 'structured' and 'toolcall' for agent_kind tagging."""
+
+    guardrails: Guard | None = None
+    llm_model = _StubLLM()
+    uuid = "uuid-structured-toolcall"
+
+    @classmethod
+    def name(cls) -> str:
+        return "Structured ToolCall"
+
+
+def test_guardrail_agent_kind_tool_call():
+    node = GuardedToolCallStub()
+    assert node._guardrail_agent_kind() == "tool_call"
+
+
+def test_guardrail_agent_kind_structured_tool_call():
+    node = GuardedStructuredToolCallStub()
+    assert node._guardrail_agent_kind() == "structured_tool_call"


### PR DESCRIPTION
## What does this add?

`LLMGuardrailsMixin` previously raised `NotImplementedError` when `guardrails=` was passed to any tool-calling agent (`ToolCallLLM`, `StreamingToolCallLLM`, `StructuredToolCallLLM`). This was because `OutputLessToolCallLLM.invoke()` drove its own tool-call loop and never called `_pre_invoke` / `_post_invoke`; the hooks that the mixin overrides to run input and output guards.

This PR wires input and output guardrails through the tool-call loop, making the guardrail semantics identical to those on `TerminalLLM` and `StructuredLLM`:

- **Input guard** fires once, before the first `chat_with_tools` call.
- **Output guard** fires once, after the LLM produces its final text reply (not on intermediate tool-call turns).

Specific changes:

- `OutputLessToolCallLLM._handle_tool_calls` return type extended to `tuple[bool, Message | None, Response | None]` so `invoke()` can pass the final `Response` to `_post_invoke`.
- `OutputLessToolCallLLM.invoke()` calls `_pre_invoke` before the loop and `_post_invoke` after, patching `message_hist[-1]` in-place when a TRANSFORM action modifies the final reply.
- `StreamingOutputLessToolCallLLM.invoke()` wires `_pre_invoke` only (output guardrails on the streaming tool-call path are deferred; see notes below).
- `StructuredToolCallLLM.invoke()` wires `_pre_invoke` only (output guardrails deferred pending a dedicated `StructuredOutputGuard` type).
- Three new guarded classes added to `guarded_llm.py`: `GuardedToolCallLLM`, `GuardedStreamingToolCallLLM`, `GuardedStructuredToolCallLLM`.
- `LLMGuardrailsMixin._guardrail_agent_kind` extended with `"tool_call"` and `"structured_tool_call"` branches.
- `helpers/tool_call_llm.py` and `helpers/structured_tool_call_llm.py` updated to accept `guardrails=` and select the guarded base class.
- `agent.py` (`_build_dynamic_agent`) removes the `NotImplementedError` and routes to the correct guarded/unguarded helper.
- Docs updated: the "Current Guardrail Support" callout in `guardrails/overview.md` now covers tool-calling agents.

## Type of changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Background context

Tool-calling agents use a different invocation loop (`_handle_tool_calls`) that bypasses the `_pre_invoke` / `_post_invoke` hooks relied on by `LLMGuardrailsMixin`. As a result, guardrails silently had no effect, and the framework explicitly blocked the combination with a `NotImplementedError`.

**Deferred (follow-up PRs):**
- Output guardrails for `StreamingToolCallLLM`; the streaming generator bypasses `LLMBase._gen_wrapper` where `_post_invoke` normally runs; requires dedicated refactoring.
- Output guardrails for `StructuredToolCallLLM`; the final content, which is a pydantic model, not a string; needs a `StructuredOutputGuard` base type to handle it meaningfully.

## Checklist for Author

### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Documentation
- [x] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

---

## Final Product

```python
import railtracks as rt
from railtracks.guardrails import Guard, GuardrailDecision, InputGuard, OutputGuard, LLMGuardrailEvent
from railtracks.llm import AssistantMessage

@rt.function_node
async def get_forecast(city: str):
    """Return the forecast for a given city. Args: city (str)"""
    return f"Cloudy and 25°C in {city}"

class TopicBlocker(InputGuard):
    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
        if "cupcake" in str(event.messages):
            return GuardrailDecision.block(reason="Off-topic", user_facing_message="Stay on topic.")
        return GuardrailDecision.allow()

class SafetyStamp(OutputGuard):
    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
        content = event.output_message.content + " [VERIFIED]"
        return GuardrailDecision.transform_output(
            output_message=AssistantMessage(content), reason="Safety stamp applied."
        )

agent = rt.agent_node(
    name="WeatherAgent",
    llm=rt.llm.OpenAILLM("gpt-4o"),
    tool_nodes=[get_forecast],
    guardrails=Guard(input=[TopicBlocker()], output=[SafetyStamp()]),
)