### PR TITLE
Fix prompt injection with literal braces

### DIFF
--- a/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
+++ b/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
@@ -6,6 +6,34 @@ class KeyOnlyFormatter(string.Formatter):
     A simple formatter which will only use keyword arguments to fill placeholders.
     """
 
+    def vformat(self, format_string, args, kwargs):
+        try:
+            parsed_format = self.parse(format_string)
+            return "".join(
+                self._format_part(
+                    literal_text, field_name, format_spec, conversion, kwargs
+                )
+                for literal_text, field_name, format_spec, conversion in parsed_format
+            )
+        except ValueError:
+            return format_string
+
+    def _format_part(self, literal_text, field_name, format_spec, conversion, kwargs):
+        if field_name is None:
+            return literal_text
+
+        original_placeholder = f"{{{field_name}"
+        if conversion:
+            original_placeholder += f"!{conversion}"
+        if format_spec:
+            original_placeholder += f":{format_spec}"
+        original_placeholder += "}"
+
+        if conversion or format_spec or field_name not in kwargs:
+            return f"{literal_text}{original_placeholder}"
+
+        return f"{literal_text}{kwargs[field_name]}"
+
     def get_value(self, key, args, kwargs):
         try:
             return kwargs[str(key)]

--- a/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
@@ -1,40 +1,68 @@
-import railtracks.llm.prompt_injection_utils as prompt_injection_utils
-from railtracks.llm.prompt_injection_utils import KeyOnlyFormatter, ValueDict
-
+from railtracks.llm import Message, MessageHistory, SystemMessage, UserMessage
 from railtracks.llm.message import Role
+from railtracks.llm.prompt_injection_utils import KeyOnlyFormatter, ValueDict
 from railtracks.utils import prompt_injection
-from railtracks.llm import Message, MessageHistory, UserMessage, SystemMessage
-
 
 # ================= START KeyOnlyFormatter tests ============
+
 
 def test_formatter_uses_only_kwargs():
     f = KeyOnlyFormatter()
     formatted = f.format("Hello, {name}", name="Test")
     assert formatted == "Hello, Test"
 
+
 def test_formatter_missing_key_returns_placeholder():
     f = KeyOnlyFormatter()
     formatted = f.format("Hello, {name}")
     assert formatted == "Hello, {name}"
+
+
+def test_formatter_leaves_literal_braces_unchanged():
+    f = KeyOnlyFormatter()
+    formatted = f.format("We define {x. some property} and note {a, b}.", x="VALUE")
+    assert formatted == "We define {x. some property} and note {a, b}."
+
+
+def test_formatter_leaves_malformed_braces_unchanged():
+    f = KeyOnlyFormatter()
+    formatted = f.format("We define {x.", x="VALUE")
+    assert formatted == "We define {x."
+
+
+def test_formatter_ignores_attribute_and_index_fields():
+    f = KeyOnlyFormatter()
+    formatted = f.format("Values: {name.upper} {name[0]}", name="Alice")
+    assert formatted == "Values: {name.upper} {name[0]}"
+
+
+def test_formatter_preserves_escaped_braces():
+    f = KeyOnlyFormatter()
+    formatted = f.format("Literal {{name}} and injected {name}", name="Alice")
+    assert formatted == "Literal {name} and injected Alice"
+
 
 # ================ END KeyOnlyFormatter tests ===============
 
 
 # ================= START ValueDict tests ====================
 
+
 def test_valuedict_returns_value_if_exists():
     d = prompt_injection.ValueDict(name="Bob")
     assert d["name"] == "Bob"
+
 
 def test_valuedict_missing_returns_placeholder():
     d = prompt_injection.ValueDict()
     assert d["missing"] == "{missing}"
 
+
 # ================ END ValueDict tests =======================
 
 
 # ================= START inject_values tests ================
+
 
 def test_inject_values_injects_value():
     smsg = SystemMessage(content="System says {system_info}", inject_prompt=True)
@@ -48,6 +76,23 @@ def test_inject_values_injects_value():
     assert result[1].content == "Hello, Alice!"
     assert result[1].inject_prompt is False
 
+
+def test_inject_values_does_not_crash_on_literal_braces():
+    msg = UserMessage(
+        content="We define the set {x. some property} and note (e.g. {a, b}).",
+        inject_prompt=True,
+    )
+    history = MessageHistory([msg])
+    value_dict = ValueDict({"x": "Alice"})
+
+    result = prompt_injection.inject_values(history, value_dict)
+    assert (
+        result[0].content
+        == "We define the set {x. some property} and note (e.g. {a, b})."
+    )
+    assert result[0].inject_prompt is False
+
+
 def test_inject_values_ignores_no_inject():
     msg = Message(role=Role.user, content="Hello!", inject_prompt=False)
     history = MessageHistory([msg])
@@ -57,6 +102,7 @@ def test_inject_values_ignores_no_inject():
     assert result[0].content == "Hello!"
     assert result[0].inject_prompt is False
 
+
 def test_inject_values_ignores_non_string_content():
     msg = Message(role=Role.user, content=12345, inject_prompt=True)
     history = MessageHistory([msg])
@@ -65,16 +111,22 @@ def test_inject_values_ignores_non_string_content():
     result = prompt_injection.inject_values(history, value_dict)
     assert result[0].content == 12345
 
+
 def test_inject_values_catches_valueerror(monkeypatch):
     # Patch fill_prompt to throw ValueError
     msg = Message(role=Role.user, content="Hello, {name}!", inject_prompt=True)
     history = MessageHistory([msg])
     value_dict = ValueDict({"name": "Alice"})
 
-    monkeypatch.setattr(UserMessage, "fill_prompt", lambda content, vd: (_ for _ in ()).throw(ValueError("forced")))
+    monkeypatch.setattr(
+        UserMessage,
+        "fill_prompt",
+        lambda content, vd: (_ for _ in ()).throw(ValueError("forced")),
+    )
 
     # Should not raise, and content should be unchanged
     result = prompt_injection.inject_values(history, value_dict)
     assert result[0].content == "Hello, {name}!"
+
 
 # ================ END inject_values tests ==================


### PR DESCRIPTION
## Summary

Closes #1116.

- Update `KeyOnlyFormatter` to substitute only exact known context keys.
- Preserve literal, malformed, attribute-style, and index-style brace content instead of raising before LLM calls.
- Add regression coverage for literal brace prompt injection inputs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Validation

- `uv run --with rich --group test pytest packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py`
- `uv run --group lint ruff check packages/railtracks/src/railtracks/llm/prompt_injection_utils.py packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py --no-fix`
- `uv run --group lint ruff format --check packages/railtracks/src/railtracks/llm/prompt_injection_utils.py packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py`

## Notes

No breaking changes intended.