### PR TITLE
feat: add BlockText input and output guardrails

### DIFF
--- a/docs/documentation/advanced/guardrails/builtin_guardrails.md
+++ b/docs/documentation/advanced/guardrails/builtin_guardrails.md
@@ -31,6 +31,41 @@ Keep dependencies optional or zero unless the feature truly needs them; document
 
 ## Guardrails
 
+### Block text
+
+`BlockTextInputGuard` and `BlockTextOutputGuard` reject an LLM interaction when a user-supplied **regex pattern** matches. Unlike PII redaction, these guards do **not** transform content — they return ``BLOCK`` on a match and ``ALLOW`` otherwise.
+
+The input guard scans user and system messages; assistant and tool messages are ignored. The output guard scans the model's output message. Non-string content is skipped.
+
+---
+
+#### Usage
+
+Pass a regex string to `pattern`. The pattern is compiled once at construction time; an invalid regex raises `re.error` immediately.
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:block_text_demo"
+```
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:block_text_output_demo"
+```
+
+---
+
+#### Agent usage
+
+Attach like any other guard:
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:block_text_agent"
+```
+
+!!! note "Scope"
+    These guards perform a simple `re.search` against string message content. They do not inspect tool-call arguments, multi-part content lists, or streaming chunks.
+
+---
+
 ### PII redaction
 
 `PIIRedactInputGuard` and `PIIRedactOutputGuard` scan **string** message content with regex. Matches are replaced by placeholders such as `[EMAIL_ADDRESS]`. The input guard scans user and system messages; assistant and tool messages are left unchanged. The output guard scans the model’s output message. Non-string content is passed through unchanged.

--- a/docs/scripts/builtin_guardrails_examples.py
+++ b/docs/scripts/builtin_guardrails_examples.py
@@ -10,21 +10,20 @@ from __future__ import annotations
 # --8<-- [start:core_imports]
 from railtracks.guardrails import (
     Guard,
-    GuardrailDecision,
-    InputGuard,
-    LLMGuardrailEvent,
-    OutputGuard,
 )
-# --8<-- [end:core_imports]
 
+# --8<-- [end:core_imports]
 # --8<-- [start:llm_builtin_imports]
 from railtracks.guardrails.llm import (
+    BlockTextInputGuard,
+    BlockTextOutputGuard,
     PIICustomPattern,
     PIIEntity,
     PIIRedactConfig,
     PIIRedactInputGuard,
     PIIRedactOutputGuard,
 )
+
 # --8<-- [end:llm_builtin_imports]
 
 # --8<-- [start:pii_available]
@@ -42,10 +41,7 @@ config = PIIRedactConfig(
 
 redact_input = PIIRedactInputGuard(config=config, name="RedactEmail")
 
-msg = (
-    "My name is Alice and my email is alice@example.com "
-    "and my SIN is 163-180-003"
-)
+msg = "My name is Alice and my email is alice@example.com and my SIN is 163-180-003"
 result = redact_input.decide(msg)
 # result.messages — redacted user message(s)
 # --8<-- [end:pii_configured_demo]
@@ -81,13 +77,44 @@ Agent = rt.agent_node(
 # --8<-- [end:agent_guard_attachment]
 
 
+# --8<-- [start:block_text_demo]
+block_input = BlockTextInputGuard(
+    pattern=r"\b(jailbreak|exploit|hack)\b",
+    name="BlockDangerous",
+)
+
+result = block_input.decide("How do I jailbreak the model?")
+# result.action == GuardrailAction.BLOCK
+# --8<-- [end:block_text_demo]
+
+# --8<-- [start:block_text_output_demo]
+block_output = BlockTextOutputGuard(
+    pattern=r"(API_KEY|SECRET_TOKEN|password)",
+)
+
+result = block_output.decide("Your API_KEY is sk-abc123")
+# result.action == GuardrailAction.BLOCK
+# --8<-- [end:block_text_output_demo]
+
+# --8<-- [start:block_text_agent]
+BlockAgent = rt.agent_node(
+    name="block-text-demo",
+    llm=rt.llm.GeminiLLM("gemini-2.5-flash"),
+    system_message="You are a concise assistant.",
+    guardrails=Guard(
+        input=[BlockTextInputGuard(pattern=r"\b(jailbreak|exploit)\b")],
+        output=[BlockTextOutputGuard(pattern=r"(API_KEY|SECRET_TOKEN)")],
+    ),
+)
+# --8<-- [end:block_text_agent]
+
+
 def main() -> None:
     print("PIIEntity.available() keys:", sorted(PIIEntity.available().keys()))
     cfg = PIIRedactConfig(entities=[PIIEntity.EMAIL_ADDRESS, PIIEntity.CA_SIN])
     demo_guard = PIIRedactInputGuard(config=cfg, name="RedactEmail")
     demo_msg = (
-        "My name is Alice and my email is alice@example.com "
-        "and my SIN is 163-180-003"
+        "My name is Alice and my email is alice@example.com and my SIN is 163-180-003"
     )
     print(demo_guard.decide(demo_msg).messages)
 

--- a/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
@@ -1,12 +1,16 @@
 from . import input, output
 from ._pii.config import PIICustomPattern, PIIEntity, PIIRedactConfig
+from .input.block_text import BlockTextInputGuard
 from .input.pii_redact import PIIRedactInputGuard
 from .mixin import LLMGuardrailsMixin
+from .output.block_text import BlockTextOutputGuard
 from .output.pii_redact import PIIRedactOutputGuard
 
 __all__ = [
     "input",
     "output",
+    "BlockTextInputGuard",
+    "BlockTextOutputGuard",
     "LLMGuardrailsMixin",
     "PIICustomPattern",
     "PIIEntity",

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
@@ -1,3 +1,4 @@
+from .block_text import BlockTextInputGuard
 from .pii_redact import PIIRedactInputGuard
 
-__all__ = ["PIIRedactInputGuard"]
+__all__ = ["BlockTextInputGuard", "PIIRedactInputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/block_text.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/block_text.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import InputGuard
+from railtracks.llm.message import Role
+
+_SCANNABLE_ROLES = frozenset({Role.user, Role.system})
+
+
+class BlockTextInputGuard(InputGuard):
+    """Blocks LLM input when any user or system message matches a regex pattern."""
+
+    def __init__(
+        self,
+        pattern: str,
+        *,
+        name: str | None = None,
+        user_facing_message: str | None = None,
+    ) -> None:
+        """Initialize the input block-text guard.
+
+        Args:
+            pattern: Regex pattern; if it matches any scannable message content
+                the guard returns ``BLOCK``.
+            name: Optional rail name for traces (see :class:`InputGuard`).
+            user_facing_message: Optional message surfaced to UIs and
+                visualizers when the guard blocks.
+
+        Raises:
+            re.error: If *pattern* is not a valid regular expression.
+        """
+        super().__init__(name=name)
+        self._pattern = re.compile(pattern)
+        self._user_facing_message = user_facing_message
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        """Block if any user/system string message matches the pattern.
+
+        Returns:
+            ``BLOCK`` when the pattern is found, ``ALLOW`` otherwise.
+        """
+        for msg in event.messages:
+            if msg.role not in _SCANNABLE_ROLES or not isinstance(msg.content, str):
+                continue
+            if self._pattern.search(msg.content):
+                return GuardrailDecision.block(
+                    reason=(
+                        f"Input blocked: matched pattern '{self._pattern.pattern}'."
+                    ),
+                    user_facing_message=self._user_facing_message,
+                )
+        return GuardrailDecision.allow(reason="No blocked patterns detected in input.")

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/block_text.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/block_text.py
@@ -47,9 +47,7 @@ class BlockTextInputGuard(InputGuard):
                 continue
             if self._pattern.search(msg.content):
                 return GuardrailDecision.block(
-                    reason=(
-                        f"Input blocked: matched pattern '{self._pattern.pattern}'."
-                    ),
+                    reason=("Input blocked: prohibited content detected."),
                     user_facing_message=self._user_facing_message,
                 )
         return GuardrailDecision.allow(reason="No blocked patterns detected in input.")

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
@@ -1,3 +1,4 @@
+from .block_text import BlockTextOutputGuard
 from .pii_redact import PIIRedactOutputGuard
 
-__all__ = ["PIIRedactOutputGuard"]
+__all__ = ["BlockTextOutputGuard", "PIIRedactOutputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/block_text.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/block_text.py
@@ -45,7 +45,7 @@ class BlockTextOutputGuard(OutputGuard):
 
         if self._pattern.search(msg.content):
             return GuardrailDecision.block(
-                reason=(f"Output blocked: matched pattern '{self._pattern.pattern}'."),
+                reason=("Output blocked: prohibited content detected."),
                 user_facing_message=self._user_facing_message,
             )
         return GuardrailDecision.allow(reason="No blocked patterns detected in output.")

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/block_text.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/block_text.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import OutputGuard
+
+
+class BlockTextOutputGuard(OutputGuard):
+    """Blocks LLM output when the assistant message matches a regex pattern."""
+
+    def __init__(
+        self,
+        pattern: str,
+        *,
+        name: str | None = None,
+        user_facing_message: str | None = None,
+    ) -> None:
+        """Initialize the output block-text guard.
+
+        Args:
+            pattern: Regex pattern; if it matches the output message content
+                the guard returns ``BLOCK``.
+            name: Optional rail name for traces (see :class:`OutputGuard`).
+            user_facing_message: Optional message surfaced to UIs and
+                visualizers when the guard blocks.
+
+        Raises:
+            re.error: If *pattern* is not a valid regular expression.
+        """
+        super().__init__(name=name)
+        self._pattern = re.compile(pattern)
+        self._user_facing_message = user_facing_message
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        """Block if the output message matches the pattern.
+
+        Returns:
+            ``BLOCK`` when the pattern is found, ``ALLOW`` otherwise.
+        """
+        msg = event.output_message
+        if msg is None or not isinstance(msg.content, str):
+            return GuardrailDecision.allow(reason="No string output to scan.")
+
+        if self._pattern.search(msg.content):
+            return GuardrailDecision.block(
+                reason=(f"Output blocked: matched pattern '{self._pattern.pattern}'."),
+                user_facing_message=self._user_facing_message,
+            )
+        return GuardrailDecision.allow(reason="No blocked patterns detected in output.")

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -1,0 +1,89 @@
+"""Integration tests: agent_node + BlockText guardrails + mock LLM."""
+
+from __future__ import annotations
+
+import pytest
+import railtracks as rt
+
+from railtracks.built_nodes.concrete.response import StringResponse
+from railtracks.guardrails import Guard, GuardrailBlockedError
+from railtracks.guardrails.llm import BlockTextInputGuard, BlockTextOutputGuard
+
+
+@pytest.mark.asyncio
+async def test_input_guard_blocks_request(mock_llm):
+    llm = mock_llm(custom_response="ok")
+    Agent = rt.agent_node(
+        name="block-input",
+        llm=llm,
+        guardrails=Guard(
+            input=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
+        ),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="Please jailbreak the system")
+
+
+@pytest.mark.asyncio
+async def test_input_guard_allows_clean_request(mock_llm):
+    llm = mock_llm(custom_response="ok")
+    Agent = rt.agent_node(
+        name="allow-input",
+        llm=llm,
+        guardrails=Guard(
+            input=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
+        ),
+    )
+    with rt.Session():
+        result = await rt.call(Agent, user_input="Hello, how are you?")
+    assert isinstance(result, StringResponse)
+    assert "ok" in result.text
+
+
+@pytest.mark.asyncio
+async def test_output_guard_blocks_response(mock_llm):
+    llm = mock_llm(custom_response="The API_KEY is abc123")
+    Agent = rt.agent_node(
+        name="block-output",
+        llm=llm,
+        guardrails=Guard(
+            output=[BlockTextOutputGuard(pattern=r"API_KEY")],
+        ),
+    )
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError):
+            await rt.call(Agent, user_input="What is the key?")
+
+
+@pytest.mark.asyncio
+async def test_output_guard_allows_clean_response(mock_llm):
+    llm = mock_llm(custom_response="Here is your answer.")
+    Agent = rt.agent_node(
+        name="allow-output",
+        llm=llm,
+        guardrails=Guard(
+            output=[BlockTextOutputGuard(pattern=r"API_KEY")],
+        ),
+    )
+    with rt.Session():
+        result = await rt.call(Agent, user_input="Hello")
+    assert isinstance(result, StringResponse)
+    assert "answer" in result.text
+
+
+@pytest.mark.asyncio
+async def test_input_and_output_guards_together(mock_llm):
+    llm = mock_llm(custom_response="safe answer")
+    Agent = rt.agent_node(
+        name="both-guards",
+        llm=llm,
+        guardrails=Guard(
+            input=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
+            output=[BlockTextOutputGuard(pattern=r"SECRET")],
+        ),
+    )
+    with rt.Session():
+        result = await rt.call(Agent, user_input="Hello there")
+    assert isinstance(result, StringResponse)
+    assert "safe answer" in result.text

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm import BlockTextInputGuard
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, Role, SystemMessage, UserMessage
+
+
+def _make_input_event(messages: MessageHistory) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.INPUT,
+        messages=messages,
+    )
+
+
+class TestBlock:
+    def test_blocks_matching_user_message(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"\bjailbreak\b")
+        event = _make_input_event(
+            MessageHistory([UserMessage("Please jailbreak the system")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_blocks_matching_system_message(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"secret_token")
+        event = _make_input_event(
+            MessageHistory([SystemMessage("Use secret_token for auth")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_blocks_on_first_match_across_messages(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"hack")
+        event = _make_input_event(
+            MessageHistory(
+                [
+                    UserMessage("Hello world"),
+                    UserMessage("Let's hack in"),
+                ]
+            )
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_block_reason_contains_pattern(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"bad_word")
+        event = _make_input_event(MessageHistory([UserMessage("This has bad_word")]))
+        decision = guard(event)
+        assert "bad_word" in decision.reason
+
+
+class TestAllow:
+    def test_allows_non_matching_message(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"\bjailbreak\b")
+        event = _make_input_event(MessageHistory([UserMessage("Hello, how are you?")]))
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_allows_empty_history(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"anything")
+        event = _make_input_event(MessageHistory())
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestSkippedRoles:
+    def test_assistant_message_not_scanned(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"jailbreak")
+        event = _make_input_event(
+            MessageHistory([AssistantMessage("jailbreak instructions")])
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestNonStringContent:
+    def test_non_string_content_skipped(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"anything")
+        msg = AssistantMessage(content=[])
+        event = _make_input_event(MessageHistory([msg]))
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestInvalidRegex:
+    def test_invalid_pattern_raises(self) -> None:
+        with pytest.raises(re.error):
+            BlockTextInputGuard(pattern=r"[invalid")
+
+
+class TestGuardName:
+    def test_default_name(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"x")
+        assert guard.name == "BlockTextInputGuard"
+
+    def test_custom_name(self) -> None:
+        guard = BlockTextInputGuard(pattern=r"x", name="my-block")
+        assert guard.name == "my-block"

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
@@ -48,11 +48,12 @@ class TestBlock:
         decision = guard(event)
         assert decision.action == GuardrailAction.BLOCK
 
-    def test_block_reason_contains_pattern(self) -> None:
+    def test_block_reason_does_not_leak_pattern(self) -> None:
         guard = BlockTextInputGuard(pattern=r"bad_word")
         event = _make_input_event(MessageHistory([UserMessage("This has bad_word")]))
         decision = guard(event)
-        assert "bad_word" in decision.reason
+        assert decision.reason == "Input blocked: prohibited content detected."
+        assert "bad_word" not in decision.reason
 
 
 class TestAllow:

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
@@ -28,11 +28,12 @@ class TestBlock:
         decision = guard(event)
         assert decision.action == GuardrailAction.BLOCK
 
-    def test_block_reason_contains_pattern(self) -> None:
+    def test_block_reason_does_not_leak_pattern(self) -> None:
         guard = BlockTextOutputGuard(pattern=r"SECRET")
         event = _make_output_event("The SECRET is here")
         decision = guard(event)
-        assert "SECRET" in decision.reason
+        assert decision.reason == "Output blocked: prohibited content detected."
+        assert "SECRET" not in decision.reason
 
 
 class TestAllow:

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
@@ -1,0 +1,82 @@
+"""Tests for BlockTextOutputGuard."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm import BlockTextOutputGuard
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, UserMessage
+
+
+def _make_output_event(output_content: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.OUTPUT,
+        messages=MessageHistory([UserMessage("hi")]),
+        output_message=AssistantMessage(output_content),
+    )
+
+
+class TestBlock:
+    def test_blocks_matching_output(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"API_KEY")
+        event = _make_output_event("Your API_KEY is abc123")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_block_reason_contains_pattern(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"SECRET")
+        event = _make_output_event("The SECRET is here")
+        decision = guard(event)
+        assert "SECRET" in decision.reason
+
+
+class TestAllow:
+    def test_allows_non_matching_output(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"API_KEY")
+        event = _make_output_event("Here is your answer.")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_allows_no_output_message(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"anything")
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("hi")]),
+            output_message=None,
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestNonStringContent:
+    def test_non_string_content_skipped(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"anything")
+        msg = AssistantMessage(content=[])
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("hi")]),
+            output_message=msg,
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestInvalidRegex:
+    def test_invalid_pattern_raises(self) -> None:
+        with pytest.raises(re.error):
+            BlockTextOutputGuard(pattern=r"[invalid")
+
+
+class TestGuardName:
+    def test_default_name(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"x")
+        assert guard.name == "BlockTextOutputGuard"
+
+    def test_custom_name(self) -> None:
+        guard = BlockTextOutputGuard(pattern=r"x", name="my-block")
+        assert guard.name == "my-block"


### PR DESCRIPTION
## What does this add?

  Adds `BlockTextInputGuard` and `BlockTextOutputGuard` ; regex-based guardrails that reject LLM                              interactions when a user-defined pattern is detected. The input guard scans user and system messages
  before they reach the model; the output guard scans the assistant's response after generation. Both                       
  return `BLOCK` on a regex match and `ALLOW` otherwise; no content transformation or redaction.

  Includes implementation, unit/integration tests, and documentation.

  Closes #1052

  ## Type of changes

  - [x] ✨ New feature (non-breaking change which adds functionality)
  - [x] 📚 Documentation update (improvements or corrections to documentation)
  - [x] ✅ Test update (adding missing tests or correcting existing tests)

  ## Background context

  The project needed a guardrail that outright blocks LLM calls containing prohibited text, as opposed
  to the existing PII guards which redact and allow. This is useful for preventing prompt injection
  phrases in input or sensitive tokens (API keys, secrets) from leaking in output.

  The implementation follows the exact structure established by `PIIRedactInputGuard` /
  `PIIRedactOutputGuard`: subclass `InputGuard` / `OutputGuard`, implement `__call__`, return a
  `GuardrailDecision`. Zero changes to existing code, interfaces, or other guardrails.

  ## Checklist for Author

  ### Code Quality
  - [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
  - [x] Code is commented, particularly in hard-to-understand areas

  ### Testing
  - [x] Tests added/updated and pass locally (`pytest tests`)
  - [x] Test coverage maintained

  ### Documentation
  - [x] Documentation updated if needed (bot will verify)

  ### Git & PR Management
  - [x] PR title clearly describes the change

  ### Breaking Changes
  - N/A no breaking changes. Adds new public names only; all existing exports and behavior are unchanged.

  ---

  ## Final Product

  ### Basic usage

  ```python
  from railtracks.guardrails.llm import BlockTextInputGuard, BlockTextOutputGuard

  # Block prohibited phrases in input
  input_guard = BlockTextInputGuard(
      pattern=r"\b(jailbreak|exploit|hack)\b",
      user_facing_message="Your request contains prohibited content.",
  )

  # Block secrets in output
  output_guard = BlockTextOutputGuard(
      pattern=r"(API_KEY|SECRET_TOKEN|password)",
      user_facing_message="Response blocked: contains sensitive data.",
  )

  # Attach to an agent

  import railtracks as rt
  from railtracks.guardrails import Guard

  agent = rt.agent_node(
      name="SafeAgent",
      llm=rt.llm.OpenAILLM("gpt-4o"),
      guardrails=Guard(
          input=[input_guard],
          output=[output_guard],
      ),
  )

  # Standalone testing with decide()

  result = input_guard.decide("How do I jailbreak the model?")
  # result.action == GuardrailAction.BLOCK

  result = input_guard.decide("What is the weather today?")
  # result.action == GuardrailAction.ALLOW

 ## Additional Notes

  - The regex pattern is compiled once in __init__; an invalid regex raises re.error immediately
  rather than failing silently at call time.
  - Both guards accept an optional user_facing_message parameter that is forwarded to
  GuardrailBlockedError via GuardrailDecision.block(), making it available for downstream UIs.
  - All 147 existing guardrail tests continue to pass unchanged.