### PR TITLE
fix: flow.invoke() works inside a running event loop (notebook support)

### DIFF
--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -24,40 +24,29 @@ _P = ParamSpec("_P")
 class Flow(Generic[_P, _TOutput]):
     """A reusable, configured entry point for running an agent graph.
 
-    A ``Flow`` binds an entry-point node to a fixed set of runtime options
-    (context, timeout, callbacks, etc.) so the same configuration can be
-    invoked repeatedly without repeating arguments.  Each invocation is fully
-    isolated — flows never share state between runs.
+    Binds an entry-point node to a fixed set of runtime options so the same
+    configuration can be invoked repeatedly.  Each invocation is fully isolated.
 
     Typical usage::
 
         flow = Flow("my-agent", entry_point=my_node, context={"user": "alice"})
-
-        # async (preferred — native event loop, no overhead)
-        result = await flow.ainvoke(query)
-
-        # sync (works in scripts and Jupyter; dispatches to a worker thread
-        # when an event loop is already running)
-        result = flow.invoke(query)
+        result = await flow.ainvoke(query)   # async (preferred)
+        result = flow.invoke(query)          # sync
 
     Args:
         name: Unique human-readable name used in logging and state filenames.
         entry_point: The node (or decorated function) that starts the graph.
-        context: Key/value pairs made available to every node via
-            ``rt.context`` for the duration of the run.  Deep-copied at
-            invocation time so mutations inside a run never affect later runs.
-        timeout: Maximum seconds to wait for the top-level call to complete.
-            ``None`` means no limit.
-        end_on_error: When ``True``, the first unhandled exception aborts the
-            run immediately.
-        broadcast_callback: Called with each broadcast string emitted by
-            ``rt.broadcast()``.  May be sync or async.
-        prompt_injection: When ``True``, prompt text is automatically injected
-            from context variables before the run starts.
-        save_state: When ``True``, the session state is persisted to
-            ``.railtracks/data/sessions/`` after the run completes.
-        payload_callback: Called with the final result payload once the run
-            finishes successfully.
+        context: Key/value pairs available to every node via ``rt.context``.
+            Deep-copied at invocation time so mutations never affect later runs.
+        timeout: Maximum seconds to wait for the run. ``None`` means no limit.
+        end_on_error: When ``True``, the first unhandled exception aborts the run.
+        broadcast_callback: Called with each string emitted by ``rt.broadcast()``.
+            May be sync or async.
+        prompt_injection: When ``True``, prompt text is injected from context
+            variables before the run starts.
+        save_state: When ``True``, session state is persisted to
+            ``.railtracks/data/sessions/`` after the run.
+        payload_callback: Called with the final result payload on success.
     """
 
     def __init__(
@@ -114,14 +103,6 @@ class Flow(Generic[_P, _TOutput]):
     async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
         """Run the flow asynchronously and return the entry-point result.
 
-        Preferred invocation path — call it directly from any async context::
-
-            result = await flow.ainvoke(arg1, arg2)
-
-        Each call is fully isolated: context is deep-copied at the start so
-        mutations inside the run never affect subsequent calls or other
-        concurrent runs.
-
         Args:
             *args: Positional arguments forwarded to the entry-point node.
             **kwargs: Keyword arguments forwarded to the entry-point node.
@@ -148,21 +129,7 @@ class Flow(Generic[_P, _TOutput]):
     def invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
         """Run the flow synchronously and return the entry-point result.
 
-        Thin synchronous wrapper around :meth:`ainvoke`.  Behaviour depends
-        on whether an event loop is already running in the current thread:
-
-        - **No running loop** (plain script, ``pytest``, etc.) —
-          delegates to ``asyncio.run()``, which creates a fresh event loop.
-        - **Running loop** (Jupyter, FastAPI, async test runner) —
-          submits the coroutine to a ``ThreadPoolExecutor`` running its own
-          fresh event loop.  ``contextvars.copy_context()`` propagates the
-          current context into the worker thread so all ContextVars are
-          visible inside the run.
-
-        .. note::
-            Prefer ``await flow.ainvoke()`` in async contexts — ``invoke``
-            adds thread-dispatch overhead and is provided as a convenience
-            for callers that cannot use ``await``.
+        Prefer ``await flow.ainvoke()`` in async contexts.
 
         Args:
             *args: Positional arguments forwarded to the entry-point node.
@@ -170,6 +137,11 @@ class Flow(Generic[_P, _TOutput]):
 
         Returns:
             The value returned by the entry-point node.
+
+        Note:
+            When no event loop is running, delegates to ``asyncio.run()``.
+            When a loop is already running (e.g. Jupyter, FastAPI), submits
+            the coroutine to a ``ThreadPoolExecutor`` worker thread.
         """
         try:
             asyncio.get_running_loop()

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
+import contextvars
 import hashlib
 import json
 from copy import deepcopy
@@ -20,21 +22,43 @@ _P = ParamSpec("_P")
 
 
 class Flow(Generic[_P, _TOutput]):
-    """
-    Initializes a Flow object with a provided entry point and a unique name.
+    """A reusable, configured entry point for running an agent graph.
 
-    A flow object is the configuration where you can run your agent with different input arguments.
+    A ``Flow`` binds an entry-point node to a fixed set of runtime options
+    (context, timeout, callbacks, etc.) so the same configuration can be
+    invoked repeatedly without repeating arguments.  Each call to
+    :meth:`invoke` / :meth:`ainvoke` creates an isolated :class:`Session` —
+    flows never share state between runs.
+
+    Typical usage::
+
+        flow = Flow("my-agent", entry_point=my_node, context={"user": "alice"})
+
+        # async (preferred — native event loop, no overhead)
+        result = await flow.ainvoke(query)
+
+        # sync (works in scripts and Jupyter; dispatches to a worker thread
+        # when an event loop is already running)
+        result = flow.invoke(query)
 
     Args:
-        name (str): A unique name for the flow. This is used for logging and state management.
-        entry_point (Callable | RTSyncFunction | RTAsyncFunction): The starting point of your flow.
-        context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
-        timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
-        end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
-        payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
+        name: Unique human-readable name used in logging and state filenames.
+        entry_point: The node (or decorated function) that starts the graph.
+        context: Key/value pairs made available to every node via
+            ``rt.context`` for the duration of the run.  Deep-copied at
+            invocation time so mutations inside a run never affect later runs.
+        timeout: Maximum seconds to wait for the top-level call to complete.
+            ``None`` means no limit.
+        end_on_error: When ``True``, the first unhandled exception aborts the
+            run immediately.  Defaults to the session-level setting.
+        broadcast_callback: Called with each broadcast string emitted by
+            ``rt.broadcast()``.  May be sync or async.
+        prompt_injection: When ``True``, prompt text is automatically injected
+            from context variables before the run starts.
+        save_state: When ``True``, the session state is persisted to
+            ``.railtracks/data/sessions/`` after the run completes.
+        payload_callback: Called with the final result payload once the run
+            finishes successfully.
     """
 
     def __init__(
@@ -73,14 +97,41 @@ class Flow(Generic[_P, _TOutput]):
         self._payload_callback = payload_callback
 
     def update_context(self, context: dict[str, Any]) -> Flow[_P, _TOutput]:
-        """
-        Creates a new Flow with the updated context. Note this will include the previous context values.
+        """Return a new Flow with additional context values merged in.
+
+        The original flow is not modified.  Values in ``context`` override
+        any existing keys; keys not present in ``context`` are preserved.
+
+        Args:
+            context: Entries to add or override in the flow's context.
+
+        Returns:
+            A new :class:`Flow` instance with the merged context.
         """
         new_obj = deepcopy(self)
         new_obj._context.update(context)
         return new_obj
 
     async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        """Run the flow asynchronously and return the entry-point result.
+
+        Creates a new :class:`Session`, executes the entry-point node with
+        the supplied arguments, then tears down the session.  This is the
+        preferred invocation path — call it directly from any async context::
+
+            result = await flow.ainvoke(arg1, arg2)
+
+        Each call is fully isolated: context is deep-copied at the start so
+        mutations inside the run never affect subsequent calls or other
+        concurrent runs.
+
+        Args:
+            *args: Positional arguments forwarded to the entry-point node.
+            **kwargs: Keyword arguments forwarded to the entry-point node.
+
+        Returns:
+            The value returned by the entry-point node.
+        """
         with Session(
             context=deepcopy(self._context),
             flow_name=self.name,
@@ -98,17 +149,47 @@ class Flow(Generic[_P, _TOutput]):
         return result
 
     def invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        """Run the flow synchronously and return the entry-point result.
+
+        Thin synchronous wrapper around :meth:`ainvoke`.  Behaviour depends
+        on whether an event loop is already running in the current thread:
+
+        - **No running loop** (plain script, ``pytest``, etc.) —
+          delegates to ``asyncio.run()``, which creates a fresh event loop.
+        - **Running loop** (Jupyter, FastAPI, async test runner) —
+          submits the coroutine to a ``ThreadPoolExecutor`` running its own
+          fresh event loop.  ``contextvars.copy_context()`` propagates the
+          current context into the worker thread so Session and logging
+          ContextVars are visible inside the run.
+
+        .. note::
+            Prefer ``await flow.ainvoke()`` in async contexts — ``invoke``
+            adds thread-dispatch overhead and is provided as a convenience
+            for callers that cannot use ``await``.
+
+        Args:
+            *args: Positional arguments forwarded to the entry-point node.
+            **kwargs: Keyword arguments forwarded to the entry-point node.
+
+        Returns:
+            The value returned by the entry-point node.
+        """
         try:
+            asyncio.get_running_loop()
+        except RuntimeError:
             return asyncio.run(self.ainvoke(*args, **kwargs))
 
-        except RuntimeError:
-            raise RuntimeError(
-                "Cannot invoke flow synchronously within an active event loop. Use 'ainvoke' instead."
-            )
+        ctx = contextvars.copy_context()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(ctx.run, asyncio.run, self.ainvoke(*args, **kwargs))
+            return future.result()
 
     def equality_hash(self) -> str:
-        """
-        Generates a hash based on the flow's configuration for equality checks.
+        """Return a stable hash that identifies this flow's configuration.
+
+        Two flows with the same name produce the same hash regardless of
+        other parameters (timeout, context, etc.).  Used internally to
+        tag session records with a flow identity that survives restarts.
         """
         config_string = json.dumps(self._get_hash_content(), sort_keys=True)
         return hashlib.sha256(config_string.encode()).hexdigest()

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -30,8 +30,8 @@ class Flow(Generic[_P, _TOutput]):
     Typical usage::
 
         flow = Flow("my-agent", entry_point=my_node, context={"user": "alice"})
-        result = await flow.ainvoke(query)   # async (preferred)
-        result = flow.invoke(query)          # sync
+        result = await flow.ainvoke(query)  # async (preferred)
+        result = flow.invoke(query)  # sync
 
     Args:
         name: Unique human-readable name used in logging and state filenames.

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -26,9 +26,8 @@ class Flow(Generic[_P, _TOutput]):
 
     A ``Flow`` binds an entry-point node to a fixed set of runtime options
     (context, timeout, callbacks, etc.) so the same configuration can be
-    invoked repeatedly without repeating arguments.  Each call to
-    :meth:`invoke` / :meth:`ainvoke` creates an isolated :class:`Session` —
-    flows never share state between runs.
+    invoked repeatedly without repeating arguments.  Each invocation is fully
+    isolated — flows never share state between runs.
 
     Typical usage::
 
@@ -50,7 +49,7 @@ class Flow(Generic[_P, _TOutput]):
         timeout: Maximum seconds to wait for the top-level call to complete.
             ``None`` means no limit.
         end_on_error: When ``True``, the first unhandled exception aborts the
-            run immediately.  Defaults to the session-level setting.
+            run immediately.
         broadcast_callback: Called with each broadcast string emitted by
             ``rt.broadcast()``.  May be sync or async.
         prompt_injection: When ``True``, prompt text is automatically injected
@@ -115,9 +114,7 @@ class Flow(Generic[_P, _TOutput]):
     async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
         """Run the flow asynchronously and return the entry-point result.
 
-        Creates a new :class:`Session`, executes the entry-point node with
-        the supplied arguments, then tears down the session.  This is the
-        preferred invocation path — call it directly from any async context::
+        Preferred invocation path — call it directly from any async context::
 
             result = await flow.ainvoke(arg1, arg2)
 
@@ -159,8 +156,8 @@ class Flow(Generic[_P, _TOutput]):
         - **Running loop** (Jupyter, FastAPI, async test runner) —
           submits the coroutine to a ``ThreadPoolExecutor`` running its own
           fresh event loop.  ``contextvars.copy_context()`` propagates the
-          current context into the worker thread so Session and logging
-          ContextVars are visible inside the run.
+          current context into the worker thread so all ContextVars are
+          visible inside the run.
 
         .. note::
             Prefer ``await flow.ainvoke()`` in async contexts — ``invoke``
@@ -188,8 +185,7 @@ class Flow(Generic[_P, _TOutput]):
         """Return a stable hash that identifies this flow's configuration.
 
         Two flows with the same name produce the same hash regardless of
-        other parameters (timeout, context, etc.).  Used internally to
-        tag session records with a flow identity that survives restarts.
+        other parameters (timeout, context, etc.).
         """
         config_string = json.dumps(self._get_hash_content(), sort_keys=True)
         return hashlib.sha256(config_string.encode()).hexdigest()

--- a/packages/railtracks/tests/integration_tests/orchestration/test_flows.py
+++ b/packages/railtracks/tests/integration_tests/orchestration/test_flows.py
@@ -85,9 +85,24 @@ async def test_flow_ainvoke_async_returns_value():
 
 @pytest.mark.asyncio
 async def test_flow_invoke_in_an_event_loop():
+    # invoke() must work transparently even when called from inside a running
+    # event loop (e.g. Jupyter) — it should dispatch to a worker thread rather
+    # than raising RuntimeError.
     flow = Flow(name="add-flow", entry_point=add)
-    with pytest.raises(RuntimeError):
-        result = flow.invoke(1, 2)
+    result = flow.invoke(1, 2)
+    assert result == 3
+
+
+@pytest.mark.asyncio
+async def test_flow_invoke_in_event_loop_preserves_context():
+    # Context set on the Flow must be visible inside the worker-thread run.
+    flow = Flow(
+        name="context-invoke-loop-flow",
+        entry_point=read_context_value,
+        context={"env": "notebook"},
+    )
+    result = flow.invoke("env")
+    assert result == "notebook"
 
 
 


### PR DESCRIPTION
## Summary

- `flow.invoke()` previously raised `RuntimeError` when called from a Jupyter notebook or any other async host (FastAPI, async test runner) because `asyncio.run()` rejects calls from within an already-running event loop
- Fixed by detecting the running loop and dispatching to a `ThreadPoolExecutor` with its own fresh event loop; `contextvars.copy_context()` ensures Session and logging `ContextVar`s are visible inside the worker thread
- Removed `nest_asyncio` (monkey-patches the live loop globally — unnecessary side-effect); replaced with a stdlib-only approach using `concurrent.futures` + `contextvars`
- Docstring 

## Behaviour

| Caller context | Before | After |
|---|---|---|
| Plain script / pytest | ✅ works | ✅ works |
| Jupyter notebook | ❌ `RuntimeError` | ✅ works |
| FastAPI / async test runner | ❌ `RuntimeError` | ✅ works |
| `await flow.ainvoke()` anywhere | ✅ works | ✅ works (unchanged) |

## Test plan

- [ ] `test_flow_invoke_in_an_event_loop` — updated: previously asserted `RuntimeError`, now asserts the correct return value is produced when called from inside a running loop
- [ ] `test_flow_invoke_in_event_loop_preserves_context` — new: verifies that Flow-level context is visible to nodes when `invoke()` dispatches through the worker thread
- [ ] All existing `test_flows.py` tests continue to pass unchanged