### PR TITLE
Fix prompt injection literal brace handling

### DIFF
--- a/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
+++ b/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
@@ -6,6 +6,44 @@ class KeyOnlyFormatter(string.Formatter):
     A simple formatter which will only use keyword arguments to fill placeholders.
     """
 
+    def vformat(self, format_string, args, kwargs):
+        result: list[str] = []
+        index = 0
+
+        while index < len(format_string):
+            char = format_string[index]
+
+            if char == "{":
+                if index + 1 < len(format_string) and format_string[index + 1] == "{":
+                    result.append("{")
+                    index += 2
+                    continue
+
+                end_index = format_string.find("}", index + 1)
+                if end_index == -1:
+                    result.append(char)
+                    index += 1
+                    continue
+
+                key = format_string[index + 1:end_index]
+                try:
+                    result.append(str(kwargs[key]))
+                except KeyError:
+                    result.append(f"{{{key}}}")
+                index = end_index + 1
+                continue
+
+            if char == "}":
+                if index + 1 < len(format_string) and format_string[index + 1] == "}":
+                    result.append("}")
+                    index += 2
+                    continue
+
+            result.append(char)
+            index += 1
+
+        return "".join(result)
+
     def get_value(self, key, args, kwargs):
         try:
             return kwargs[str(key)]

--- a/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
@@ -18,6 +18,32 @@ def test_formatter_missing_key_returns_placeholder():
     formatted = f.format("Hello, {name}")
     assert formatted == "Hello, {name}"
 
+def test_formatter_treats_unknown_attribute_like_field_as_literal():
+    f = KeyOnlyFormatter()
+    formatted = f.format("We define the set {x. some property} and keep it.")
+    assert formatted == "We define the set {x. some property} and keep it."
+
+def test_formatter_treats_json_like_content_as_literal():
+    f = KeyOnlyFormatter()
+    formatted = f.format('Payload: {"items": [1, 2], "ok": true}')
+    assert formatted == 'Payload: {"items": [1, 2], "ok": true}'
+
+def test_formatter_treats_unbalanced_braces_as_literal():
+    f = KeyOnlyFormatter()
+    formatted = f.format("Start {x and end }")
+    assert formatted == "Start {x and end }"
+
+def test_formatter_uses_getitem_for_lookup_only_mappings():
+    class LookupOnlyDict(dict):
+        def __getitem__(self, key):
+            if key == "name":
+                return "Alice"
+            raise KeyError(key)
+
+    f = KeyOnlyFormatter()
+    formatted = f.vformat("Hello, {name}", (), LookupOnlyDict())
+    assert formatted == "Hello, Alice"
+
 # ================ END KeyOnlyFormatter tests ===============
 
 
@@ -64,6 +90,18 @@ def test_inject_values_ignores_non_string_content():
 
     result = prompt_injection.inject_values(history, value_dict)
     assert result[0].content == 12345
+
+def test_inject_values_preserves_literal_brace_content():
+    msg = UserMessage(
+        content='We define {x. some property}; JSON: {"items": [1, 2]}.',
+        inject_prompt=True,
+    )
+    history = MessageHistory([msg])
+    value_dict = ValueDict({"name": "Alice"})
+
+    result = prompt_injection.inject_values(history, value_dict)
+    assert result[0].content == 'We define {x. some property}; JSON: {"items": [1, 2]}.'
+    assert result[0].inject_prompt is False
 
 def test_inject_values_catches_valueerror(monkeypatch):
     # Patch fill_prompt to throw ValueError


### PR DESCRIPTION
## Summary
- replace prompt injection formatting with key-only brace scanning
- preserve unknown/literal brace groups such as JSON, LaTeX-like text, and unbalanced braces
- add regression coverage for literal braces and lookup-only context mappings

Fixes #1116

## Validation
- uv run --group test --with rich pytest packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py packages/railtracks/tests/unit_tests/prompt/test_prompt.py