### PR TITLE
1077 litellm safety cap

### DIFF
--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
@@ -53,7 +54,7 @@ visual = [
 cli = ["railtracks[visual]"]
 chat = ["railtracks[visual]"]
 chroma = [
-    "chromadb > 1.3.0",
+    "chromadb >= 1.3.0",
     "pdfplumber >= 0.10.1",
 ]
 portkey = ["portkey_ai >= 2.0.2"]
@@ -77,6 +78,3 @@ include = ["docs/", "README.md", "LICENSE"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-
-[tool.setuptools.package-data]
-railtracks = ["py.typed"]

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -17,38 +17,28 @@ readme = "README.md"
 license = { file = "LICENSE" }
 dynamic = ["version", "description"]
 requires-python = ">=3.10"
-
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-
     "License :: OSI Approved :: MIT License",
-
     "Operating System :: OS Independent",
-
     "Development Status :: 4 - Beta",
-
     "Framework :: AsyncIO",
-
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-
     "Natural Language :: English",
-
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
-
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Environment :: Console",
     "Typing :: Typed",
 ]
-
 dependencies = [
     "colorama >= 0.4.6",
-    "litellm <= 1.82.6",
-    "litellm >= 1.70.2",
-    "mcp >= 1.9.0",
+    "litellm >= 1.70.2, != 1.82.7, != 1.82.8, <= 1.83.12",
+    "mcp >= 1.9.0, <2",
     "pydantic >= 2.5.3, <3",
     "python-dotenv >= 1.0.0",
     "PyYAML >= 6.0",
@@ -59,18 +49,15 @@ visual = [
     "fastapi >= 0.104.0",
     "uvicorn[standard] >= 0.24.0",
 ]
+# cli and chat both require the visual extras (may diverge in future)
 cli = ["railtracks[visual]"]
 chat = ["railtracks[visual]"]
-# For each Integration package dependencies go here.
-rag = ["litellm >= 1.70.2"]
 chroma = [
     "chromadb > 1.3.0",
-    "pdfplumber >= 0.10.1"
+    "pdfplumber >= 0.10.1",
 ]
-# the integrations submodule will be list a of the above deps
 portkey = ["portkey_ai >= 2.0.2"]
 integrations = ["railtracks[portkey]", "railtracks[chroma]"]
-
 all = ["railtracks[visual]", "railtracks[integrations]"]
 
 [project.scripts]
@@ -81,7 +68,6 @@ documentation = "https://railtownai.github.io/railtracks/"
 "Release Notes" = "https://github.com/RailtownAI/railtracks/releases"
 repository = "https://github.com/RailtownAI/railtracks"
 home = "https://railtracks.org"
-
 
 [tool.flit.module]
 name = "railtracks"


### PR DESCRIPTION
## What does this add?

Refreshes the `litellm` safety cap introduced in #1035 to address the supply-chain incident (#1034). The original fix capped at `<=1.82.6`, which inadvertently blocked all `1.83.x` releases including clean versions that close downstream CVEs. This PR replaces the blanket upper bound with a narrower constraint (`!=1.82.7, !=1.82.8`) while setting a new soft ceiling at `<=1.83.12` (latest verified clean release as of 2026-04-26), restoring compatibility for users blocked on CVE patches.

Also includes packaging housekeeping: removes the stale `Python :: 3.9` classifier (below `requires-python = ">=3.10"`), adds `Python :: 3.13`, fixes the `chromadb` lower bound from `>` to `>=`, drops the dead `[tool.setuptools.package-data]` section (unused with `flit_core`), removes the redundant `rag` extra, and adds an upper bound to `mcp` (`<2`) for consistency.

## Type of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI changes (changes to build process or continuous integration)

## Background context

PR #1035 (closes #1034) added `litellm<=1.82.6` on 2026-03-24 in response to malicious wheels published as `litellm 1.82.7` and `1.82.8` (BerriAI/litellm#24512). Per OSV.dev's GHSA entry, the compromised range is exactly those two versions, `1.83.0` and the entire `1.83.x` line are unaffected. The hard cap was blocking downstream users from resolving `litellm>=1.83.x` to patch their own CVEs. See #1077 for the external report.

The new constraint (`!=1.82.7, !=1.82.8, <=1.83.12`) brackets out only the two bad wheels while allowing access to the clean `1.83.x` series. The upper bound is intentionally kept as a soft safety rail and should be bumped periodically as new litellm releases are vetted.

## Checklist for Author

### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Documentation
- [x] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

---

## Final Product

Users on `litellm>=1.83.0` can now resolve `railtracks` without conflict:

```toml
# Before
litellm <= 1.82.6
litellm >= 1.70.2

# After
litellm >= 1.70.2, != 1.82.7, != 1.82.8, <= 1.83.12
```
#### Additional Notes
The <=1.83.12 ceiling is a deliberate conservative choice. It should be bumped in a follow-up once newer 1.83.x / 1.84.x releases have been vetted clean. Closes #1077.