### PR TITLE
fix: move LLMError into the llm package (#1096)

### DIFF
--- a/docs/scripts/error_handling.py
+++ b/docs/scripts/error_handling.py
@@ -11,7 +11,8 @@ def critical_function():
 # --8<-- [end: fatal_error]
 
 # --8<-- [start: simple_handling]
-from railtracks.exceptions import NodeInvocationError, LLMError
+from railtracks.exceptions import NodeInvocationError
+from railtracks.llm import LLMError
 import logging
 
 logger = logging.getLogger(__name__)
@@ -36,9 +37,10 @@ except LLMError as e:
 
 # --8<-- [start: comprehensive_handling]
 from railtracks.exceptions import (
-    NodeCreationError, NodeInvocationError, 
-    LLMError, GlobalTimeOutError, ContextError, FatalError
+    NodeCreationError, NodeInvocationError,
+    GlobalTimeOutError, ContextError, FatalError
 )
+from railtracks.llm import LLMError
 
 try:
     # Setup phase

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
@@ -15,7 +15,7 @@ from typing import (
 from pydantic import BaseModel
 from typing_extensions import Self
 
-from railtracks.exceptions.errors import LLMError, NodeInvocationError
+from railtracks.exceptions.errors import NodeInvocationError
 from railtracks.exceptions.messages.exception_messages import get_message
 from railtracks.llm import (
     Message,
@@ -26,6 +26,7 @@ from railtracks.llm import (
     SystemMessage,
     UserMessage,
 )
+from railtracks.llm.errors import LLMError
 from railtracks.llm.response import Response
 from railtracks.nodes.nodes import Node
 from railtracks.prompts.prompt import inject_context

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from railtracks.built_nodes.concrete.response import LLMResponse
-from railtracks.exceptions import LLMError, NodeCreationError
+from railtracks.exceptions import NodeCreationError
 from railtracks.interaction._call import call
 from railtracks.llm import (
     AssistantMessage,
@@ -28,6 +28,7 @@ from railtracks.llm import (
     UserMessage,
 )
 from railtracks.llm.content import Content
+from railtracks.llm.errors import LLMError
 from railtracks.llm.message import Role
 from railtracks.llm.providers import ModelProvider
 from railtracks.llm.response import Response

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/chat_tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/chat_tool_call_llm.py
@@ -1,7 +1,6 @@
 import asyncio
 from abc import ABC
 
-from railtracks.exceptions import LLMError
 from railtracks.interaction import call
 from railtracks.llm import (
     AssistantMessage,
@@ -10,6 +9,7 @@ from railtracks.llm import (
     ToolResponse,
     UserMessage,
 )
+from railtracks.llm.errors import LLMError
 from railtracks.llm.message import Role
 
 from ._llm_base import StringOutputMixIn

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
@@ -4,8 +4,8 @@ from typing import Generator, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
 
-from railtracks.exceptions.errors import LLMError
 from railtracks.llm import Message, MessageHistory, ModelBase, UserMessage
+from railtracks.llm.errors import LLMError
 from railtracks.validation.node_creation.validation import (
     check_classmethod,
     check_schema,

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
@@ -3,7 +3,6 @@ from typing import Any, ClassVar, Generic, Literal, Type, TypeVar, cast
 
 from pydantic import BaseModel
 
-from railtracks.exceptions.errors import LLMError
 from railtracks.interaction import call
 from railtracks.llm import (
     AssistantMessage,
@@ -12,6 +11,7 @@ from railtracks.llm import (
     ModelBase,
     UserMessage,
 )
+from railtracks.llm.errors import LLMError
 
 from ._llm_base import StructuredOutputMixIn
 from ._tool_call_base import OutputLessToolCallLLM

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
@@ -4,7 +4,7 @@ import asyncio
 from abc import ABC
 from typing import Generator, Generic, Literal, TypeVar
 
-from railtracks.exceptions import LLMError
+from railtracks.llm.errors import LLMError
 from railtracks.llm.response import Response
 
 from ._llm_base import LLMBase, StringOutputMixIn

--- a/packages/railtracks/src/railtracks/exceptions/__init__.py
+++ b/packages/railtracks/src/railtracks/exceptions/__init__.py
@@ -2,7 +2,6 @@ from .errors import (
     ContextError,
     FatalError,
     GlobalTimeOutError,
-    LLMError,
     NodeCreationError,
     NodeInvocationError,
 )
@@ -13,7 +12,6 @@ __all__ = [
     "NodeCreationError",
     "NodeInvocationError",
     "GlobalTimeOutError",
-    "LLMError",
     "ContextError",
     "VisualExtraRequiredError",
 ]

--- a/packages/railtracks/src/railtracks/exceptions/errors.py
+++ b/packages/railtracks/src/railtracks/exceptions/errors.py
@@ -1,9 +1,4 @@
-from typing import TYPE_CHECKING
-
 from ._base import RTError
-
-if TYPE_CHECKING:
-    from railtracks.llm.history import MessageHistory
 
 
 class NodeInvocationError(RTError):
@@ -50,44 +45,6 @@ class NodeCreationError(RTError):
                 "\n"
                 + self._color("Tips to debug:\n", self.GREEN)
                 + "\n".join(self._color(f"- {note}", self.GREEN) for note in self.notes)
-            )
-            return f"\n{self._color(base, self.RED)}{notes_str}"
-        return self._color(base, self.RED)
-
-
-class LLMError(RTError):
-    """
-    Raised when an error occurs during LLM invocation or completion.
-    """
-
-    def __init__(
-        self,
-        reason: str,
-        message_history: "MessageHistory" = None,
-    ):
-        self.reason = reason
-        self.message_history = message_history
-
-        message = f"{self._color('LLM Error: ', self.BOLD_RED)}{self._color(reason, self.RED)}"
-        super().__init__(message)
-
-    def __str__(self):
-        base = super().__str__()
-        details = []
-        if self.message_history:
-            mh_str = str(self.message_history)
-            indented_mh = "\n".join(
-                "    " + line for line in mh_str.splitlines()
-            )  # 2 indents (2-spaces) per indent
-            details.append(
-                self._color("Message History:\n", self.BOLD_GREEN)
-                + self._color(indented_mh, self.GREEN)
-            )
-        if details:
-            notes_str = (
-                "\n"
-                + self._color("Details:\n", self.BOLD_GREEN)
-                + "\n".join(f"  {d}" for d in details)
             )
             return f"\n{self._color(base, self.RED)}{notes_str}"
         return self._color(base, self.RED)

--- a/packages/railtracks/src/railtracks/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/llm/__init__.py
@@ -1,5 +1,6 @@
 from . import retries
 from .content import ToolCall, ToolResponse
+from .errors import LLMError
 from .history import MessageHistory
 from .message import AssistantMessage, Message, SystemMessage, ToolMessage, UserMessage
 from .model import ModelBase
@@ -27,6 +28,7 @@ from .tools import (
 
 __all__ = [
     "ModelBase",
+    "LLMError",
     "ToolCall",
     "ToolResponse",
     "UserMessage",

--- a/packages/railtracks/src/railtracks/llm/errors.py
+++ b/packages/railtracks/src/railtracks/llm/errors.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._exceptions import RTLLMError
+
+if TYPE_CHECKING:
+    from .history import MessageHistory
+
+
+class LLMError(RTLLMError):
+    """
+    Raised when an error occurs during LLM invocation or completion.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        message_history: "MessageHistory" = None,
+    ):
+        self.reason = reason
+        self.message_history = message_history
+
+        message = f"{self._color('LLM Error: ', self.BOLD_RED)}{self._color(reason, self.RED)}"
+        super().__init__(message)
+
+    def __str__(self):
+        base = super().__str__()
+        details = []
+        if self.message_history:
+            mh_str = str(self.message_history)
+            indented_mh = "\n".join(
+                "    " + line for line in mh_str.splitlines()
+            )  # 2 indents (2-spaces) per indent
+            details.append(
+                self._color("Message History:\n", self.BOLD_GREEN)
+                + self._color(indented_mh, self.GREEN)
+            )
+        if details:
+            notes_str = (
+                "\n"
+                + self._color("Details:\n", self.BOLD_GREEN)
+                + "\n".join(f"  {d}" for d in details)
+            )
+            return f"\n{self._color(base, self.RED)}{notes_str}"
+        return self._color(base, self.RED)

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -26,8 +26,8 @@ from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 from litellm.types.utils import ModelResponse
 from pydantic import BaseModel, Field
 
-from ...exceptions.errors import LLMError, NodeInvocationError
 from ..content import ToolCall
+from ..errors import LLMError
 from ..history import MessageHistory
 from ..message import AssistantMessage, Message, ToolMessage, UserMessage
 from ..model import ModelBase
@@ -35,6 +35,7 @@ from ..response import MessageInfo, Response
 from ..retries import RetryApproach
 from ..tools import Tool
 from ..tools.parameters import Parameter
+from ._model_exception_base import ModelError
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 
@@ -96,12 +97,8 @@ def _parameters_to_json_schema(
     ):
         return _handle_set_of_parameters(list(parameters))
 
-    raise NodeInvocationError(
-        message=f"Unable to parse Tool.parameters. It was {parameters}",
-        fatal=True,
-        notes=[
-            "Tool.parameters must be a set of Parameter objects",
-        ],
+    raise ModelError(
+        reason=f"Unable to parse Tool.parameters. It was {parameters}. Tool.parameters must be a set of Parameter objects.",
     )
 
 

--- a/packages/railtracks/tests/integration_tests/library/test_retry_agent_node.py
+++ b/packages/railtracks/tests/integration_tests/library/test_retry_agent_node.py
@@ -3,9 +3,8 @@ from unittest.mock import patch
 
 import litellm
 import pytest
-
 import railtracks as rt
-from railtracks.exceptions import LLMError
+from railtracks.llm.errors import LLMError
 from railtracks.llm.retries import ExponentialRetry, FixedRetry
 
 

--- a/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
@@ -1,20 +1,21 @@
+import json
+from json import JSONDecodeError
 from typing import Generator, Literal
 from unittest.mock import patch
+
+import litellm
 import pytest
+from pydantic import BaseModel
+from railtracks.llm import AssistantMessage, UserMessage
+from railtracks.llm.errors import LLMError
 from railtracks.llm.models._litellm_wrapper import (
     LiteLLMWrapper,
     _parameters_to_json_schema,
     _to_litellm_tool,
 )
-from railtracks.exceptions import NodeInvocationError, LLMError
-from railtracks.llm import AssistantMessage, UserMessage
+from railtracks.llm.models._model_exception_base import ModelError
 from railtracks.llm.providers import ModelProvider
-from pydantic import BaseModel
 from railtracks.llm.response import Response
-from json import JSONDecodeError
-import litellm
-from railtracks.llm.content import Stream
-import json
 
 
 class _ConcreteLiteLLMWrapperForTest(LiteLLMWrapper[Literal[False]]):
@@ -54,7 +55,7 @@ class TestHelpers:
         """
         Test _parameters_to_json_schema with invalid input.
         """
-        with pytest.raises(NodeInvocationError):
+        with pytest.raises(ModelError):
             _parameters_to_json_schema(123)  # type: ignore
 
     # =================================== END _parameters_to_json_schema Tests ====================================
@@ -252,9 +253,9 @@ class TestCompletionMethods:
             wrapper = mock_litellm_wrapper(content="Invalid JSON")
             method = getattr(wrapper, method_name)
             if is_async:
-                result = await method(message_history, schema=Schema)
+                await method(message_history, schema=Schema)
             else:
-                result = method(message_history, schema=Schema)
+                method(message_history, schema=Schema)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("method_name,is_async", [
@@ -270,9 +271,9 @@ class TestCompletionMethods:
             wrapper = mock_litellm_wrapper(content='{"field": "VAL", "invalid": "json"}')
             method = getattr(wrapper, method_name)
             if is_async:
-                result = await method(message_history, schema=Schema)
+                await method(message_history, schema=Schema)
             else:
-                result = method(message_history, schema=Schema)
+                method(message_history, schema=Schema)
 
     @pytest.mark.parametrize("method_name,is_async,stream", [
         ("_chat_with_tools", False, False),
@@ -324,7 +325,7 @@ class TestCompletionMethods:
                         assert calls[0]["name"] == "tool_x"
                         assert calls[0]["arguments"] == {"foo": 1}
                         assert calls[0]["identifier"] == "id123"
-                    except Exception as e:
+                    except Exception:
                         pytest.fail("Structured response did not match schema")
                 elif not isinstance(chunk, str):
                     pytest.fail("Stream yielded non-string, non-Response chunk")

--- a/packages/railtracks/tests/unit_tests/nodes/library/tool_calling_llms/test_structured_tool_call_llm.py
+++ b/packages/railtracks/tests/unit_tests/nodes/library/tool_calling_llms/test_structured_tool_call_llm.py
@@ -1,14 +1,14 @@
 import pytest
 import railtracks as rt
 from pydantic import BaseModel, Field
-
-from railtracks.llm.response import Response
-from railtracks.built_nodes.easy_usage_wrappers.helpers import structured_tool_call_llm, structured_llm
-from railtracks.exceptions import NodeCreationError, LLMError
-from railtracks.llm import MessageHistory, SystemMessage, UserMessage, AssistantMessage
-
 from railtracks.built_nodes.concrete import StructuredToolCallLLM
-
+from railtracks.built_nodes.easy_usage_wrappers.helpers import (
+    structured_llm,
+    structured_tool_call_llm,
+)
+from railtracks.exceptions import NodeCreationError
+from railtracks.llm import AssistantMessage, MessageHistory, SystemMessage, UserMessage
+from railtracks.llm.errors import LLMError
 
 # =========================== Basic functionality ==========================
 

--- a/packages/railtracks/tests/unit_tests/test_exceptions.py
+++ b/packages/railtracks/tests/unit_tests/test_exceptions.py
@@ -1,13 +1,13 @@
 import pytest
+from railtracks.exceptions._base import RTError
 from railtracks.exceptions.errors import (
-    NodeInvocationError,
-    NodeCreationError,
-    LLMError,
-    GlobalTimeOutError,
     ContextError,
     FatalError,
+    GlobalTimeOutError,
+    NodeCreationError,
+    NodeInvocationError,
 )
-from railtracks.exceptions._base import RTError
+from railtracks.llm.errors import LLMError
 
 # NOTE: This file contains very basic tests to ensure that the exception classes are working as expected.
 


### PR DESCRIPTION
## Summary

- Moves `LLMError` from `railtracks.exceptions` into `railtracks.llm.errors`, inheriting from `RTLLMError` instead of `RTError`, so the `llm` package no longer imports from `railtracks.exceptions`
- Also removes a secondary violation: `NodeInvocationError` (a railtracks exception) was being raised inside `llm/models/_litellm_wrapper.py`; replaced with `ModelError` from within the llm package
- Updates all consumers (`built_nodes`, tests) to import `LLMError` from `railtracks.llm` or `railtracks.llm.errors`
- Exports `LLMError` from `railtracks.llm.__init__` for discoverability

## Files changed

| File | Change |
|------|--------|
| `llm/errors.py` | New — `LLMError(RTLLMError)` definition |
| `llm/__init__.py` | Export `LLMError` |
| `llm/models/_litellm_wrapper.py` | Import `LLMError` from `..errors`; replace `NodeInvocationError` with `ModelError` |
| `exceptions/errors.py` | Remove `LLMError` class |
| `exceptions/__init__.py` | Remove `LLMError` export |
| 6× `built_nodes/concrete/*.py` | Update imports |
| 3× test files | Update imports; update `NodeInvocationError` → `ModelError` test expectation |

## Test plan

- [x] `test_litellm_wrapper.py` — all tests pass, including the updated `ModelError` expectation for invalid tool parameters
- [x] `test_structured_tool_call_llm.py` — all tests pass
- [x] `test_exceptions.py` — `LLMError` tests pass with new location
- [x] Full unit suite: 1508 passed

Closes #1096