### PR TITLE
fix: update stale README links to docs.railtracks.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ result = await rt.call(agent, query)
 
 Railtracks includes a visualizer for inspecting agent runs and evaluations in real-time, run completely locally with no signups required.
 
-See the [Observability documentation](https://railtownai.github.io/railtracks/observability/visualization/) for setup and usage.
+See the [Observability documentation](https://docs.railtracks.org/observability/agenthub/local/) for setup and usage.
 
 </td>
 </tr>
@@ -184,14 +184,14 @@ rt.llm.AnthropicLLM("claude-4-6-sonnet")
 rt.llm.OllamaLLM("llama3")
 ```
 
-Works with **OpenAI**, **Anthropic**, **Google**, **Azure**, and more. See the [full provider list](https://railtownai.github.io/railtracks/llm_support/providers/).
+Works with **OpenAI**, **Anthropic**, **Google**, **Azure**, and more. See the [full provider list](https://docs.railtracks.org/integrations/llms/providers/).
 
 ## Contributing
 
 Railtracks is developed in the open. Contributions, bug reports, and feature requests are welcome via [GitHub Issues](https://github.com/RailtownAI/railtracks/issues).
 
 <p align="center">
-  <a href="https://railtownai.github.io/railtracks/quickstart/quickstart/">
+  <a href="https://docs.railtracks.org/documentation/getting_started/quickstart/">
     <img src="https://img.shields.io/badge/Quick_Start-4285F4?style=for-the-badge&logo=rocket&logoColor=white" alt="Quick Start" />
   </a>
   <a href="https://docs.railtracks.org/">


### PR DESCRIPTION
## Summary

- Fixes dead link reported in #1107 (`observability/visualization/` → `observability/agenthub/local/`)
- Updates two additional stale `railtownai.github.io` links found during README audit, with corrected paths reflecting the current docs structure:
  - `llm_support/providers/` → `integrations/llms/providers/`
  - `quickstart/quickstart/` → `documentation/getting_started/quickstart/`

## Test plan

- [ ] Verify all three links resolve correctly on `docs.railtracks.org`

Closes #1107