### PR TITLE
[Docs] Fix markdown list rendering in agent design overview

### DIFF
--- a/docs/documentation/agent_design/overview.md
+++ b/docs/documentation/agent_design/overview.md
@@ -3,6 +3,7 @@
 Design and complexity of agent systems scales with the problem domain they are intended to solve. By definition, they can range from a single LLM answering questions all the way to a multi-agent architecture, with tools enabling interactionsf with databases and external services.
 
 At its core, the design is two pronged:
+
 1. Agent Level Design
 2. Agent Interaction Design
 

--- a/docs/documentation/agent_design/overview.md
+++ b/docs/documentation/agent_design/overview.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-Design and complexity of agent systems scales with the problem domain they are intended to solve. By definition, they can range from a single LLM answering questions all the way to a multi-agent architecture, with tools enabling interactionsf with databases and external services.
+Design and complexity of agent systems scales with the problem domain they are intended to solve. By definition, they can range from a single LLM answering questions all the way to a multi-agent architecture, with tools enabling interactions with databases and external services.
 
 At its core, the design is two pronged:
 


### PR DESCRIPTION
part of  #1114.\n\nAdds a paragraph break so the ordered list in the agent design overview renders as separate items instead of collapsing onto one line in markdown renderers.