### PR TITLE
pooria/1154 reimplement mcp

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -219,6 +219,7 @@ class NodeBuilder(Generic[_P, _T]):
         output_maps: list[MapOutputs[_T2]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | Type[BaseModel] | dict[str, Any] | None = None,
+        tool_info: Tool | None = None,
     ) -> NodeBuilder[_P2, _T2]:
         instance = cls()
         casted_instance = cast(NodeBuilder[_P2, _T2], instance)
@@ -230,8 +231,12 @@ class NodeBuilder(Generic[_P, _T]):
         casted_instance._node_name = name or function.__name__
 
         tm = TypeMapper(function)
-        tool = Tool.from_function(function, details=tool_details, params=tool_params)
-        casted_instance._tool_info = lambda: tool
+        resolved_tool = (
+            tool_info
+            if tool_info is not None
+            else Tool.from_function(function, details=tool_details, params=tool_params)
+        )
+        casted_instance._tool_info = lambda: resolved_tool
 
         casted_instance._prepare_arguments = tm.convert_kwargs_to_appropriate_types
 

--- a/packages/railtracks/src/railtracks/rt_mcp/main.py
+++ b/packages/railtracks/src/railtracks/rt_mcp/main.py
@@ -427,6 +427,9 @@ def from_mcp(
                 f"Tool invocation failed: {type(e).__name__}: {str(e)}"
             ) from e
 
-    builder = NodeBuilder.function(invoke, class_name=tool.name, name=tool.name)
-    builder._tool_info = lambda: Tool.from_mcp(tool)
-    return builder.build()
+    return NodeBuilder.function(
+        invoke,
+        class_name=tool.name,
+        name=tool.name,
+        tool_info=Tool.from_mcp(tool),
+    ).build()

--- a/packages/railtracks/src/railtracks/rt_mcp/main.py
+++ b/packages/railtracks/src/railtracks/rt_mcp/main.py
@@ -4,12 +4,14 @@ from contextlib import AsyncExitStack
 from datetime import timedelta
 from typing import Any
 
+import httpx
 from mcp import ClientSession, StdioServerParameters
+from mcp.types import Tool as MCPTool
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from pydantic import BaseModel
-from typing_extensions import Self, Type
+from typing_extensions import Type
 
 from railtracks.llm import Tool
 from railtracks.nodes.nodes import Node
@@ -51,13 +53,17 @@ class MCPHttpParams(BaseModel):
         timeout: Connection timeout (default: 30 seconds)
         sse_read_timeout: SSE read timeout (default: 5 minutes)
         terminate_on_close: Whether to terminate connection on close (default: True)
+        auth: Optional HTTPX authentication handler
     """
+
+    model_config = {"arbitrary_types_allowed": True}
 
     url: str
     headers: dict[str, Any] | None = None
     timeout: timedelta = timedelta(seconds=30)
     sse_read_timeout: timedelta = timedelta(seconds=60 * 5)
     terminate_on_close: bool = True
+    auth: httpx.Auth | None = None
 
 
 class MCPAsyncClient:
@@ -138,11 +144,11 @@ class MCPAsyncClient:
         Returns:
             List of available tools
         """
+        assert self.session is not None, "call connect() before list_tools()"
         if self._tools_cache is not None:
             return self._tools_cache
-        else:
-            resp = await self.session.list_tools()
-            self._tools_cache = resp.tools
+        resp = await self.session.list_tools()
+        self._tools_cache = resp.tools
         return self._tools_cache
 
     async def call_tool(self, tool_name: str, tool_args: dict):
@@ -156,6 +162,7 @@ class MCPAsyncClient:
         Returns:
             Tool execution result
         """
+        assert self.session is not None, "call connect() before call_tool()"
         return await self.session.call_tool(tool_name, tool_args)
 
     async def _init_http(self):
@@ -168,6 +175,7 @@ class MCPAsyncClient:
 
         Supports optional OAuth authentication via the 'auth' attribute.
         """
+        assert isinstance(self.config, MCPHttpParams)
         # Determine transport type from URL
         if self.config.url.rstrip("/").endswith("/sse"):
             self.transport_type = "sse"
@@ -181,16 +189,23 @@ class MCPAsyncClient:
                 headers=self.config.headers,
                 timeout=self.config.timeout.total_seconds(),
                 sse_read_timeout=self.config.sse_read_timeout.total_seconds(),
-                auth=self.config.auth if hasattr(self.config, "auth") else None,
+                auth=self.config.auth,
             )
         else:
-            client = streamablehttp_client(
-                url=self.config.url,
+            http_client = httpx.AsyncClient(
                 headers=self.config.headers,
-                timeout=self.config.timeout.total_seconds(),
-                sse_read_timeout=self.config.sse_read_timeout.total_seconds(),
+                timeout=httpx.Timeout(
+                    connect=self.config.timeout.total_seconds(),
+                    read=self.config.sse_read_timeout.total_seconds(),
+                    write=self.config.timeout.total_seconds(),
+                    pool=self.config.timeout.total_seconds(),
+                ),
+                auth=self.config.auth,
+            )
+            client = streamable_http_client(
+                url=self.config.url,
+                http_client=http_client,
                 terminate_on_close=self.config.terminate_on_close,
-                auth=self.config.auth if hasattr(self.config, "auth") else None,
             )
 
         # Initialize session with the client
@@ -374,13 +389,12 @@ class MCPServer:
             Each Node has:
             - name(): Tool name
             - tool_info(): Tool metadata (description, parameters)
-            - prepare_tool(**kwargs): Create tool instance with arguments
         """
         return self._tools
 
 
 def from_mcp(
-    tool: Tool,
+    tool: MCPTool,
     client: MCPAsyncClient,
     loop: asyncio.AbstractEventLoop,
 ) -> Type[Node]:
@@ -398,9 +412,8 @@ def from_mcp(
 
     Returns:
         A Node subclass that:
-        - Implements invoke() to call the MCP tool
+        - Implements invoke(**kwargs) to call the MCP tool
         - Provides tool_info() for schema introspection
-        - Supports prepare_tool() for argument binding
         - Can be used with rt.call() and agent_node()
 
     Example:
@@ -412,30 +425,19 @@ def from_mcp(
     class MCPToolNode(Node):
         """Dynamic Node class representing an MCP tool."""
 
-        def __init__(self, **kwargs):
-            """Initialize with tool arguments."""
-            super().__init__()
-            self.kwargs = kwargs
-
-        def invoke(self):
+        async def invoke(self, **kwargs):
             """
             Execute the MCP tool with the provided arguments.
 
-            Bridges from sync to async by running the tool call in the
-            background thread's event loop and waiting for the result.
-
-            Returns:
-                The tool's execution result
-
-            Raises:
-                RuntimeError: If tool execution fails
+            Submits the call to the MCP background event loop and awaits
+            it via asyncio.wrap_future — non-blocking and type-compatible
+            with Node.invoke.
             """
             try:
                 future = asyncio.run_coroutine_threadsafe(
-                    client.call_tool(tool.name, self.kwargs), loop
+                    client.call_tool(tool.name, kwargs), loop
                 )
-                result = future.result(timeout=client.config.timeout.total_seconds())
-                return result
+                return await asyncio.wrap_future(future)
             except Exception as e:
                 raise RuntimeError(
                     f"Tool invocation failed: {type(e).__name__}: {str(e)}"
@@ -443,35 +445,14 @@ def from_mcp(
 
         @classmethod
         def name(cls):
-            """Return the tool name."""
             return tool.name
 
         @classmethod
         def tool_info(cls) -> Tool:
-            """
-            Get tool metadata including parameters and description.
-
-            Returns:
-                Tool object with name, description, and parameter schemas
-            """
             return Tool.from_mcp(tool)
 
         @classmethod
-        def prepare_tool(cls, **kwargs) -> Self:
-            """
-            Create a tool instance with bound arguments.
-
-            Args:
-                **kwargs: Arguments to pass to the tool
-
-            Returns:
-                Tool instance ready for execution
-            """
-            return cls(**kwargs)
-
-        @classmethod
         def type(cls):
-            """Return the node type identifier."""
             return "Tool"
 
     return MCPToolNode

--- a/packages/railtracks/src/railtracks/rt_mcp/main.py
+++ b/packages/railtracks/src/railtracks/rt_mcp/main.py
@@ -13,6 +13,7 @@ from mcp.types import Tool as MCPTool
 from pydantic import BaseModel
 from typing_extensions import Type
 
+from railtracks.built_nodes._node_builder import NodeBuilder
 from railtracks.llm import Tool
 from railtracks.nodes.nodes import Node
 
@@ -401,20 +402,13 @@ def from_mcp(
     """
     Convert an MCP tool into a Railtracks Node class.
 
-    Creates a Node subclass that bridges between Railtracks' synchronous API
-    and the MCP tool's asynchronous execution. The Node can be used directly
-    with rt.call() or passed to agents as a tool.
-
     Args:
         tool: The MCP tool object with name, description, and schema
         client: Async client for communicating with the MCP server
         loop: Event loop running in the background thread
 
     Returns:
-        A Node subclass that:
-        - Implements invoke(**kwargs) to call the MCP tool
-        - Provides tool_info() for schema introspection
-        - Can be used with rt.call() and agent_node()
+        A Node class that can be used with rt.call() and passed to agents as a tool.
 
     Example:
         server = rt.connect_mcp(config)
@@ -422,37 +416,17 @@ def from_mcp(
         result = await rt.call(ToolNode, param1="value1")
     """
 
-    class MCPToolNode(Node):
-        """Dynamic Node class representing an MCP tool."""
+    async def invoke(**kwargs):
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                client.call_tool(tool.name, kwargs), loop
+            )
+            return await asyncio.wrap_future(future)
+        except Exception as e:
+            raise RuntimeError(
+                f"Tool invocation failed: {type(e).__name__}: {str(e)}"
+            ) from e
 
-        async def invoke(self, **kwargs):
-            """
-            Execute the MCP tool with the provided arguments.
-
-            Submits the call to the MCP background event loop and awaits
-            it via asyncio.wrap_future — non-blocking and type-compatible
-            with Node.invoke.
-            """
-            try:
-                future = asyncio.run_coroutine_threadsafe(
-                    client.call_tool(tool.name, kwargs), loop
-                )
-                return await asyncio.wrap_future(future)
-            except Exception as e:
-                raise RuntimeError(
-                    f"Tool invocation failed: {type(e).__name__}: {str(e)}"
-                ) from e
-
-        @classmethod
-        def name(cls):
-            return tool.name
-
-        @classmethod
-        def tool_info(cls) -> Tool:
-            return Tool.from_mcp(tool)
-
-        @classmethod
-        def type(cls):
-            return "Tool"
-
-    return MCPToolNode
+    builder = NodeBuilder.function(invoke, class_name=tool.name, name=tool.name)
+    builder._tool_info = lambda: Tool.from_mcp(tool)
+    return builder.build()

--- a/packages/railtracks/src/railtracks/rt_mcp/main.py
+++ b/packages/railtracks/src/railtracks/rt_mcp/main.py
@@ -6,10 +6,10 @@ from typing import Any
 
 import httpx
 from mcp import ClientSession, StdioServerParameters
-from mcp.types import Tool as MCPTool
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import Tool as MCPTool
 from pydantic import BaseModel
 from typing_extensions import Type
 

--- a/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
@@ -97,6 +97,14 @@ def stdio_config():
 def fake_tool():
     obj = MagicMock()
     obj.name = "abc"
+    obj.description = "A fake tool for testing"
+    obj.inputSchema = {
+        "type": "object",
+        "properties": {
+            "bar": {"type": "integer", "description": "A bar parameter"},
+        },
+        "required": ["bar"],
+    }
     obj.to_dict = MagicMock(return_value={"name": "abc"})
     return obj
 

--- a/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
@@ -31,7 +31,13 @@ def patch_stdio_client():
 def mock_client_session():
     mock = MagicMock(spec=ClientSession)
     mock.initialize = AsyncMock()
-    mock.list_tools = AsyncMock(return_value=MagicMock(tools=[{"name": "toolA"}]))
+
+    mock_tool = MagicMock()
+    mock_tool.name = "toolA"
+    mock_tool.description = "A test tool"
+    mock_tool.inputSchema = {"type": "object", "properties": {}, "required": []}
+
+    mock.list_tools = AsyncMock(return_value=MagicMock(tools=[mock_tool]))
     mock.call_tool = AsyncMock(return_value=MagicMock(content="output"))
     return mock
 

--- a/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/conftest.py
@@ -48,7 +48,7 @@ def patch_streamablehttp_client():
     cm_mock = AsyncMock()
     cm_mock.__aenter__.return_value = (AsyncMock(), AsyncMock())
     cm_mock.__aexit__.return_value = None
-    with patch("railtracks.rt_mcp.main.streamablehttp_client", return_value=cm_mock) as p:
+    with patch("railtracks.rt_mcp.main.streamable_http_client", return_value=cm_mock) as p:
         yield p
 
 @pytest.fixture

--- a/packages/railtracks/tests/unit_tests/rt_mcp/test_main.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/test_main.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -107,60 +108,40 @@ async def test_async_client_init_http_uses_correct_transport(
 def test_from_mcp_returns_node_class(fake_tool, mcp_http_params):
     mock_loop = MagicMock()
     mock_client = AsyncMock()
-    mock_result = MagicMock(content="abc")
-    mock_client.call_tool.return_value = mock_result
 
-    # Patch run_coroutine_threadsafe to return a Future with result
-    future = MagicMock()
-    future.result.return_value = mock_result
-    with patch("asyncio.run_coroutine_threadsafe", return_value=future):
-        result_class = from_mcp(fake_tool, mock_client, mock_loop)
+    result_class = from_mcp(fake_tool, mock_client, mock_loop)
+    node = result_class()
+    assert result_class.name() == f"{fake_tool.name}"
+    with patch.object(result_class, 'tool_info', wraps=result_class.tool_info):
+        Tool = type("Tool", (), {"from_mcp": staticmethod(lambda tool: "X")})
+        result_class.tool_info = classmethod(lambda cls: Tool.from_mcp(fake_tool))
+        assert result_class.tool_info() == "X"
 
-        node = result_class(bar=1)
-        # must have custom name
-        assert result_class.name() == f"{fake_tool.name}"
-        # must have correct tool_info
-        with patch.object(result_class, 'tool_info', wraps=result_class.tool_info) as ti:
-            Tool = type("Tool", (), {"from_mcp": staticmethod(lambda tool: "X")})
-            result_class.tool_info = classmethod(lambda cls: Tool.from_mcp(fake_tool))
-            assert result_class.tool_info() == "X"
-
-def test_from_mcp_prepare_tool(fake_tool, mcp_http_params):
+def test_from_mcp_prepare_args(fake_tool, mcp_http_params):
     mock_loop = MagicMock()
     mock_client = AsyncMock()
-    mock_result = MagicMock(content="abc")
-    mock_client.call_tool.return_value = mock_result
-
-    # Patch run_coroutine_threadsafe to return a Future with result
-    future = MagicMock()
-    future.result.return_value = mock_result
-    with patch("asyncio.run_coroutine_threadsafe", return_value=future):
-        result_class = from_mcp(fake_tool, mock_client, mock_loop)
-        options = {"one": 1, "two": 2}
-        inst = result_class.prepare_tool(**options)
-        assert isinstance(inst, result_class)
-        assert inst.kwargs == options
+    result_class = from_mcp(fake_tool, mock_client, mock_loop)
+    # prepare_args is inherited from Node — passes kwargs through unchanged
+    assert result_class.prepare_args(one=1, two=2) == {"one": 1, "two": 2}
 
 @pytest.mark.asyncio
 async def test_from_mcp_invoke(fake_tool, mcp_http_params):
     mock_loop = MagicMock()
     mock_client = AsyncMock()
-    mock_result = "abc"
-    mock_client.call_tool.return_value = mock_result
 
-    # Patch run_coroutine_threadsafe to return a Future with result
-    future = MagicMock()
-    future.result.return_value = mock_result
-    with patch("asyncio.run_coroutine_threadsafe", return_value=future):
-        node_cls = from_mcp(fake_tool, mock_client, mock_loop)
-        node = node_cls(bar=2)
-        result = await node.invoke()
+    node_cls = from_mcp(fake_tool, mock_client, mock_loop)
+    node = node_cls()
+
+    fut = concurrent.futures.Future()
+    fut.set_result("abc")
+    with patch("asyncio.run_coroutine_threadsafe", return_value=fut):
+        result = await node.invoke(bar=2)
         assert result == "abc"
 
-        # also test fallback to raw result (no .content)
-        mock_result2 = "valonly"
-        future.result.return_value = mock_result2
-        result = await node.invoke()
+    fut2 = concurrent.futures.Future()
+    fut2.set_result("valonly")
+    with patch("asyncio.run_coroutine_threadsafe", return_value=fut2):
+        result = await node.invoke(bar=2)
         assert result == "valonly"
 
 

--- a/packages/railtracks/tests/unit_tests/rt_mcp/test_main.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/test_main.py
@@ -67,7 +67,8 @@ async def test_async_client_list_tools(
     server = MCPServer(stdio_config, mock_client_session)
 
     tools = await server.client.list_tools()
-    assert tools == [{"name": "toolA"}]
+    assert len(tools) == 1
+    assert tools[0].name == "toolA"
     assert mock_client_session.list_tools.call_count == 1
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Updates `rt_mcp` for compatibility with the NodeBuilder unification (PR #1151) and replaces the deprecated `streamablehttp_client` with the current MCP SDK API.

**NodeBuilder unification (`MCPToolNode`):**
- Removed `__init__(**kwargs)` / `self.kwargs` — the old "node-as-factory" pattern where args were baked into the instance at construction time. Under the new system `_create_node_and_request` calls `node()` with no args; invocation args arrive via `wrapped_invoke(**kwargs)`
- Changed `invoke(self)` → `async def invoke(self, **kwargs)` so args are received explicitly, matching the new `Node` base contract
- Replaced blocking `future.result()` with `await asyncio.wrap_future(future)` — non-blocking bridge between the caller's event loop and the MCP background loop
- Removed `prepare_tool` — the tool invocation path in `llm_helpers.py` now uses `prepare_args` (inherited passthrough from `Node`)
- Fixed parameter type: `tool: Tool` → `tool: MCPTool` (`mcp.types.Tool` vs `railtracks.llm.Tool` name collision)
- Replaced the manual `MCPToolNode(Node)` class definition with `NodeBuilder.function()`, eliminating ~30 lines of boilerplate

**`NodeBuilder.function()` — added `tool_info` param:**
- Added `tool_info: Tool | None = None` to `NodeBuilder.function()` for callers that already have a fully-constructed `Tool` (e.g. converted from an external schema). When provided it bypasses `Tool.from_function()` entirely; otherwise the existing inference path is unchanged
- `from_mcp` now passes `Tool.from_mcp(tool)` through this param instead of monkey-patching `builder._tool_info` after construction

**`streamablehttp_client` deprecation:**
- Replaced with `streamable_http_client`. The new API takes an `httpx.AsyncClient` instead of raw `headers`/`timeout`/`auth` kwargs; `httpx.Timeout` maps both `timeout` and `sse_read_timeout` from `MCPHttpParams`
- Added `auth: httpx.Auth | None = None` to `MCPHttpParams` (was referenced via `hasattr` guard but never declared)
- Added `assert isinstance(self.config, MCPHttpParams)` in `_init_http` and `assert self.session is not None` in `list_tools`/`call_tool` for type narrowing

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

`prepare_tool` removal is technically a breaking change for any caller constructing `MCPToolNode` instances manually, but that was never part of the public API — `connect_mcp` → `server.tools` → `rt.call(ToolNode, **kwargs)` is the only documented path and is unaffected.

Verified end-to-end with the Filesystem MCP server: 14 tools discovered, all 11 exercised tool calls pass.
