### PR TITLE
debug: tool manifest param type

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,6 +112,8 @@ Orchestrator = rt.agent_node(
 )
 ```
 
+`Parameter.param_type` may be a JSON schema type string (e.g. `"string"`) or a Python builtin (`str`, `int`, …) mapped to the same schema types.
+
 #### MCP Tools
 ```python
 server = rt.connect_mcp(rt.MCPStdioParams(command="python", args=["-m", "my_mcp_server"]))

--- a/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
+++ b/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
@@ -124,7 +124,7 @@ Orchestrator = rt.agent_node(
 `Parameter` fields:
 - `name` — the argument name the orchestrator LLM passes
 - `description` — explains what to put in this argument
-- `param_type` — JSON schema type string: `"string"`, `"integer"`, `"number"`, `"boolean"`
+- `param_type` — JSON schema type string (`"string"`, `"integer"`, `"number"`, `"boolean"`, …) **or** a Python builtin mapped the same way: `str`, `int`, `float` (→ `"number"`), `bool`, `list` / `tuple` / `set` (→ `"array"`), `dict` (→ `"object"`), `type(None)` (→ `"null"`). Unknown types fall back to `"object"`.
 - `required` — defaults to `True`
 - `enum` — optional list of allowed values
 

--- a/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
+++ b/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
@@ -29,8 +29,22 @@ class ParameterType(str, Enum):
         return mapping.get(py_type, cls.OBJECT)
 
 
+def _normalize_param_type_scalar(
+    param_type: Union[str, ParameterType, type],
+) -> str:
+    """Map ParameterType enum, JSON schema type string, or Python type to a schema type string."""
+    if isinstance(param_type, ParameterType):
+        return param_type.value
+    if isinstance(param_type, type):
+        return ParameterType.from_python_type(param_type).value
+    return param_type
+
+
 # Generic Type for subclass methods that return Parameter
 T = TypeVar("T", bound="Parameter")
+
+ParameterTypeInputScalar = Union[str, ParameterType, type]
+ParameterTypeInput = Optional[Union[ParameterTypeInputScalar, List[ParameterTypeInputScalar]]]
 
 
 class Parameter(ABC):
@@ -48,7 +62,7 @@ class Parameter(ABC):
         default: Any = None,
         enum: Optional[List[Any]] = None,
         default_present: bool = False,
-        param_type: Optional[Union[str, List[str]]] = None,
+        param_type: ParameterTypeInput = None,
     ):
         """
         Initialize a Parameter instance.
@@ -60,7 +74,8 @@ class Parameter(ABC):
             default (Any): Default value for the parameter.
             enum (Optional[List[Any]]): Allowed values for the parameter.
             default_present (bool): Whether a default value is explicitly set.
-            param_type (Optional[Union[str, List[str]]]): The type or types of the parameter.
+            param_type: JSON schema type string (e.g. ``\"string\"``), :class:`ParameterType`,
+                a Python builtin type (e.g. ``str`` → ``\"string\"``), or a list for unions.
         """
         self.name = name
         self.description = description or ""
@@ -69,19 +84,10 @@ class Parameter(ABC):
         self.enum = enum
         self.default_present = default_present
         if param_type is not None:
-            # Accept either list[str], str, or ParameterType enum or list of them
-            # Normalize to str or List[str]
             if isinstance(param_type, list):
-                self.param_type = [
-                    pt.value if isinstance(pt, ParameterType) else pt
-                    for pt in param_type
-                ]
+                self.param_type = [_normalize_param_type_scalar(pt) for pt in param_type]
             else:
-                self.param_type = (
-                    param_type.value
-                    if isinstance(param_type, ParameterType)
-                    else param_type
-                )
+                self.param_type = _normalize_param_type_scalar(param_type)
         elif hasattr(self, "param_type") and self.param_type is None:
             self.param_type = None
 

--- a/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
+++ b/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
@@ -44,7 +44,9 @@ def _normalize_param_type_scalar(
 T = TypeVar("T", bound="Parameter")
 
 ParameterTypeInputScalar = Union[str, ParameterType, type]
-ParameterTypeInput = Optional[Union[ParameterTypeInputScalar, List[ParameterTypeInputScalar]]]
+ParameterTypeInput = Optional[
+    Union[ParameterTypeInputScalar, List[ParameterTypeInputScalar]]
+]
 
 
 class Parameter(ABC):
@@ -85,7 +87,9 @@ class Parameter(ABC):
         self.default_present = default_present
         if param_type is not None:
             if isinstance(param_type, list):
-                self.param_type = [_normalize_param_type_scalar(pt) for pt in param_type]
+                self.param_type = [
+                    _normalize_param_type_scalar(pt) for pt in param_type
+                ]
             else:
                 self.param_type = _normalize_param_type_scalar(param_type)
         elif hasattr(self, "param_type") and self.param_type is None:

--- a/packages/railtracks/tests/unit_tests/llm/tools/parameters/test__base.py
+++ b/packages/railtracks/tests/unit_tests/llm/tools/parameters/test__base.py
@@ -1,4 +1,5 @@
-import pytest
+import json
+
 from railtracks.llm.tools.parameters._base import Parameter, ParameterType
 
 
@@ -26,3 +27,22 @@ def test_param_type_from_python_type():
     assert ParameterType.from_python_type(list) == ParameterType.ARRAY
     assert ParameterType.from_python_type(dict) == ParameterType.OBJECT
     assert ParameterType.from_python_type(type(None)) == ParameterType.NONE
+
+
+def test_parameter_accepts_python_type_str():
+    p = Parameter("query", description="The search query string.", param_type=str)
+    assert p.param_type == "string"
+    assert p.to_json_schema()["type"] == "string"
+    json.dumps(p.to_json_schema())
+
+
+def test_parameter_accepts_python_type_int():
+    p = Parameter("n", description="A number.", param_type=int)
+    assert p.param_type == "integer"
+    assert p.to_json_schema()["type"] == "integer"
+    json.dumps(p.to_json_schema())
+
+
+def test_parameter_list_accepts_mixed_python_and_schema_types():
+    p = Parameter("x", param_type=[str, "null"])
+    assert p.param_type == ["string", "null"]


### PR DESCRIPTION
## What does this add?
Closes #1066 

`rt.llm.Parameter` now accepts **Python builtin types** for `param_type` (e.g. `str`, `int`, `float`, `bool`, `list`, `dict`, `type(None)`) in addition to existing **JSON Schema type strings** (`"string"`, `"integer"`, …) and `ParameterType` enum values. Values are normalized internally to the same JSON Schema type strings the rest of the stack already expects.

This fixes incorrect behavior when a **type object** was passed: previously `param_type=str` stored `<class 'str'>`, produced invalid `to_json_schema()` output, and broke `json.dumps` ([RailtownAI/railtracks#1066](https://github.com/RailtownAI/railtracks/issues/1066)). It also aligns the public type hints with what we support and removes spurious static errors for natural Python call sites.

**References:** JSON Schema defines tool-facing types via the `type` keyword as **strings** such as `"string"` and `"integer"` (see [JSON Schema — Type-specific keywords](https://json-schema.org/understanding-json-schema/reference/type)), including a JSON↔Python analogy table. Railtracks still speaks JSON Schema on the wire; this change adds an explicit **Python-side** mapping (reusing `ParameterType.from_python_type`) so authors can write `str` / `int` in code without changing the emitted schema vocabulary.

## Type of changes

Please check the type of change your PR introduces:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Background context

[#1066](https://github.com/RailtownAI/railtracks/issues/1066) reported that `param_type=str` should be valid. The underlying issue was twofold: annotations only allowed schema strings, and at runtime **type objects** were not normalized to schema strings, so schemas were not JSON-serializable. Normalization is centralized in `_normalize_param_type_scalar` in `packages/railtracks/src/railtracks/llm/tools/parameters/_base.py`.

## Checklist for Author
<!-- Skip sections not relevant to your change type (e.g., skip Testing for docs-only changes) -->

### Code Quality
- [ ] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [ ] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Test coverage maintained

### Documentation
- [x] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

---

## Final Product

**Before (broken at runtime for type objects):** `param_type=str` could yield a non-serializable schema `type` field.

**After:** both styles work; stored `param_type` remains normalized schema string(s).

```python
import json
import railtracks as rt

p = rt.llm.Parameter(
    name="query",
    description="Search query.",
    param_type=str,  # or param_type="string"
)
assert p.param_type == "string"
json.dumps(p.to_json_schema())  # ok

# Union-style list: mix Python type + schema string
q = rt.llm.Parameter("x", param_type=[str, "null"])
assert q.param_type == ["string", "null"]
```

Docs: `packages/railtracks/src/railtracks/cli/skills/agent-builder.md` (`param_type` bullet); `.github/copilot-instructions.md` (one-line note).

## Additional Notes

- **Non-breaking:** Existing callers using `"string"` / `"integer"` / `ParameterType` are unchanged.
- **Mapping** follows existing `ParameterType.from_python_type` (e.g. `float` → `"number"`; unknown `type` → `"object"`).