### PR TITLE
Reimplement context injection via LLM-level wrapper

### DIFF
--- a/docs/scripts/prompts.py
+++ b/docs/scripts/prompts.py
@@ -19,14 +19,22 @@ response = assistant_flow.update_context({"role": "technical", "domain": "Python
 # --8<-- [end: prompt_basic]
 
 # --8<-- [start: disable_injection]
-# Disable context injection for a specific run
+# 1. LLM level — disable for a specific agent class (takes precedence over session level)
+assistant_no_inject = rt.agent_node(
+    name="Assistant",
+    system_message=system_message,
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    context_injection=False,
+)
+
+# 2. Session level — disable for an entire session run
 flow = rt.Flow(
     "assistant-flow",
     entry_point=assistant,
-    prompt_injection=False
+    prompt_injection=False,
 )
 
-# or globally via 
+# 3. Global level — disable for all future sessions
 rt.set_config(prompt_injection=False)
 # --8<-- [end: disable_injection]
 

--- a/docs/tutorials/concepts/prompts_and_context.md
+++ b/docs/tutorials/concepts/prompts_and_context.md
@@ -1,28 +1,140 @@
 # Prompts and Context Injection
 
-Prompts are a fundamental part of working with LLMs in the Railtracks framework. This guide explains how to create dynamic prompts that use our context injection feature to make your prompts more flexible and powerful.
+Prompts are the primary interface between your application and an LLM. Railtracks lets you write prompts as **templates** with placeholders, then fill those placeholders at runtime from the session context — a feature called **context injection**.
 
-## Understanding Prompts in Railtracks
+---
 
-In Railtracks, prompts are provided as system messages or user messages when interacting with LLMs. These messages guide the LLM's behavior and responses.
+## Why Context Injection?
 
+Passing dynamic data to an LLM typically means one of two things: building prompt strings in application code, or appending additional user messages. Both approaches couple your prompt logic to your application logic and can inflate token usage.
 
-## Context Injection
+Context injection separates concerns: the prompt is a static template that lives with the agent class; the runtime data lives in the context. The framework connects them automatically.
 
-Railtracks provides a powerful feature called "context injection" (also referred to as "prompt injection") that allows you to dynamically insert values from the global context into your prompts. This makes your prompts more flexible and reusable across different scenarios.
+```text
+system_message = "You are a {role} assistant for {company}."
 
-### What is Context Injection?
+# At runtime:
+context = {"role": "billing", "company": "Acme Corp"}
+# → "You are a billing assistant for Acme Corp."
+```
 
-Context injection refers to the practice of dynamically inserting values into a prompt template. This is especially useful when your prompt needs information that isn't known until runtime.
+This keeps agents reusable across sessions and scenarios without code changes.
 
-Passing prompt details up the chain can be expensive in both **tokens** and **latency**. In many cases, it's more efficient to **inject values directly** into a prompt using our [context system](../../documentation/advanced/context.md).
+---
 
-### How Context Injection Works
+## How It Works
 
-1. Define placeholders in your prompts using curly braces: `{variable_name}`
-2. Set values in the Railtracks context (see [Context Management](../../documentation/advanced/context.md) for details)
-3. When the prompt is processed, the placeholders are replaced with the corresponding values from the context
+Context injection uses Python's standard `str.format_map` style substitution with one practical difference: **unknown placeholders are left as-is** rather than raising a `KeyError`. This means a prompt with `{optional_value}` will not break if that key is absent from the context — it simply stays as `{optional_value}`.
+
+### Placeholder syntax
+
+Use `{key}` anywhere in a `SystemMessage` or `UserMessage` content string:
+
+```python
+"Today's date is {date}. The user's name is {name}."
+```
+
+### Escaping
+
+To include a literal curly brace that should **not** be treated as a placeholder, double it:
+
+```python
+"Wrap your answer in {{code_block}} tags."
+# → "Wrap your answer in {code_block} tags."
+```
+
+### What gets injected
+
+Injection runs over every message in the history where `inject_prompt=True` (the default). Messages with non-string content (tool call results, structured outputs) are skipped automatically.
+
+---
+
+## Control Levels
+
+Context injection can be turned off at four levels, from broadest to most granular. Each level is independent — you can mix and match.
+
+### 1. Global level
+
+Disables injection for all agents in the current process. Useful for testing or when you want injection off by default across an entire application.
+
+```python
+rt.set_config(prompt_injection=False)
+```
+
+### 2. Session / Flow level
+
+Disables injection for a single session or flow run. Overrides the global default.
+
+```python
+with rt.Session(prompt_injection=False):
+    ...
+
+# or via Flow
+rt.Flow("my-flow", entry_point=agent, prompt_injection=False)
+```
+
+### 3. LLM level (agent class)
+
+Disables injection for a specific agent class, regardless of the session setting. The most targeted way to opt a particular agent out permanently.
+
+```python
+# Via the factory function
+agent = rt.agent_node(
+    system_message="Render {variable} literally.",
+    llm=my_llm,
+    context_injection=False,
+)
+
+# Via the NodeBuilder
+builder.context_injection(False)
+
+# Via class inheritance
+class RawAgent(TerminalLLM):
+    context_injection = False
+```
+
+### 4. Message level
+
+Disables injection for one specific message while leaving all others enabled. The most granular option.
+
+```python
+# System message with injection (default)
+system = rt.llm.SystemMessage("You are a {role} assistant.")
+
+# User message without injection — e.g. to protect LaTeX expressions
+user = rt.llm.UserMessage(r"Solve \frac{x}{2} = 4", inject_prompt=False)
+```
+
+A common use case: a maths assistant that injects the user's name via the system message but must not touch the user's input, which may contain `{` and `}` in equations.
+
+### Level precedence
+
+The LLM-level flag short-circuits session-level configuration: if `context_injection=False` is set on the agent class, the session's `prompt_injection` setting has no effect for that agent. Message-level control always wins for the individual message, regardless of all other settings.
+
+| Level | Scope | API |
+|---|---|---|
+| Global | Entire process | `rt.set_config(prompt_injection=False)` |
+| Session / Flow | One session run | `rt.Session(prompt_injection=False)` |
+| LLM (agent class) | One agent class | `agent_node(context_injection=False)` |
+| Message | One message | `UserMessage(..., inject_prompt=False)` |
+
+---
+
+## Setting Context Values
+
+Values are read from the active session context at the moment the LLM is called — not when the agent is defined. Set them using `rt.context.put()` inside a session, or provide them up-front via `rt.Session(context={...})`:
+
+```python
+with rt.Session(context={"role": "billing", "company": "Acme"}):
+    response = await rt.call(agent, user_input="Hello")
+```
+
+Values can also be updated mid-session with `rt.context.put("key", value)`, and the next LLM call will pick up the latest values.
+
+---
 
 ## Related Topics
 
-* [Tutorials/Prompts and Context](../walkthroughs/prompts_and_context.md)
+* [Walkthrough: Prompts and Context Injection](../walkthroughs/prompts_and_context.md) — code examples and reusable prompt templates
+* [Context Management](../../documentation/advanced/context.md) — full reference for the context system
+* [NodeBuilder](../../advanced_usage/node_builder.md) — building agent classes programmatically, including the `context_injection()` method

--- a/docs/tutorials/walkthroughs/prompts_and_context.md
+++ b/docs/tutorials/walkthroughs/prompts_and_context.md
@@ -8,25 +8,31 @@ In this example, the system message will be expanded to: "You are a technical as
 
 ### Enabling and Disabling Context Injection
 
-Context injection is enabled by default but can be disabled if needed:
+Context injection is enabled by default. It can be disabled at three levels — from broadest to narrowest:
 
 ```python
 --8<-- "docs/scripts/prompts.py:disable_injection"
 ```
 
-This may be useful when formatting prompts that should not change based on the context.
+**Choosing the right level:**
+
+| Level | API | When to use |
+|---|---|---|
+| **LLM level** | `agent_node(context_injection=False)` | A specific agent should never do injection, regardless of session config |
+| **Session level** | `rt.Session(prompt_injection=False)` or `rt.Flow(..., prompt_injection=False)` | Disable injection for one session or run |
+| **Global level** | `rt.set_config(prompt_injection=False)` | Disable injection everywhere for the current process |
+
+The LLM-level flag short-circuits the session setting — if `context_injection=False` on the node class, the session config is irrelevant for that node.
 
 !!! note "Message-Level Control"
 
-    Context injection can be controlled at the message level using the `inject_prompt` parameter:
+    Context injection can also be controlled at the message level using the `inject_prompt` parameter:
 
     ```python
     --8<-- "docs/scripts/prompts.py:injection_at_message_level"
     ```
 
-    This can be useful when you want to control which messages should have context injected and which should not. 
-
-    As an example, in a Math Assistant, you might want to inject context into the system message, but not the user message that may contain LaTeX that has `{}` characters. To prevent formatting issues, you can set `inject_prompt=False` for the user message.
+    This is the most granular option. For example, in a Math Assistant you might inject context into the system message but not the user message, which may contain LaTeX `{}` characters that would otherwise be treated as placeholders.
 
 ### Escaping Placeholders
 
@@ -42,7 +48,7 @@ If you need to include literal curly braces in your prompt without triggering co
 If your prompts aren't producing the expected results:
 
 1. **Check context values**: Ensure the context contains the expected values for your placeholders
-2. **Verify prompt injection is enabled**: Check that `prompt_injection=True` in your session configuration
+2. **Verify prompt injection is not disabled**: Context injection is on by default — check that `prompt_injection=False` has not been set in your session, flow, or global config
 3. **Look for syntax errors**: Ensure your placeholders use the correct format `{variable_name}`
 
 

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -344,6 +344,22 @@ class NodeBuilder(Generic[_TNode]):
             else:
                 self._with_override(name, attribute)
 
+    def context_injection(self, enabled: bool):
+        """
+        Control whether context variable injection is active for this LLM node.
+
+        When disabled, placeholders such as ``{variable}`` in prompts are left as-is
+        regardless of the session context or ``ExecutorConfig.prompt_injection``.
+
+        Args:
+            enabled (bool): ``False`` to turn off injection for this node class.
+        """
+        assert issubclass(self._node_class, LLMBase), (
+            f"context_injection can only be configured on LLMBase subclasses, got {self._node_class}"
+        )
+        self._with_override("context_injection", enabled)
+        return self
+
     def _with_override(self, name: str, method):
         """
         Add an override method for the node.

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
@@ -28,7 +28,7 @@ from railtracks.llm import (
 )
 from railtracks.llm.response import Response
 from railtracks.nodes.nodes import Node
-from railtracks.prompts.prompt import inject_context
+from railtracks.prompts.context_injection import ContextInjectionPreMapper
 from railtracks.utils.logging import get_rt_logger
 from railtracks.validation.node_invocation.validation import (
     check_llm_model,
@@ -91,6 +91,22 @@ class LLMBase(Node[_T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
             If a UserMessage is provided, it will be converted to a MessageHistory.
             llm: The LLM model to use. If None, the default model will be used.
     """
+
+    context_injection: bool = True
+    """
+    Enable or disable context variable injection for this LLM node class.
+
+    When True (default), placeholders like ``{variable}`` in messages are replaced
+    with values from the active session context before the LLM call.  Can be
+    disabled at three granularities:
+
+    - **LLM level** (this flag): set ``context_injection = False`` on the class,
+      or pass ``context_injection=False`` to ``agent_node()``.
+    - **Session level**: ``rt.Session(prompt_injection=False)`` / ``ExecutorConfig(prompt_injection=False)``.
+    - **Message level**: ``UserMessage(..., inject_prompt=False)``.
+    """
+
+    _context_injection_mapper: ContextInjectionPreMapper = ContextInjectionPreMapper()
 
     def __init__(
         self,
@@ -251,7 +267,10 @@ class LLMBase(Node[_T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
 
     def _pre_llm_hook(self, message_history: MessageHistory) -> MessageHistory:
         """Hook to modify messages before sending them to the llm model."""
-        return inject_context(message_history)
+        if not self.context_injection:
+            return message_history
+        messages, _, _ = self._context_injection_mapper(message_history)
+        return messages
 
     def _post_llm_hook(self, message_history: MessageHistory, response: Response):
         """Hook to store the response details after invoking the llm model."""

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -65,6 +65,7 @@ def _build_dynamic_agent(
     tool_details: str | None,
     tool_params: set | Iterable | None,
     guardrails: Guard | None,
+    context_injection: bool = True,
 ):
     if unpacked_tool_nodes is not None and len(unpacked_tool_nodes) > 0:
         if output_schema is not None:
@@ -77,6 +78,7 @@ def _build_dynamic_agent(
                 tool_details=tool_details,
                 tool_params=tool_params,
                 guardrails=guardrails,
+                context_injection=context_injection,
             )
         return tool_call_llm(
             tool_nodes=unpacked_tool_nodes,
@@ -86,6 +88,7 @@ def _build_dynamic_agent(
             tool_details=tool_details,
             tool_params=tool_params,
             guardrails=guardrails,
+            context_injection=context_injection,
         )
     if output_schema is not None:
         return structured_llm(
@@ -96,6 +99,7 @@ def _build_dynamic_agent(
             system_message=system_message,
             tool_details=tool_details,
             tool_params=tool_params,
+            context_injection=context_injection,
         )
     return terminal_llm(
         name=name,
@@ -104,6 +108,7 @@ def _build_dynamic_agent(
         system_message=system_message,
         tool_details=tool_details,
         tool_params=tool_params,
+        context_injection=context_injection,
     )
 
 
@@ -326,6 +331,7 @@ def agent_node(
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
     guardrails: Guard | None = None,
+    context_injection: bool = True,
 ):
     """
     Dynamically creates an agent based on the provided parameters.
@@ -359,6 +365,7 @@ def agent_node(
         tool_details=tool_details,
         tool_params=tool_params,
         guardrails=guardrails,
+        context_injection=context_injection,
     )
 
     if rag is not None:

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
@@ -33,6 +33,7 @@ def structured_llm(
     return_into: str | None = None,
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
+    context_injection: bool = True,
 ) -> Type[StructuredLLM[_TOutput] | StreamingStructuredLLM[_TOutput]]:
     """
     Dynamically create a StructuredLastMessageLLM node class with custom configuration for output_schema.
@@ -75,6 +76,8 @@ def structured_llm(
     )
     builder.llm_base(llm, system_message)
     builder.structured(output_schema)
+    if not context_injection:
+        builder.context_injection(False)
     if guardrails is not None:
         builder.add_attribute("guardrails", guardrails, make_function=False)
     if tool_details is not None or tool_params is not None:

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_tool_call_llm.py
@@ -32,6 +32,7 @@ def structured_tool_call_llm(
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
     guardrails: Guard | None = None,
+    context_injection: bool = True,
 ) -> Type[StructuredToolCallLLM[_TOutput]]:
     """
     Dynamically create a StructuredToolCallLLM node class with custom configuration for tool calling.
@@ -76,7 +77,8 @@ def structured_tool_call_llm(
 
     builder.llm_base(llm, system_message)
     builder.tool_calling_llm(set(tool_nodes))
-
+    if not context_injection:
+        builder.context_injection(False)
     if tool_details is not None or tool_params is not None:
         builder.tool_callable_llm(tool_details, tool_params)
     builder.structured(output_schema)

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
@@ -25,6 +25,7 @@ def terminal_llm(
     return_into: str | None = None,
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
+    context_injection: bool = True,
 ):
     """
     Dynamically create a LastMessageTerminalLLM node class with custom configuration.
@@ -63,6 +64,8 @@ def terminal_llm(
         format_for_context=format_for_context,
     )
     builder.llm_base(llm, system_message)
+    if not context_injection:
+        builder.context_injection(False)
     if guardrails is not None:
         builder.add_attribute("guardrails", guardrails, make_function=False)
     if tool_details is not None or tool_params is not None:

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
@@ -28,6 +28,7 @@ def tool_call_llm(
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
     guardrails: Guard | None = None,
+    context_injection: bool = True,
 ) -> Type[ToolCallLLM | StreamingToolCallLLM]:
     """
     Dynamically create a ToolCallLLM node class with custom configuration for tool calling.
@@ -73,6 +74,8 @@ def tool_call_llm(
     )
     builder.llm_base(llm, system_message)
     builder.tool_calling_llm(tool_nodes)
+    if not context_injection:
+        builder.context_injection(False)
     if tool_details is not None or tool_params is not None:
         builder.tool_callable_llm(tool_details, tool_params)
 

--- a/packages/railtracks/src/railtracks/prompts/__init__.py
+++ b/packages/railtracks/src/railtracks/prompts/__init__.py
@@ -1,0 +1,3 @@
+from railtracks.prompts.context_injection import ContextInjectionPreMapper
+
+__all__ = ["ContextInjectionPreMapper"]

--- a/packages/railtracks/src/railtracks/prompts/context_injection.py
+++ b/packages/railtracks/src/railtracks/prompts/context_injection.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from railtracks.prompts.prompt import inject_context
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+
+    from railtracks.llm.history import MessageHistory
+    from railtracks.llm.tools.tool import Tool
+
+
+class ContextInjectionPreMapper:
+    """
+    A pre-mapper that injects context variables into message history placeholders.
+
+    Satisfies the GatewayPreMapper protocol so it can be passed directly to a
+    ModelGateway(pre_mappers=[...]) once that interface is available (PR #1132).
+
+    Injection is controlled at two levels:
+    - Session level: ExecutorConfig(prompt_injection=False) disables it globally.
+    - Message level: Message(inject_prompt=False) skips a specific message.
+    """
+
+    def __call__(
+        self,
+        messages: "MessageHistory",
+        schema: "type[BaseModel] | None" = None,
+        tools: "list[Tool] | None" = None,
+    ) -> "tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]":
+        return inject_context(messages), schema, tools

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -270,3 +270,35 @@ def test_classmethod_preserving_function_meta():
         def type(cls): return "Tool"
     Dummy.f = cm
     assert Dummy.f(2) == 3
+
+def test_nodebuilder_context_injection_disabled():
+    builder = NodeBuilder(DummyNode, name="TestNode")
+    builder.llm_base(llm_model(), system_message="sysmsg")
+    builder.context_injection(False)
+    node_cls = builder.build()
+    assert node_cls.context_injection is False
+
+def test_nodebuilder_context_injection_enabled_explicitly():
+    builder = NodeBuilder(DummyNode, name="TestNode")
+    builder.llm_base(llm_model(), system_message="sysmsg")
+    builder.context_injection(True)
+    node_cls = builder.build()
+    assert node_cls.context_injection is True
+
+def test_nodebuilder_context_injection_default():
+    builder = NodeBuilder(DummyNode, name="TestNode")
+    builder.llm_base(llm_model(), system_message="sysmsg")
+    node_cls = builder.build()
+    # default inherited from LLMBase
+    assert node_cls.context_injection is True
+
+def test_nodebuilder_context_injection_wrong_base():
+    class NotLLM(Node):
+        @classmethod
+        def name(cls): return "NotLLM"
+        async def invoke(self): return "notllm"
+        @classmethod
+        def type(cls): return "Tool"
+    builder = NodeBuilder(NotLLM, name="NotLLM")
+    with pytest.raises(AssertionError):
+        builder.context_injection(False)

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
@@ -2,7 +2,8 @@ import asyncio
 
 import pytest
 import railtracks as rt
-from railtracks.llm import Message, MessageHistory
+from railtracks.built_nodes.concrete.terminal_llm_base import TerminalLLM
+from railtracks.llm import Message, MessageHistory, UserMessage
 from railtracks.llm.response import Response
 from railtracks.llm.message import Role
 
@@ -95,6 +96,86 @@ def test_prompt_not_in_context(mock_llm):
     response = asyncio.run(top_level())
 
     assert response.content == "{secret2}"
+
+
+def test_prompt_injection_llm_level_bypass(mock_llm):
+    prompt = "{secret_value}"
+
+    def return_message(messages: MessageHistory) -> Response:
+        return Response(message=Message(role=Role.assistant, content=messages[-1].content))
+
+    model = mock_llm()
+    model._chat = return_message
+
+    node = rt.agent_node(
+        system_message=prompt,
+        llm=model,
+        context_injection=False,
+    )
+
+    async def top_level():
+        with rt.Session(context={"secret_value": "tomato"}):
+            response = await rt.call(node, user_input=MessageHistory())
+
+        return response
+
+    response = asyncio.run(top_level())
+    assert response.content == "{secret_value}"
+
+
+def test_prompt_injection_class_based_bypass(mock_llm):
+    """Class-based API: subclass with context_injection = False skips injection."""
+    prompt = "{secret_value}"
+
+    def return_message(messages: MessageHistory) -> Response:
+        return Response(message=Message(role=Role.assistant, content=messages[-1].content))
+
+    model = mock_llm()
+    model._chat = return_message
+
+    class MyAgent(TerminalLLM):
+        context_injection = False
+
+        @classmethod
+        def system_message(cls):
+            return rt.llm.SystemMessage(prompt)
+
+        @classmethod
+        def get_llm(cls):
+            return model
+
+    async def top_level():
+        with rt.Session(context={"secret_value": "tomato"}):
+            response = await rt.call(MyAgent, user_input=MessageHistory())
+        return response
+
+    response = asyncio.run(top_level())
+    assert response.content == "{secret_value}"
+
+
+def test_prompt_injection_message_level_bypass(mock_llm):
+    """Message-level inject_prompt=False leaves that message's placeholders untouched."""
+
+    def return_message(messages: MessageHistory) -> Response:
+        # Return the user message content (last non-system message before assistant)
+        user_content = next(
+            m.content for m in reversed(messages) if m.role == "user"
+        )
+        return Response(message=Message(role=Role.assistant, content=user_content))
+
+    model = mock_llm()
+    model._chat = return_message
+
+    node = rt.agent_node(llm=model)
+
+    async def top_level():
+        with rt.Session(context={"topic": "Python"}):
+            user_msg = UserMessage("{topic}", inject_prompt=False)
+            response = await rt.call(node, user_input=MessageHistory([user_msg]))
+        return response
+
+    response = asyncio.run(top_level())
+    assert response.content == "{topic}"
 
 
 @pytest.mark.order("last")


### PR DESCRIPTION
## Summary

- Introduces `ContextInjectionPreMapper`, a `GatewayPreMapper`-compatible class that wraps the existing `inject_context()` logic — forward-compatible with the `ModelGateway` pattern landing in #1132
- Adds `context_injection: bool = True` class variable to `LLMBase` so injection can be disabled at the agent-class level, independent of session config
- Threads `context_injection` through `agent_node()`, `NodeBuilder.context_injection()`, and all four helper factories
- Expands docs: concepts page (`prompts_and_context.md`) rewritten as a full reference; walkthrough updated with three-level disable table; debugging tip corrected (injection is on by default)

**Control levels (narrowest wins):**

| Level | API |
|---|---|
| Global | `rt.set_config(prompt_injection=False)` |
| Session / Flow | `rt.Session(prompt_injection=False)` |
| LLM (agent class) | `agent_node(context_injection=False)` |
| Message | `UserMessage(..., inject_prompt=False)` |

## Test plan

- [ ] `test_prompt_injection_llm_level_bypass` — `agent_node(context_injection=False)` leaves placeholders untouched
- [ ] `test_prompt_injection_class_based_bypass` — subclass with `context_injection = False` class var
- [ ] `test_prompt_injection_message_level_bypass` — `UserMessage(inject_prompt=False)` skips one message
- [ ] `test_nodebuilder_context_injection_disabled/enabled/default/wrong_base` — NodeBuilder method unit tests
- [ ] All existing prompt injection tests continue to pass (session-level, bypass, numerical, missing key)