### PR TITLE
Simple none support for runtime

### DIFF
--- a/packages/railtracks/src/railtracks/evaluations/point.py
+++ b/packages/railtracks/src/railtracks/evaluations/point.py
@@ -55,7 +55,7 @@ class ToolCall(BaseModel):
     name: str
     arguments: ToolArguments
     output: Any
-    runtime: float
+    runtime: float | None = None
     status: Status
 
 
@@ -83,10 +83,10 @@ class LLMCall(BaseModel):
     model_provider: str
     input: list[LLMIO]
     output: LLMIO
-    input_tokens: int
-    output_tokens: int
-    total_cost: float
-    latency: float
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_cost: float | None = None
+    latency: float | None = None
     index: int
 
 
@@ -134,10 +134,10 @@ def extract_llm_details(llm_details: list[dict]) -> LLMDetails:
                 model_provider=detail.get("model_provider", ""),
                 input=inputs,
                 output=output,
-                input_tokens=detail.get("input_tokens", -1),
-                output_tokens=detail.get("output_tokens", -1),
-                total_cost=detail.get("total_cost", -1),
-                latency=detail.get("latency", -1),
+                input_tokens=detail.get("input_tokens"),
+                output_tokens=detail.get("output_tokens"),
+                total_cost=detail.get("total_cost"),
+                latency=detail.get("latency"),
                 index=idx,
             )
         )
@@ -222,7 +222,7 @@ def extract_tool_details(
                 output=edge.details.get("output", None),
                 runtime=target.details.get("internals", {})
                 .get("latency", {})
-                .get("total_time", 0),
+                .get("total_time"),
                 status=Status(edge.details.get("status")),
             )
         )

--- a/packages/railtracks/src/railtracks/evaluations/result/metric_results.py
+++ b/packages/railtracks/src/railtracks/evaluations/result/metric_results.py
@@ -9,7 +9,7 @@ class MetricResult(BaseModel):
     result_name: str  # primary for human readability and debugging
     metric_id: str
     agent_data_id: list[UUID]
-    value: str | float | int
+    value: str | float | int | None
 
 
 class ToolMetricResult(MetricResult):

--- a/packages/railtracks/tests/unit_tests/evaluations/test_null_metrics.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/test_null_metrics.py
@@ -1,0 +1,106 @@
+import json
+import uuid
+import pytest
+from pathlib import Path
+from railtracks.evaluations.point import extract_agent_data_points, AgentDataPoint
+from railtracks.evaluations.evaluators.llm_inference_evaluator import LLMInferenceEvaluator
+from railtracks.evaluations.runners._evaluate import evaluate
+
+@pytest.fixture
+def session_with_null_metrics(tmp_path):
+    """Create a temporary session file with null values for metrics."""
+    session_id = str(uuid.uuid4())
+    agent_node_id = str(uuid.uuid4())
+    session_data = {
+        "session_id": session_id,
+        "runs": [
+            {
+                "nodes": [
+                    {
+                        "identifier": agent_node_id,
+                        "node_type": "Agent",
+                        "name": "Test Agent",
+                        "details": {
+                            "internals": {
+                                "llm_details": [
+                                    {
+                                        "model_name": "gpt-4",
+                                        "model_provider": "openai",
+                                        "input": [{"role": "user", "content": "hello"}],
+                                        "output": {"role": "assistant", "content": "hi"},
+                                        "input_tokens": None,
+                                        "output_tokens": 10,
+                                        "total_cost": None,
+                                        "latency": 0.5
+                                    },
+                                    {
+                                        "model_name": "gpt-4",
+                                        "model_provider": "openai",
+                                        "input": [{"role": "user", "content": "world"}],
+                                        "output": {"role": "assistant", "content": "hello"},
+                                        "input_tokens": 5,
+                                        "output_tokens": None,
+                                        "total_cost": 0.01,
+                                        "latency": None
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "edges": []
+            }
+        ]
+    }
+    
+    session_file = tmp_path / f"{session_id}.json"
+    session_file.write_text(json.dumps(session_data))
+    return tmp_path
+
+def test_extract_agent_data_points_with_null_metrics(session_with_null_metrics):
+    """Ensure extract_agent_data_points handles null metrics without validation errors."""
+    data_points = extract_agent_data_points(str(session_with_null_metrics))
+    assert len(data_points) == 1
+    adp = data_points[0]
+    
+    # Check that nulls are preserved correctly
+    assert adp.llm_details.calls[0].input_tokens is None
+    assert adp.llm_details.calls[0].total_cost is None
+    assert adp.llm_details.calls[1].output_tokens is None
+    assert adp.llm_details.calls[1].latency is None
+    
+    # Check that valid values are also preserved
+    assert adp.llm_details.calls[0].output_tokens == 10
+    assert adp.llm_details.calls[1].total_cost == 0.01
+
+def test_llm_inference_evaluator_with_null_metrics(session_with_null_metrics):
+    """Ensure LLMInferenceEvaluator skips null values in aggregation."""
+    data_points = extract_agent_data_points(str(session_with_null_metrics))
+    evaluator = LLMInferenceEvaluator()
+    result = evaluator.run(data_points)
+    
+    # Verify cost aggregate skips the None value
+    token_cost_aggregates = [
+        node for node in result.aggregate_results.nodes.values() 
+        if getattr(node, "name", "").startswith("Aggregate/TokenCost")
+    ]
+    
+    # We expect one aggregate for Call_1 (Call_0 has total_cost=None and is skipped)
+    assert len(token_cost_aggregates) == 1
+    agg = token_cost_aggregates[0]
+    assert agg.llm_call_index == 1
+    assert agg.mean == 0.01
+    assert agg.values == [0.01]
+
+def test_evaluate_runner_with_null_metrics(session_with_null_metrics):
+    """Ensure the full evaluate() flow works with null metrics."""
+    data_points = extract_agent_data_points(str(session_with_null_metrics))
+    evaluator = LLMInferenceEvaluator()
+    
+    # Should not raise any exceptions
+    results = evaluate(
+        data=data_points,
+        evaluators=[evaluator],
+        agent_selection=False
+    )
+    assert len(results) == 1


### PR DESCRIPTION
## What does this add?

This PR fixes a bug where `null` values for LLM metrics (total cost, token counts, latency) in session JSON files caused the evaluation process to fail or stall. This was due to strict Pydantic validation in the `LLMCall` and `MetricResult` models. 

By making these fields optional, the system now gracefully handles incomplete or missing metric data from session logs.

close #1036

## Type of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update (improvements or corrections to documentation)
- [ ] 🎨 Code style/formatting (changes that do not affect the meaning of the code)
- [ ] ♻️ Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] ⚡ Performance improvement (code change that improves performance)
- [x] ✅ Test update (adding missing tests or correcting existing tests)
- [ ] 🔧 Build/CI changes (changes to build process or continuous integration)
- [ ] 🗑️ Chore (other changes that don't modify src or test files)

## Background context

Users reported that the evaluation process would stall and then fail when a session contained an agent with `null` as `total_cost`. Investigation revealed that `extract_agent_data_points` was raising a `ValidationError` because the `LLMCall` model expected `float` but received `None`. This PR relaxes those requirements and ensures evaluators (like `LLMInferenceEvaluator`) skip `None` values during aggregation.


## Checklist for Author

### Code Quality
- [x] Code follows the project's style guidelines (run `ruff check .` and `ruff format .`)
- [x] Code is commented, particularly in hard-to-understand areas

### Testing
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Test coverage maintained

### Documentation
- [ ] Documentation updated if needed (bot will verify)

### Git & PR Management
- [x] PR title clearly describes the change

### Breaking Changes
- [ ] Breaking changes are documented
- [ ] Migration guide provided in documentation (step-by-step instructions for users to update their code/config)

---

## Final Product

Added a comprehensive unit test `packages/railtracks/tests/unit_tests/evaluations/test_null_metrics.py` which:
1.  Simulates a session JSON with `null` values for various metrics.
2.  Verifies that `extract_agent_data_points` parses the data without errors.
3.  Verifies that `LLMInferenceEvaluator` correctly computes aggregates by skipping the `null` entries.
4.  Ensures the full `evaluate()` runner flow works end-to-end with missing data.

## Additional Notes

*   Also updated `ToolCall`'s `runtime` field to be optional for consistency with LLM metrics.
*   Aggregation logic in `NumericalAggregateNode` correctly filters for `(int, float)` ensuring `None` values don't affect computed means or maximums.