### PR TITLE
feat: add InputLengthGuard and OutputLengthGuard

### DIFF
--- a/docs/documentation/advanced/guardrails/builtin_guardrails.md
+++ b/docs/documentation/advanced/guardrails/builtin_guardrails.md
@@ -66,6 +66,41 @@ Attach like any other guard:
 
 ---
 
+### Length limits
+
+`InputLengthGuard` and `OutputLengthGuard` block an LLM interaction when the character count exceeds a configured ceiling. Both guards return `BLOCK` over the limit and `ALLOW` otherwise, they never transform content.
+
+`InputLengthGuard` sums `len(message.content)` across **all** messages in the input history (user, system, assistant, tool). `OutputLengthGuard` measures the assistant reply on `event.output_message`; if there is no output message, it allows.
+
+---
+
+#### Usage
+
+`max_chars` must be a positive integer; non-positive values raise `ValueError` at construction. Defaults are `4096` for input and `2048` for output. Each decision's `meta` carries `total_chars` and `max_chars` for logging.
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:length_input_demo"
+```
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:length_output_demo"
+```
+
+---
+
+#### Agent usage
+
+Attach like any other guard:
+
+```python
+--8<-- "docs/scripts/builtin_guardrails_examples.py:length_agent"
+```
+
+!!! note "Scope"
+    Counting is character-based and dependency-free. Word- or token-based counting (e.g. via `tiktoken`) is out of scope today and may arrive in later releases. Non-string content is treated as zero-length.
+
+---
+
 ### PII redaction
 
 `PIIRedactInputGuard` and `PIIRedactOutputGuard` scan **string** message content with regex. Matches are replaced by placeholders such as `[EMAIL_ADDRESS]`. The input guard scans user and system messages; assistant and tool messages are left unchanged. The output guard scans the model’s output message. Non-string content is passed through unchanged.

--- a/docs/scripts/builtin_guardrails_examples.py
+++ b/docs/scripts/builtin_guardrails_examples.py
@@ -17,6 +17,8 @@ from railtracks.guardrails import (
 from railtracks.guardrails.llm import (
     BlockTextInputGuard,
     BlockTextOutputGuard,
+    InputLengthGuard,
+    OutputLengthGuard,
     PIICustomPattern,
     PIIEntity,
     PIIRedactConfig,
@@ -107,6 +109,34 @@ BlockAgent = rt.agent_node(
     ),
 )
 # --8<-- [end:block_text_agent]
+
+
+# --8<-- [start:length_input_demo]
+input_length = InputLengthGuard(max_chars=4000)
+
+result = input_length.decide("a" * 5000)
+# result.action == GuardrailAction.BLOCK
+# result.meta == {"total_chars": 5000, "max_chars": 4000}
+# --8<-- [end:length_input_demo]
+
+# --8<-- [start:length_output_demo]
+output_length = OutputLengthGuard(max_chars=2000)
+
+result = output_length.decide("ok")
+# result.action == GuardrailAction.ALLOW
+# --8<-- [end:length_output_demo]
+
+# --8<-- [start:length_agent]
+Agent = rt.agent_node(
+    name="length-guard-demo",
+    llm=rt.llm.GeminiLLM("gemini-2.5-flash"),
+    system_message="You are a concise assistant.",
+    guardrails=Guard(
+        input=[InputLengthGuard(max_chars=4000)],
+        output=[OutputLengthGuard(max_chars=2000)],
+    ),
+)
+# --8<-- [end:length_agent]
 
 
 def main() -> None:

--- a/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
@@ -1,9 +1,11 @@
 from . import input, output
 from ._pii.config import PIICustomPattern, PIIEntity, PIIRedactConfig
 from .input.block_text import BlockTextInputGuard
+from .input.length_guard import InputLengthGuard
 from .input.pii_redact import PIIRedactInputGuard
 from .mixin import LLMGuardrailsMixin
 from .output.block_text import BlockTextOutputGuard
+from .output.length_guard import OutputLengthGuard
 from .output.pii_redact import PIIRedactOutputGuard
 
 __all__ = [
@@ -11,7 +13,9 @@ __all__ = [
     "output",
     "BlockTextInputGuard",
     "BlockTextOutputGuard",
+    "InputLengthGuard",
     "LLMGuardrailsMixin",
+    "OutputLengthGuard",
     "PIICustomPattern",
     "PIIEntity",
     "PIIRedactConfig",

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/__init__.py
@@ -1,4 +1,5 @@
 from .block_text import BlockTextInputGuard
+from .length_guard import InputLengthGuard
 from .pii_redact import PIIRedactInputGuard
 
-__all__ = ["BlockTextInputGuard", "PIIRedactInputGuard"]
+__all__ = ["BlockTextInputGuard", "InputLengthGuard", "PIIRedactInputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/input/length_guard.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/input/length_guard.py
@@ -1,0 +1,48 @@
+"""Input length guardrail — blocks LLM requests that exceed a character limit."""
+
+from __future__ import annotations
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import InputGuard
+
+
+class InputLengthGuard(InputGuard):
+    """Blocks LLM input (the full message history) that exceeds ``max_chars`` characters.
+
+    Character counting is used as the simplest, dependency-free unit.  A future
+    implementation may add word- or token-based counting via an optional parameter.
+
+    Example::
+
+        guard = InputLengthGuard(max_chars=4000)
+
+    Args:
+        max_chars: Maximum number of characters allowed across all messages in the
+            input history.  Defaults to ``4096``.
+        name: Optional display name for the guardrail instance.
+    """
+
+    def __init__(self, max_chars: int = 4096, name: str | None = None) -> None:
+        super().__init__(name=name)
+        if max_chars <= 0:
+            raise ValueError(f"max_chars must be a positive integer, got {max_chars!r}")
+        self.max_chars = max_chars
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        total_chars = sum(len(m.content or "") for m in event.messages)
+        if total_chars > self.max_chars:
+            return GuardrailDecision.block(
+                reason=(
+                    f"Input length {total_chars} characters exceeds the maximum of "
+                    f"{self.max_chars} characters."
+                ),
+                user_facing_message=(
+                    "Your message is too long. Please shorten your input and try again."
+                ),
+                meta={"total_chars": total_chars, "max_chars": self.max_chars},
+            )
+        return GuardrailDecision.allow(
+            reason=f"Input length {total_chars} chars is within the {self.max_chars}-char limit.",
+            meta={"total_chars": total_chars, "max_chars": self.max_chars},
+        )

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/__init__.py
@@ -1,4 +1,5 @@
 from .block_text import BlockTextOutputGuard
+from .length_guard import OutputLengthGuard
 from .pii_redact import PIIRedactOutputGuard
 
-__all__ = ["BlockTextOutputGuard", "PIIRedactOutputGuard"]
+__all__ = ["BlockTextOutputGuard", "OutputLengthGuard", "PIIRedactOutputGuard"]

--- a/packages/railtracks/src/railtracks/guardrails/llm/output/length_guard.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/output/length_guard.py
@@ -1,0 +1,52 @@
+"""Output length guardrail — blocks LLM responses that exceed a character limit."""
+
+from __future__ import annotations
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.core.interfaces import OutputGuard
+
+
+class OutputLengthGuard(OutputGuard):
+    """Blocks LLM output that exceeds ``max_chars`` characters.
+
+    Inspects ``event.output_message`` (the assistant reply produced this turn).
+
+    Example::
+
+        guard = OutputLengthGuard(max_chars=2000)
+
+    Args:
+        max_chars: Maximum number of characters allowed in the assistant reply.
+            Defaults to ``2048``.
+        name: Optional display name for the guardrail instance.
+    """
+
+    def __init__(self, max_chars: int = 2048, name: str | None = None) -> None:
+        super().__init__(name=name)
+        if max_chars <= 0:
+            raise ValueError(f"max_chars must be a positive integer, got {max_chars!r}")
+        self.max_chars = max_chars
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        if event.output_message is None:
+            return GuardrailDecision.allow(reason="No output message to evaluate.")
+
+        content = event.output_message.content or ""
+        total_chars = len(content)
+        if total_chars > self.max_chars:
+            return GuardrailDecision.block(
+                reason=(
+                    f"Output length {total_chars} characters exceeds the maximum of "
+                    f"{self.max_chars} characters."
+                ),
+                user_facing_message=(
+                    "The response was too long and has been blocked. "
+                    "Please try a more specific question."
+                ),
+                meta={"total_chars": total_chars, "max_chars": self.max_chars},
+            )
+        return GuardrailDecision.allow(
+            reason=f"Output length {total_chars} chars is within the {self.max_chars}-char limit.",
+            meta={"total_chars": total_chars, "max_chars": self.max_chars},
+        )

--- a/packages/railtracks/tests/unit_tests/guardrails/test_length_guards.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_length_guards.py
@@ -1,0 +1,160 @@
+"""Unit tests for InputLengthGuard and OutputLengthGuard."""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.core.decision import GuardrailAction
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm.input import InputLengthGuard
+from railtracks.guardrails.llm.output import OutputLengthGuard
+from railtracks.llm import MessageHistory, UserMessage
+from railtracks.llm.message import AssistantMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _input_event(text: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.INPUT,
+        messages=MessageHistory([UserMessage(text)]),
+    )
+
+
+def _output_event(text: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.OUTPUT,
+        messages=MessageHistory([UserMessage("prompt")]),
+        output_message=AssistantMessage(text),
+    )
+
+
+# ---------------------------------------------------------------------------
+# InputLengthGuard
+# ---------------------------------------------------------------------------
+
+class TestInputLengthGuard:
+    def test_default_max_chars(self):
+        guard = InputLengthGuard()
+        assert guard.max_chars == 4096
+
+    def test_custom_max_chars(self):
+        guard = InputLengthGuard(max_chars=100)
+        assert guard.max_chars == 100
+
+    def test_invalid_max_chars_raises(self):
+        with pytest.raises(ValueError, match="max_chars"):
+            InputLengthGuard(max_chars=0)
+        with pytest.raises(ValueError, match="max_chars"):
+            InputLengthGuard(max_chars=-10)
+
+    def test_allows_short_input(self):
+        guard = InputLengthGuard(max_chars=50)
+        event = _input_event("hello")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+        assert decision.meta["total_chars"] == 5
+
+    def test_blocks_long_input(self):
+        guard = InputLengthGuard(max_chars=10)
+        event = _input_event("this is definitely longer than ten characters")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+        assert decision.meta["max_chars"] == 10
+        assert decision.user_facing_message is not None
+
+    def test_exact_limit_is_allowed(self):
+        guard = InputLengthGuard(max_chars=5)
+        event = _input_event("hello")  # exactly 5 chars
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_one_over_limit_is_blocked(self):
+        guard = InputLengthGuard(max_chars=5)
+        event = _input_event("hello!")  # 6 chars
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_meta_contains_expected_keys(self):
+        guard = InputLengthGuard(max_chars=100)
+        event = _input_event("hi")
+        decision = guard(event)
+        assert "total_chars" in decision.meta
+        assert "max_chars" in decision.meta
+
+    def test_custom_name(self):
+        guard = InputLengthGuard(max_chars=100, name="my-input-guard")
+        assert guard.name == "my-input-guard"
+
+    def test_default_name_is_class_name(self):
+        guard = InputLengthGuard()
+        assert guard.name == "InputLengthGuard"
+
+    def test_phase_is_input(self):
+        from railtracks.guardrails.core.event import LLMGuardrailPhase
+        guard = InputLengthGuard()
+        assert guard.phase == LLMGuardrailPhase.INPUT
+
+
+# ---------------------------------------------------------------------------
+# OutputLengthGuard
+# ---------------------------------------------------------------------------
+
+class TestOutputLengthGuard:
+    def test_default_max_chars(self):
+        guard = OutputLengthGuard()
+        assert guard.max_chars == 2048
+
+    def test_custom_max_chars(self):
+        guard = OutputLengthGuard(max_chars=200)
+        assert guard.max_chars == 200
+
+    def test_invalid_max_chars_raises(self):
+        with pytest.raises(ValueError, match="max_chars"):
+            OutputLengthGuard(max_chars=0)
+
+    def test_allows_short_output(self):
+        guard = OutputLengthGuard(max_chars=100)
+        event = _output_event("short reply")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_blocks_long_output(self):
+        guard = OutputLengthGuard(max_chars=10)
+        event = _output_event("this reply is way too long for the limit")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+        assert decision.meta["max_chars"] == 10
+
+    def test_allows_when_no_output_message(self):
+        guard = OutputLengthGuard(max_chars=10)
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([UserMessage("prompt")]),
+            output_message=None,
+        )
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_exact_limit_is_allowed(self):
+        guard = OutputLengthGuard(max_chars=5)
+        event = _output_event("hello")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_one_over_limit_is_blocked(self):
+        guard = OutputLengthGuard(max_chars=5)
+        event = _output_event("hello!")
+        decision = guard(event)
+        assert decision.action == GuardrailAction.BLOCK
+
+    def test_phase_is_output(self):
+        from railtracks.guardrails.core.event import LLMGuardrailPhase
+        guard = OutputLengthGuard()
+        assert guard.phase == LLMGuardrailPhase.OUTPUT
+
+    def test_custom_name(self):
+        guard = OutputLengthGuard(max_chars=100, name="my-output-guard")
+        assert guard.name == "my-output-guard"


### PR DESCRIPTION
Implements #1053 - character-based length guardrails for LLM input and output.

- InputLengthGuard: blocks requests where total message history exceeds max_chars
- OutputLengthGuard: blocks responses where assistant reply exceeds max_chars
- Both default to sane limits (4096 input / 2048 output)
- Raise ValueError on non-positive max_chars
- Include meta dict with total_chars and max_chars for observability
- Expose both guards at railtracks.guardrails.llm.* for easy import
- Unit tests covering allow/block boundary, edge cases, custom names

Please note this PR is handling the merge conflicts of #1054 and the work is credited to https://github.com/vibeyclaw
