### PR TITLE
Potential fix for code scanning alert no. 20: Uncontrolled data used in path expression

### DIFF
--- a/packages/railtracks/src/railtracks/cli/viz_server.py
+++ b/packages/railtracks/src/railtracks/cli/viz_server.py
@@ -95,8 +95,12 @@ async def serve_ui_or_404(full_path: str):
     if full_path.startswith("api/"):
         return JSONResponse(content={"error": "Not Found"}, status_code=404)
 
+    requested_path = Path(full_path)
+    if requested_path.is_absolute() or ".." in requested_path.parts:
+        return JSONResponse(content={"error": "Not Found"}, status_code=404)
+
     ui_dir = (get_railtracks_dir() / "ui").resolve()
-    ui_file = (ui_dir / full_path).resolve()
+    ui_file = (ui_dir / requested_path).resolve()
     try:
         ui_file.relative_to(ui_dir)
     except ValueError:

--- a/packages/railtracks/src/railtracks/cli/viz_server.py
+++ b/packages/railtracks/src/railtracks/cli/viz_server.py
@@ -95,8 +95,13 @@ async def serve_ui_or_404(full_path: str):
     if full_path.startswith("api/"):
         return JSONResponse(content={"error": "Not Found"}, status_code=404)
 
-    ui_dir = get_railtracks_dir() / "ui"
-    ui_file = ui_dir / full_path
+    ui_dir = (get_railtracks_dir() / "ui").resolve()
+    ui_file = (ui_dir / full_path).resolve()
+    try:
+        ui_file.relative_to(ui_dir)
+    except ValueError:
+        return JSONResponse(content={"error": "Not Found"}, status_code=404)
+
     if ui_file.exists() and ui_file.is_file():
         return FileResponse(str(ui_file))
     index_file = ui_dir / "index.html"


### PR DESCRIPTION
Potential fix for [https://github.com/RailtownAI/railtracks/security/code-scanning/20](https://github.com/RailtownAI/railtracks/security/code-scanning/20)

Use path canonicalization plus a containment check before serving any requested file.

Best fix in this file:
- In `serve_ui_or_404` (around lines 98–101), resolve `ui_dir` and resolve the candidate file path from user input.
- Reject the request if the resolved candidate is not within the resolved `ui_dir`.
- Keep existing behavior for valid files and SPA fallback (`index.html`) unchanged.

Implementation details:
- `pathlib.Path.resolve()` for normalization.
- `Path.relative_to()` inside `try/except ValueError` to validate containment (portable and clear).
- No new dependencies required.
- No import changes needed since `Path` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
