### PR TITLE
feat: add HuggingFaceDatasetLoader for streaming HF datasets

### DIFF
--- a/docs/rag/components/ingestion/huggingface.md
+++ b/docs/rag/components/ingestion/huggingface.md
@@ -1,0 +1,110 @@
+# Hugging Face Datasets
+
+`HuggingFaceDatasetLoader` streams rows from any [Hugging Face Hub](https://huggingface.co/datasets) dataset and converts each row into a [`Document`](overview.md#the-document-object). Rows are fetched lazily, so this works on datasets that would never fit in memory. It requires the optional `huggingface` extra:
+
+```bash
+pip install "railtracks[huggingface]"
+```
+
+```python
+from railtracks.retrieval.loaders.huggingface_loader import HuggingFaceDatasetLoader
+```
+
+---
+
+## Basic Usage
+
+```python
+loader = HuggingFaceDatasetLoader(
+    dataset_name="ag_news",
+    split="test",
+    content_columns=["text"],
+)
+
+async for doc in loader.astream():
+    print(doc.content[:80])
+    print(doc.source)    # "ag_news/test"
+    print(doc.metadata)  # {"row_index": 0}
+```
+
+Each row of the chosen split becomes one `Document`. Use `astream()` for large datasets — `aload()` and `load()` collect everything into memory and should only be used on small splits.
+
+---
+
+## Joining Multiple Columns into Content
+
+Many datasets store the "text" across several columns (question + context, title + body, etc.). Pass them all to `content_columns` and they'll be joined by `content_separator`:
+
+```python
+loader = HuggingFaceDatasetLoader(
+    dataset_name="squad",
+    split="validation",
+    content_columns=["question", "context"],
+    content_separator="\n\n",
+)
+
+# doc.content == "What is RAG?\n\nRetrieval-augmented generation..."
+```
+
+---
+
+## Forwarding Metadata Columns
+
+Columns listed in `metadata_columns` are copied into `Document.metadata` as-is — handy for filtering or citation:
+
+```python
+loader = HuggingFaceDatasetLoader(
+    dataset_name="squad",
+    split="validation",
+    content_columns=["question", "context"],
+    metadata_columns=["title", "id"],
+)
+
+# doc.metadata == {"title": "...", "id": "...", "row_index": 0}
+```
+
+Anything not in `content_columns` or `metadata_columns` is dropped.
+
+---
+
+## Subsets, Revisions, and Auth
+
+Many HF datasets have multiple configurations (subsets). Pass extra keyword arguments via `dataset_kwargs` — they're forwarded straight to `datasets.load_dataset`:
+
+```python
+loader = HuggingFaceDatasetLoader(
+    dataset_name="ms_marco",
+    split="validation",
+    content_columns=["query", "passages"],
+    dataset_kwargs={"name": "v2.1"},          # subset selector
+)
+```
+
+For gated datasets, set `HF_TOKEN` in your environment or pass `dataset_kwargs={"token": "hf_xxxxxxx"}`.
+
+!!! tip
+    Streaming mode is enabled by default. To disable it (e.g. for a small dataset you want fully cached locally), pass `dataset_kwargs={"streaming": False}`.
+
+---
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dataset_name` | `str` | — | Dataset name on the Hugging Face Hub (e.g. `"squad"`). |
+| `split` | `str` | — | Which split to stream (`"train"`, `"validation"`, etc.). |
+| `content_columns` | `list[str]` | — | Columns joined into `Document.content`. Must be non-empty. |
+| `metadata_columns` | `list[str] \| None` | `None` | Columns to copy into `Document.metadata`. |
+| `content_separator` | `str` | `"\n"` | Separator used to join `content_columns` values. |
+| `dataset_kwargs` | `dict \| None` | `None` | Forwarded to `datasets.load_dataset` (subset name, revision, token, etc.). |
+
+---
+
+## Document Metadata
+
+| Key | Value |
+|-----|-------|
+| `row_index` | Zero-based row position within the split |
+| *(metadata_columns)* | Any column listed in `metadata_columns` |
+
+`Document.source` is set to `"{dataset_name}/{split}"`, and `Document.type` is `DocumentType.TEXT`.

--- a/docs/rag/components/ingestion/overview.md
+++ b/docs/rag/components/ingestion/overview.md
@@ -30,6 +30,7 @@ class Document:
 | `HTMLLoader`  | HTML files & URLs | `pip install "railtracks[html]"` |
 | `CodeLoader`  | Source code files | No |
 | `JSONLoader`  | `.json` files & directories | No |
+| `HuggingFaceDatasetLoader` | Hugging Face Hub datasets (streaming) | `pip install "railtracks[huggingface]"` |
 | `LangChainLoaderAdapter` | Any LangChain loader | Depends on wrapped loader |
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
           - Text and Markdown: rag/components/ingestion/text_markdown.md
           - CSV: rag/components/ingestion/csv.md
           - PDFs: rag/components/ingestion/pdfs.md
+          - Hugging Face Datasets: rag/components/ingestion/huggingface.md
           - Custom Ingestors: rag/components/ingestion/custom.md
       - Chunking:
           - Overview: rag/components/chunking/overview.md

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -65,7 +65,7 @@ chat = ["railtracks[visual]"]
 # For each Integration package dependencies go here.
 rag = ["tiktoken>=0.10.0, <=0.12.0"]
 pdf = ["pypdf >= 4.0.0, <= 6.10.2"]
-huggingface = ["datasets >= 2.14.0"]
+huggingface = ["datasets >= 2.14.0, <= 4.8.5"]
 chroma = [
     "chromadb > 1.3.0",
     "pdfplumber >= 0.10.1"

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -65,6 +65,7 @@ chat = ["railtracks[visual]"]
 # For each Integration package dependencies go here.
 rag = ["tiktoken>=0.10.0, <=0.12.0"]
 pdf = ["pypdf >= 4.0.0, <= 6.10.2"]
+huggingface = ["datasets >= 2.14.0"]
 chroma = [
     "chromadb > 1.3.0",
     "pdfplumber >= 0.10.1"

--- a/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
@@ -52,7 +52,8 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
 
     Raises:
         ValueError: If `content_columns` is empty, or if any name in
-            `content_columns` isn't present in the dataset schema.
+            `content_columns` or `metadata_columns` isn't present in the
+            dataset schema.
     """
 
     def __init__(
@@ -84,8 +85,8 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
             Document: The next row as a document.
 
         Raises:
-            ValueError: If a column in `content_columns` isn't present in
-                the dataset schema.
+            ValueError: If a column in `content_columns` or
+                `metadata_columns` isn't present in the dataset schema.
         """
         kwargs = dict(self._dataset_kwargs)
         kwargs.setdefault("streaming", True)
@@ -104,19 +105,22 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                 return
 
             if not validated:
-                missing = [c for c in self._content_columns if c not in row]
-                if missing:
+                missing_content = [c for c in self._content_columns if c not in row]
+                missing_metadata = [c for c in self._metadata_columns if c not in row]
+                if missing_content:
                     raise ValueError(
-                        f"content_columns not found in dataset schema: {missing}"
+                        f"content_columns not found in dataset schema: {missing_content}"
+                    )
+                if missing_metadata:
+                    raise ValueError(
+                        f"metadata_columns not found in dataset schema: {missing_metadata}"
                     )
                 validated = True
 
             content = self._content_separator.join(
                 str(row[col]) for col in self._content_columns
             )
-            metadata: dict[str, Any] = {
-                col: row[col] for col in self._metadata_columns if col in row
-            }
+            metadata: dict[str, Any] = {col: row[col] for col in self._metadata_columns}
             metadata["row_index"] = row_index
 
             yield Document(

--- a/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from railtracks.retrieval.loaders.base import BaseDocumentLoader
+from railtracks.retrieval.models import Document, DocumentType
+
+try:
+    from datasets import load_dataset
+except ImportError as exc:
+    raise ImportError(
+        "datasets is required for HuggingFaceDatasetLoader. "
+        'Install it with: pip install "railtracks[huggingface]"'
+    ) from exc
+
+
+# asyncio.to_thread can't surface StopIteration across the thread boundary, so we use a sentinel default and stop when next() returns it.
+_SENTINEL: object = object()
+
+
+class HuggingFaceDatasetLoader(BaseDocumentLoader):
+    """Loads a Hugging Face dataset as Document objects.
+
+    Each row of the chosen split becomes one Document. Rows are pulled from the Hub one at a time in streaming mode, so this works fine on datasets that wouldn't fit in memory (`wiki_dpr`, `c4`, etc.).
+
+    Column handling:
+
+    - `content_columns`: values are joined by `content_separator` to form
+      `Document.content`. Required.
+    - `metadata_columns`: copied into `Document.metadata` as-is.
+    - `row_index` is added to metadata automatically (0-based position
+      within the split).
+    - `Document.source` is set to `"{dataset_name}/{split}"`.
+
+    Args:
+        dataset_name: Dataset name on the Hugging Face Hub
+            (e.g. `"squad"`, `"ms_marco"`).
+        split: Which split to stream (`"train"`, `"validation"`, etc.).
+        content_columns: Columns whose values get joined into
+            `Document.content`.
+        metadata_columns: Columns to copy into `Document.metadata`.
+            Default : None.
+        content_separator: Separator used to join `content_columns`
+            values. Default: `"\\n"`.
+        dataset_kwargs: Extra keyword arguments forwarded to
+            `datasets.load_dataset`. Use this for subset selection
+            (`{"name": "v2.1"}`), pinning a revision, or passing an
+            auth token. `streaming=True` is set by default and can be
+            overridden here.
+
+    Raises:
+        ValueError: If `content_columns` is empty, or if any name in
+            `content_columns` isn't present in the dataset schema.
+    """
+
+    def __init__(
+        self,
+        dataset_name: str,
+        split: str,
+        content_columns: list[str],
+        metadata_columns: list[str] | None = None,
+        content_separator: str = "\n",
+        dataset_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if not content_columns:
+            raise ValueError("content_columns must be a non-empty list of column names")
+        self._dataset_name = dataset_name
+        self._split = split
+        self._content_columns = list(content_columns)
+        self._metadata_columns = list(metadata_columns or [])
+        self._content_separator = content_separator
+        self._dataset_kwargs = dict(dataset_kwargs or {})
+
+    async def astream(self) -> AsyncGenerator[Document, None]:
+        """Yield one `Document` per row, pulled lazily from the Hub.
+
+        Schema validation runs on the first row instead of upfront — some
+        streaming datasets don't expose their `features` ahead of time, so
+        peeking at the first row is the only reliable check.
+
+        Yields:
+            Document: The next row as a document.
+
+        Raises:
+            ValueError: If a column in `content_columns` isn't present in
+                the dataset schema.
+        """
+        kwargs = dict(self._dataset_kwargs)
+        kwargs.setdefault("streaming", True)
+        kwargs["split"] = self._split
+
+        dataset = await asyncio.to_thread(load_dataset, self._dataset_name, **kwargs)
+
+        iterator = iter(dataset)
+        source = f"{self._dataset_name}/{self._split}"
+        validated = False
+        row_index = 0
+
+        while True:
+            row = await asyncio.to_thread(next, iterator, _SENTINEL)
+            if row is _SENTINEL:
+                return
+
+            if not validated:
+                missing = [c for c in self._content_columns if c not in row]
+                if missing:
+                    raise ValueError(
+                        f"content_columns not found in dataset schema: {missing}"
+                    )
+                validated = True
+
+            content = self._content_separator.join(
+                str(row[col]) for col in self._content_columns
+            )
+            metadata: dict[str, Any] = {
+                col: row[col] for col in self._metadata_columns if col in row
+            }
+            metadata["row_index"] = row_index
+
+            yield Document(
+                content=content,
+                type=DocumentType.TEXT,
+                source=source,
+                metadata=metadata,
+            )
+            row_index += 1

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
@@ -144,6 +144,20 @@ class TestHuggingFaceLoaderValidation:
         ):
             await loader.aload()
 
+    async def test_unknown_metadata_column_raises_value_error(
+        self, mock_load_dataset
+    ):
+        loader = HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            metadata_columns=["does_not_exist"],
+        )
+        with pytest.raises(
+            ValueError, match="metadata_columns not found in dataset schema"
+        ):
+            await loader.aload()
+
 
 class TestHuggingFaceLoaderStreaming:
     """Laziness guarantees and ``load_dataset`` call shape."""

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from railtracks.retrieval.loaders.huggingface_loader import (
+    HuggingFaceDatasetLoader,
+)
+from railtracks.retrieval.models import DocumentType
+
+
+class _FakeIterableDataset:
+    """Stand-in for ``datasets.IterableDataset``.
+
+    HF streaming datasets are iterable and produce one ``dict`` per row.
+    Tracking ``consumed`` lets us prove the loader pulls rows lazily.
+    """
+
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+        self.consumed: list[dict] = []
+
+    def __iter__(self):
+        for row in self._rows:
+            self.consumed.append(row)
+            yield row
+
+
+@pytest.fixture
+def fake_rows() -> list[dict]:
+    return [
+        {"query": "what is rag", "passage": "Retrieval-augmented generation.", "label": 1, "topic": "ml"},
+        {"query": "what is bm25", "passage": "BM25 is a ranking function.", "label": 0, "topic": "ir"},
+        {"query": "what is dpr", "passage": "Dense passage retrieval.", "label": 1, "topic": "ir"},
+    ]
+
+
+@pytest.fixture
+def fake_dataset(fake_rows):
+    return _FakeIterableDataset(fake_rows)
+
+
+@pytest.fixture
+def mock_load_dataset(fake_dataset):
+    with patch(
+        "railtracks.retrieval.loaders.huggingface_loader.load_dataset",
+        return_value=fake_dataset,
+    ) as m:
+        yield m
+
+
+class TestHuggingFaceLoaderBasic:
+    """Core happy-path behaviour."""
+
+    async def test_yields_one_document_per_row(self, mock_load_dataset, fake_rows):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert len(docs) == len(fake_rows)
+
+    async def test_document_type_is_text(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert all(d.type == DocumentType.TEXT for d in docs)
+
+    async def test_source_is_dataset_name_and_split(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="validation", content_columns=["query"]
+        ).aload()
+        assert all(d.source == "fake/ds/validation" for d in docs)
+
+    async def test_row_index_in_metadata(self, mock_load_dataset, fake_rows):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert [d.metadata["row_index"] for d in docs] == list(range(len(fake_rows)))
+
+
+class TestHuggingFaceLoaderContentColumns:
+    """``content_columns`` joining + separator behaviour."""
+
+    async def test_single_content_column(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert docs[0].content == "what is rag"
+
+    async def test_multiple_content_columns_joined_with_separator(
+        self, mock_load_dataset
+    ):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query", "passage"],
+            content_separator=" | ",
+        ).aload()
+        assert docs[0].content == "what is rag | Retrieval-augmented generation."
+
+    async def test_non_string_values_are_stringified(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["label"]
+        ).aload()
+        assert docs[0].content == "1"
+
+
+class TestHuggingFaceLoaderMetadataColumns:
+    """``metadata_columns`` forwarding."""
+
+    async def test_metadata_columns_forwarded(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            metadata_columns=["label", "topic"],
+        ).aload()
+        assert docs[0].metadata["label"] == 1
+        assert docs[0].metadata["topic"] == "ml"
+
+    async def test_metadata_columns_default_to_only_row_index(
+        self, mock_load_dataset
+    ):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert set(docs[0].metadata.keys()) == {"row_index"}
+
+
+class TestHuggingFaceLoaderValidation:
+    """Schema-validation and constructor guards."""
+
+    def test_empty_content_columns_raises_in_constructor(self):
+        with pytest.raises(ValueError, match="content_columns must be a non-empty"):
+            HuggingFaceDatasetLoader("fake/ds", split="train", content_columns=[])
+
+    async def test_unknown_content_column_raises_value_error(
+        self, mock_load_dataset
+    ):
+        loader = HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["does_not_exist"]
+        )
+        with pytest.raises(
+            ValueError, match="content_columns not found in dataset schema"
+        ):
+            await loader.aload()
+
+
+class TestHuggingFaceLoaderStreaming:
+    """Laziness guarantees and ``load_dataset`` call shape."""
+
+    async def test_astream_pulls_one_row_at_a_time(
+        self, mock_load_dataset, fake_dataset
+    ):
+        loader = HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        )
+        gen = loader.astream()
+        try:
+            await gen.__anext__()
+            assert len(fake_dataset.consumed) == 1
+            await gen.__anext__()
+            assert len(fake_dataset.consumed) == 2
+        finally:
+            await gen.aclose()
+
+    async def test_streaming_enabled_by_default(self, mock_load_dataset):
+        await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        _, kwargs = mock_load_dataset.call_args
+        assert kwargs["streaming"] is True
+        assert kwargs["split"] == "train"
+
+    async def test_dataset_kwargs_forwarded(self, mock_load_dataset):
+        await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            dataset_kwargs={"name": "v2.1", "revision": "abc"},
+        ).aload()
+        _, kwargs = mock_load_dataset.call_args
+        assert kwargs["name"] == "v2.1"
+        assert kwargs["revision"] == "abc"
+
+    async def test_dataset_kwargs_can_override_streaming(self, mock_load_dataset):
+        await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            dataset_kwargs={"streaming": False},
+        ).aload()
+        _, kwargs = mock_load_dataset.call_args
+        assert kwargs["streaming"] is False
+
+
+class TestHuggingFaceLoaderSyncWrapper:
+    """``.load()`` blocking wrapper inherited from ``BaseDocumentLoader``."""
+
+    def test_load_returns_same_documents_as_aload(self, mock_load_dataset, fake_rows):
+        docs = HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).load()
+        assert len(docs) == len(fake_rows)
+        assert docs[0].metadata["row_index"] == 0


### PR DESCRIPTION
## Summary

Adds `HuggingFaceDatasetLoader`, a streaming document loader that wraps `datasets.load_dataset` in streaming mode and yields one `Document` per row through the existing `BaseDocumentLoader.astream()` contract. Unlocks hundreds of HF Hub datasets (squad, ms_marco, trivia_qa, wiki_dpr, c4, …) for the RAG ingestion pipeline without per-dataset code.

Adds a new optional extra: `huggingface = ["datasets >= 2.14.0"]`.

Closes #1092


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`): 16 new tests, full loaders suite 98/98 green
- [x] Docs updated; new page `docs/rag/components/ingestion/huggingface.md`, overview table row, mkdocs nav entry
- [x] Breaking changes include migration notes; N/A, adds new public name + new optional extra only; no existing exports or behaviour changed

## Notes

### Acceptance criteria

- [x] Extends `BaseDocumentLoader`
- [x] Constructor accepts `dataset_name`, `split`, `content_columns: list[str]`, optional `metadata_columns` and `dataset_kwargs`
- [x] `astream()` is truly lazy — verified by a test that confirms only one row is consumed per `__anext__` call (no full-dataset buffering)
- [x] Each row yields a `Document` with `source = "{dataset_name}/{split}"` and metadata populated from `metadata_columns` + `row_index`
- [x] Raises `ValueError` if any `content_columns` are not present in the dataset schema
- [x] Unit tests use a mocked `IterableDataset` — no network calls during the test suite

### Basic usage

```python
from railtracks.retrieval.loaders.huggingface_loader import HuggingFaceDatasetLoader

loader = HuggingFaceDatasetLoader(
    dataset_name="squad",
    split="validation",
    content_columns=["question", "context"],
    metadata_columns=["title", "id"],
    content_separator="\n\n",
)

# Rows are streamed lazily from the Hub — one at a time
async for doc in loader.astream():
    # doc.source   == "squad/validation"
    # doc.content  == "<question>\n\n<context>"
    # doc.metadata == {"title": "...", "id": "...", "row_index": N}
    ...
For datasets with subsets, pinned revisions, or auth tokens, forward via dataset_kwargs:


HuggingFaceDatasetLoader(..., dataset_kwargs={"name": "v2.1", "revision": "abc"})
streaming=True is set by default and can be overridden through the same dict.

