### PR TITLE
Retrieval loader fixes: per-row Document IDs + JSONL support

### DIFF
--- a/docs/retrieval/components/ingestion/base.md
+++ b/docs/retrieval/components/ingestion/base.md
@@ -28,7 +28,7 @@ to something stable.
 |---|---|---|
 | `TextLoader` | `.txt`, `.md` files & directories | None |
 | `CSVLoader`  | `.csv` files & directories | None |
-| `JSONLoader` | `.json` files & directories | None |
+| `JSONLoader` | `.json` and `.jsonl` files & directories | None |
 | `PyPDFLoader` | `.pdf` files & directories (embedded text only) | `pip install "railtracks[pdf]"` |
 | `PyPDFOCRLoader` | `.pdf` files & directories with OCR fallback | `pip install "railtracks[ocr]"` + [Tesseract](https://pypi.org/project/pytesseract/) |
 | `HuggingFaceDatasetLoader` | Hugging Face Hub datasets (streaming) | `pip install "railtracks[huggingface]"` |

--- a/docs/retrieval/components/ingestion/methods.md
+++ b/docs/retrieval/components/ingestion/methods.md
@@ -12,7 +12,7 @@ none of these fit.
 |---|---|---|---|
 | `TextLoader` | `.txt` / `.md` files (or directories) | File | None |
 | `CSVLoader` | `.csv` files (or directories) | Row | None |
-| `JSONLoader` | `.json` files (or directories) | Top-level object | None |
+| `JSONLoader` | `.json` and `.jsonl` files (or directories) | Top-level object / one per line | None |
 | `PyPDFLoader` | PDFs with a text layer | Page (default) or whole file | `railtracks[pdf]` |
 | `PyPDFOCRLoader` | PDFs that include scanned images | Page (default) or whole file | `railtracks[ocr]` + Tesseract binary |
 | `HuggingFaceDatasetLoader` | Any dataset on the [HF Hub](https://huggingface.co/datasets) | Row | `railtracks[huggingface]` |
@@ -95,19 +95,32 @@ Additionally you can decide what you want to use as a _separator_ for merging co
 
 ## `JSONLoader`
 
-Reads `.json` files where the root is an object or array of objects.
-Each object becomes one `Document`.
+Handles two formats, picked by suffix:
+
+- `.json` — root is a single object or an array of objects.
+- `.jsonl` — one JSON object per line (blank lines skipped). Streamed
+  line by line, so reach for `.jsonl` whenever the corpus is larger
+  than memory.
+
+Each object — array element or JSONL line — becomes one `Document`.
 
 ```python
 --8<-- "docs/scripts/retrieval/ingestion_example.py:json_loader"
+```
+
+For `.jsonl`:
+
+```python
+--8<-- "docs/scripts/retrieval/ingestion_example.py:jsonl_loader"
 ```
 
 **Parameters**
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `file_path` | `str` | required | Path to a `.json` file or directory |
+| `file_path` | `str` | required | Path to a `.json` / `.jsonl` file, or a directory containing them |
 | `content_keys` | `list[str] | "*"` | `"*"` | Keys whose values form `content`. `"*"` serialises the whole object. |
+| `id_key` | `str | None` | `None` | Top-level key whose value is the per-object id in `Document.source`. Falls back to position (array index or JSONL line). |
 | `ignore_keys` | `list[str] | None` | `None` | Keys dropped entirely |
 | `content_separator` | `str` | `"\n"` | Used to join content-key values |
 | `encoding` | `str` | `"utf-8-sig"` | File encoding |

--- a/docs/retrieval/components/ingestion/methods.md
+++ b/docs/retrieval/components/ingestion/methods.md
@@ -224,6 +224,8 @@ needed image-based extraction.
 ---
 
 ## `HuggingFaceDatasetLoader`
+!!! warning "Early-exit hang with `HuggingFaceDatasetLoader`"
+    Breaking out of `astream()` before the dataset is exhausted may cause the Python process to hang at shutdown. This is an upstream parquet-streaming bug in [`datasets`](https://github.com/huggingface/datasets) on `pyarrow <= 24`, see [huggingface/datasets#8176](https://github.com/huggingface/datasets/pull/8176) (fixes [#8169](https://github.com/huggingface/datasets/issues/8169) and [#7467](https://github.com/huggingface/datasets/issues/7467)). Workaround: call `gc.collect()` after you stop iterating, or upgrade to a `pyarrow` release that ships the underlying [arrow#45214](https://github.com/apache/arrow/issues/45214) fix.
 
 Streams rows from any dataset on the [Hugging Face Hub](https://huggingface.co/datasets).
 One Document per row, fetched lazily.

--- a/docs/scripts/retrieval/ingestion_example.py
+++ b/docs/scripts/retrieval/ingestion_example.py
@@ -442,6 +442,23 @@ print(docs[0].metadata)  # {"author": "Alice", "index": 0}
 # --8<-- [end:json_loader]
 
 
+# --8<-- [start:jsonl_loader]
+
+from railtracks.retrieval.loaders import JSONLoader
+
+# JSONL: one JSON object per line. Streamed line by line — safe for
+# corpora larger than memory. Use id_key for stable Document IDs across
+# re-ingestion when objects may be reordered.
+async def jsonl_stream():
+    async for doc in JSONLoader(
+        "events.jsonl",
+        content_keys=["title", "body"],
+        id_key="_id",
+    ).astream():
+        print(doc.source)  # "events.jsonl#<_id>"
+# --8<-- [end:jsonl_loader]
+
+
 # --8<-- [start:custom_loader]
 from collections.abc import AsyncGenerator
 

--- a/docs/tutorials/notebooks/retrieval-benchmark.md
+++ b/docs/tutorials/notebooks/retrieval-benchmark.md
@@ -1,0 +1,27 @@
+For a walkthrough of benchmarking different options for building a knowledge base, visit the notebook below
+
+
+<div class="colab-card">
+
+
+  <div class="colab-card-content">
+    <div class="colab-card-title">
+      Retrieval on NFCorpus
+    </div>
+
+    <div class="colab-card-description">
+      Run this tutorial interactively in Google Colab.
+    </div>
+  </div>
+
+  <div class="colab-card-action">
+    <a
+      href="https://colab.research.google.com/drive/12sb5GmrW8KWYoNWX-j-Shjd2egptiYOa#scrollTo=7LYL1uC5QNIm"
+      target="_blank"
+      rel="noopener"
+      class="colab-button"
+    >
+      Open in Colab →
+    </a>
+  </div>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,6 +189,7 @@ nav:
           - Evaluation: tutorials/videos/evaluation.md
     - Notebooks:
       - Agent Architectures: tutorials/notebooks/architectures.md
+      - Retrieval Tutorial: tutorials/notebooks/retrieval-benchmark.md
       - FastAPI Integration: tutorials/notebooks/fastapi.md
       - File Embedding (RAG): tutorials/notebooks/file_embedding.md
     - Concepts:

--- a/packages/railtracks/src/railtracks/retrieval/loaders/cloud/_common.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/cloud/_common.py
@@ -9,6 +9,7 @@ _EXTENSION_TO_TYPE: dict[str, DocumentType] = {
     ".markdown": DocumentType.MARKDOWN,
     ".csv": DocumentType.CSV,
     ".json": DocumentType.JSON,
+    ".jsonl": DocumentType.JSONL,
     ".pdf": DocumentType.PDF,
     ".txt": DocumentType.TEXT,
 }

--- a/packages/railtracks/src/railtracks/retrieval/loaders/csv_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/csv_loader.py
@@ -25,12 +25,22 @@ class CSVLoader(BaseDocumentLoader):
     - `ignore_columns`: columns dropped entirely from both content and metadata.
     - Every remaining column (not in `content_columns`, not in
       `ignore_columns`) is added to `Document.metadata`.
+    - `Document.source` is set to `"{file_path}#{row_id}"`, where `row_id`
+      is `row[id_column]` when `id_column` is given and `row_index`
+      otherwise. Per-row sources keep `Document.id` stable and unique
+      across rows, which is what the runtime needs for upsert
+      (`delete_where` on `document_id`).
 
     Args:
         file_path: Path to a `.csv` file or a directory containing `.csv`
             files.
         content_columns: Ordered list of columns to concatenate into
             `Document.content`. Defaults to `None`, which uses all columns.
+        id_column: Column whose value uniquely identifies a row (e.g.
+            `"id"`, `"uuid"`). Used as the row id in `Document.source`.
+            Default: `None` (fall back to `row_index`). Prefer this when
+            the CSV has a stable id column and rows may be reordered —
+            `row_index` is only stable as long as the row order is.
         ignore_columns: Columns to drop entirely from both content and
             metadata.
         content_separator: String used to join multiple content-column values.
@@ -40,20 +50,22 @@ class CSVLoader(BaseDocumentLoader):
     Raises:
         FileNotFoundError: If `file_path` does not exist.
         ValueError: If `file_path` points to a file with an unsupported
-            extension, or any column in `content_columns` is not found in
-            the CSV headers.
+            extension, or any column in `content_columns` or `id_column`
+            is not found in the CSV headers.
     """
 
     def __init__(
         self,
         file_path: str,
         content_columns: list[str] | None = None,
+        id_column: str | None = None,
         ignore_columns: list[str] | None = None,
         content_separator: str = "\n",
         encoding: str = "utf-8-sig",
     ) -> None:
         self._path = Path(file_path)
         self._content_columns = content_columns
+        self._id_column = id_column
         self._ignore_columns = set(ignore_columns or [])
         self._content_separator = content_separator
         self._encoding = encoding
@@ -71,7 +83,7 @@ class CSVLoader(BaseDocumentLoader):
             ValueError: If any column in `content_columns` is not found in
                 the CSV headers.
         """
-        source = str(path)
+        source_prefix = str(path)
 
         def _iter_rows():
             with path.open(encoding=self._encoding, newline="") as f:
@@ -92,6 +104,10 @@ class CSVLoader(BaseDocumentLoader):
                     raise ValueError(
                         f"content_columns not found in CSV headers: {unknown}"
                     )
+                if self._id_column is not None and self._id_column not in fieldnames:
+                    raise ValueError(
+                        f"id_column not found in CSV headers: {self._id_column!r}"
+                    )
 
                 content_col_set = set(content_columns)
 
@@ -106,10 +122,15 @@ class CSVLoader(BaseDocumentLoader):
                         and col not in self._ignore_columns
                     }
                     metadata["row_index"] = row_index
+                    row_id = (
+                        str(row[self._id_column])
+                        if self._id_column is not None
+                        else str(row_index)
+                    )
                     yield Document(
                         content=content,
                         type=DocumentType.CSV,
-                        source=source,
+                        source=f"{source_prefix}#{row_id}",
                         metadata=metadata,
                     )
 

--- a/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
-from typing import Any
+import warnings
+from collections.abc import AsyncGenerator, Iterator
+from typing import Any, Final
 
 from railtracks.retrieval.loaders.base import BaseDocumentLoader
 from railtracks.retrieval.models import Document, DocumentType
 
 try:
-    from datasets import load_dataset
+    from datasets import IterableDataset, IterableDatasetDict, load_dataset
 except ImportError as exc:
     raise ImportError(
         "datasets is required for HuggingFaceDatasetLoader. "
@@ -17,7 +18,11 @@ except ImportError as exc:
 
 
 # asyncio.to_thread can't surface StopIteration across the thread boundary, so we use a sentinel default and stop when next() returns it.
-_SENTINEL: object = object()
+class _Missing:
+    pass
+
+
+_SENTINEL: Final[_Missing] = _Missing()
 
 
 class HuggingFaceDatasetLoader(BaseDocumentLoader):
@@ -32,7 +37,11 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
     - `metadata_columns`: copied into `Document.metadata` as-is.
     - `row_index` is added to metadata automatically (0-based position
       within the split).
-    - `Document.source` is set to `"{dataset_name}/{split}"`.
+    - `Document.source` is set to `"{dataset_name}/{split}#{row_id}"`,
+      where `row_id` is `row[id_column]` when `id_column` is given and
+      `row_index` otherwise. Per-row sources keep `Document.id` stable
+      and unique across rows, which is what the runtime needs for
+      upsert (`delete_where` on `document_id`).
 
     Args:
         dataset_name: Dataset name on the Hugging Face Hub
@@ -40,6 +49,12 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         split: Which split to stream (`"train"`, `"validation"`, etc.).
         content_columns: Columns whose values get joined into
             `Document.content`.
+        id_column: Column whose value uniquely identifies a row (e.g.
+            `"id"`, `"qid"`, `"_id"`). Used as the row id in
+            `Document.source`. Default: None (fall back to `row_index`).
+            Prefer this when the dataset exposes a stable id and may be
+            re-shuffled upstream — `row_index` is only stable as long as
+            the dataset order is.
         metadata_columns: Columns to copy into `Document.metadata`.
             Default : None.
         content_separator: Separator used to join `content_columns`
@@ -47,13 +62,13 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         dataset_kwargs: Extra keyword arguments forwarded to
             `datasets.load_dataset`. Use this for subset selection
             (`{"name": "v2.1"}`), pinning a revision, or passing an
-            auth token. `streaming=True` is set by default and can be
-            overridden here.
+            auth token. `streaming=True` is always set; any `streaming`
+            entry here is ignored.
 
     Raises:
         ValueError: If `content_columns` is empty, or if any name in
-            `content_columns` or `metadata_columns` isn't present in the
-            dataset schema.
+            `content_columns`, `metadata_columns`, or `id_column` isn't
+            present in the dataset schema.
     """
 
     def __init__(
@@ -61,6 +76,7 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         dataset_name: str,
         split: str,
         content_columns: list[str],
+        id_column: str | None = None,
         metadata_columns: list[str] | None = None,
         content_separator: str = "\n",
         dataset_kwargs: dict[str, Any] | None = None,
@@ -70,6 +86,7 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         self._dataset_name = dataset_name
         self._split = split
         self._content_columns = list(content_columns)
+        self._id_column = id_column
         self._metadata_columns = list(metadata_columns or [])
         self._content_separator = content_separator
         self._dataset_kwargs = dict(dataset_kwargs or {})
@@ -89,19 +106,32 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                 `metadata_columns` isn't present in the dataset schema.
         """
         kwargs = dict(self._dataset_kwargs)
-        kwargs.setdefault("streaming", True)
+        if kwargs.pop("streaming", None) is not None:
+            warnings.warn(
+                "`streaming` in dataset_kwargs is ignored; "
+                "HuggingFaceDatasetLoader always streams.",
+                stacklevel=2,
+            )
         kwargs["split"] = self._split
 
-        dataset = await asyncio.to_thread(load_dataset, self._dataset_name, **kwargs)
+        dataset: IterableDataset | IterableDatasetDict = await asyncio.to_thread(
+            load_dataset, self._dataset_name, streaming=True, **kwargs
+        )
+        if isinstance(dataset, IterableDatasetDict):
+            if self._split not in dataset:
+                raise ValueError(
+                    f"Split {self._split!r} not found in dataset {self._dataset_name!r}"
+                )
+            dataset = dataset[self._split]
 
-        iterator = iter(dataset)
-        source = f"{self._dataset_name}/{self._split}"
+        iterator: Iterator[dict[str, Any]] = iter(dataset)
+        source_prefix = f"{self._dataset_name}/{self._split}"
         validated = False
         row_index = 0
 
         while True:
             row = await asyncio.to_thread(next, iterator, _SENTINEL)
-            if row is _SENTINEL:
+            if isinstance(row, _Missing):
                 return
 
             if not validated:
@@ -115,6 +145,10 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                     raise ValueError(
                         f"metadata_columns not found in dataset schema: {missing_metadata}"
                     )
+                if self._id_column is not None and self._id_column not in row:
+                    raise ValueError(
+                        f"id_column not found in dataset schema: {self._id_column!r}"
+                    )
                 validated = True
 
             content = self._content_separator.join(
@@ -123,10 +157,16 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
             metadata: dict[str, Any] = {col: row[col] for col in self._metadata_columns}
             metadata["row_index"] = row_index
 
+            row_id = (
+                str(row[self._id_column])
+                if self._id_column is not None
+                else str(row_index)
+            )
+
             yield Document(
                 content=content,
                 type=DocumentType.TEXT,
-                source=source,
+                source=f"{source_prefix}#{row_id}",
                 metadata=metadata,
             )
             row_index += 1

--- a/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
@@ -11,14 +11,18 @@ from railtracks.retrieval.models import Document, DocumentType
 
 
 class JSONLoader(BaseDocumentLoader):
-    """Loads JSON files as `Document` objects.
+    """Loads JSON and JSON Lines files as `Document` objects.
 
-    If `file_path` points to a directory, all `.json` files are loaded
-    recursively in sorted order. If it points to a file, that file is loaded.
+    If `file_path` points to a directory, all `.json` and `.jsonl` files are
+    loaded recursively in sorted order. If it points to a file, that file is
+    loaded; the format is selected by suffix.
 
-    Each file must contain either a JSON object or a JSON array of objects.
-    For arrays, each element becomes a separate `Document`. For a single
-    object, one `Document` is produced.
+    - `.json`: the file root must be a JSON object or an array of objects.
+      For arrays, each element becomes a separate `Document`; for a single
+      object, one `Document` is produced.
+    - `.jsonl`: each non-empty line must be a JSON object; one `Document` per
+      object. Blank lines are skipped. The file is streamed line by line, so
+      JSONL is the preferred format for corpora larger than memory.
 
     `Document.source` is set to `"{file_path}#{obj_id}"`, where `obj_id`
     is `obj[id_key]` when `id_key` is given and the object's position in
@@ -27,8 +31,8 @@ class JSONLoader(BaseDocumentLoader):
     (`delete_where` on `document_id`).
 
     Args:
-        file_path: Path to a `.json` file or a directory containing `.json`
-            files.
+        file_path: Path to a `.json` / `.jsonl` file, or a directory
+            containing them.
         content_keys: Keys whose values are concatenated to form
             `Document.content`. Use `"*"` (default) to serialise the entire
             object as content. Pass an explicit list to control which fields
@@ -39,7 +43,7 @@ class JSONLoader(BaseDocumentLoader):
             `Document.source`. Default: `None` (fall back to the object's
             position in the file). Prefer this when the JSON has a stable
             id field and objects may be reordered — position is only
-            stable as long as the array order is.
+            stable as long as the order is.
         ignore_keys: Keys to drop entirely from both content and metadata.
         content_separator: String used to join multiple content-key values.
             Defaults to `"\\n"`.
@@ -48,9 +52,11 @@ class JSONLoader(BaseDocumentLoader):
     Raises:
         FileNotFoundError: If `file_path` does not exist.
         ValueError: If `file_path` points to a file with an unsupported
-            extension, the JSON structure is not an object or array of
-            objects, or any key in `content_keys` or `id_key` is not
-            found in a parsed object.
+            extension, the JSON/JSONL structure does not match the format
+            (e.g. a `.json` file that is neither object nor array of
+            objects, or a `.jsonl` line that is not a JSON object), or any
+            key in `content_keys` or `id_key` is not found in a parsed
+            object.
     """
 
     def __init__(
@@ -70,7 +76,11 @@ class JSONLoader(BaseDocumentLoader):
         self._encoding = encoding
 
     def _object_to_document(
-        self, obj: dict[str, Any], source_prefix: str, index: int
+        self,
+        obj: dict[str, Any],
+        source_prefix: str,
+        index: int,
+        doc_type: DocumentType = DocumentType.JSON,
     ) -> Document:
         """Convert a single JSON object to a `Document`.
 
@@ -119,26 +129,32 @@ class JSONLoader(BaseDocumentLoader):
         metadata["index"] = index
         return Document(
             content=content,
-            type=DocumentType.JSON,
+            type=doc_type,
             source=f"{source_prefix}#{obj_id}",
             metadata=metadata,
         )
 
     async def _stream_file(self, path: Path) -> AsyncGenerator[Document, None]:
-        """Stream documents from a single JSON file.
+        """Stream documents from a single JSON or JSONL file.
 
-        Parses the file in a thread, then yields one `Document` per object.
+        Dispatches by suffix: `.jsonl` is streamed line by line; `.json`
+        is parsed whole. One `Document` per object is yielded.
 
         Args:
-            path: Path to the JSON file to read.
+            path: Path to the JSON or JSONL file to read.
 
         Yields:
             Document: The next converted document.
 
         Raises:
-            ValueError: If the file does not contain an object or array of
-                objects.
+            ValueError: If a `.json` file does not contain an object or
+                array of objects, or a `.jsonl` line is not a JSON object.
         """
+        if path.suffix.lower() == ".jsonl":
+            async for doc in self._stream_jsonl(path):
+                yield doc
+            return
+
         source_prefix = str(path)
         raw = await asyncio.to_thread(
             lambda: json.loads(path.read_text(encoding=self._encoding))
@@ -156,6 +172,48 @@ class JSONLoader(BaseDocumentLoader):
         for i, obj in enumerate(objects):
             yield self._object_to_document(obj, source_prefix, i)
 
+    async def _stream_jsonl(self, path: Path) -> AsyncGenerator[Document, None]:
+        """Stream documents from a single JSONL file, one object per line.
+
+        Reads and parses the file line by line in a worker thread so the
+        event loop is not blocked and the full file is never held in
+        memory. Blank lines are skipped; the `index` exposed in
+        `Document.metadata` counts only parsed objects, not raw lines.
+
+        Args:
+            path: Path to the JSONL file to read.
+
+        Yields:
+            Document: The next converted document.
+
+        Raises:
+            ValueError: If any non-empty line is not a JSON object.
+        """
+        source_prefix = str(path)
+        f = await asyncio.to_thread(lambda: path.open(encoding=self._encoding))
+        try:
+            index = 0
+            line_no = 0
+            while True:
+                raw_line = await asyncio.to_thread(f.readline)
+                if not raw_line:
+                    break
+                line_no += 1
+                stripped = raw_line.strip()
+                if not stripped:
+                    continue
+                obj = json.loads(stripped)
+                if not isinstance(obj, dict):
+                    raise ValueError(
+                        f"JSONL line must be a JSON object: line {line_no} in {path}"
+                    )
+                yield self._object_to_document(
+                    obj, source_prefix, index, DocumentType.JSONL
+                )
+                index += 1
+        finally:
+            await asyncio.to_thread(f.close)
+
     async def astream(self) -> AsyncGenerator[Document, None]:
         """Stream documents one at a time as each JSON object is parsed.
 
@@ -172,17 +230,22 @@ class JSONLoader(BaseDocumentLoader):
                 extension.
         """
         if self._path.is_dir():
-            for path in sorted(self._path.rglob("*.json")):
-                if path.is_file():
-                    async for doc in self._stream_file(path):
-                        yield doc
+            paths = sorted(
+                p
+                for pattern in ("*.json", "*.jsonl")
+                for p in self._path.rglob(pattern)
+                if p.is_file()
+            )
+            for path in paths:
+                async for doc in self._stream_file(path):
+                    yield doc
             return
 
         if not self._path.is_file():
             raise FileNotFoundError(f"File not found: {self._path}")
-        if self._path.suffix.lower() != ".json":
+        if self._path.suffix.lower() not in (".json", ".jsonl"):
             raise ValueError(
-                f"JSONLoader expects a .json file, got {self._path.suffix!r}"
+                f"JSONLoader expects a .json or .jsonl file, got {self._path.suffix!r}"
             )
 
         async for doc in self._stream_file(self._path):

--- a/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
@@ -20,6 +20,12 @@ class JSONLoader(BaseDocumentLoader):
     For arrays, each element becomes a separate `Document`. For a single
     object, one `Document` is produced.
 
+    `Document.source` is set to `"{file_path}#{obj_id}"`, where `obj_id`
+    is `obj[id_key]` when `id_key` is given and the object's position in
+    the file otherwise. Per-object sources keep `Document.id` stable and
+    unique across objects, which is what the runtime needs for upsert
+    (`delete_where` on `document_id`).
+
     Args:
         file_path: Path to a `.json` file or a directory containing `.json`
             files.
@@ -28,6 +34,12 @@ class JSONLoader(BaseDocumentLoader):
             object as content. Pass an explicit list to control which fields
             become content — all remaining non-ignored fields are added to
             `Document.metadata`.
+        id_key: Top-level key whose value uniquely identifies an object
+            (e.g. `"id"`, `"_id"`). Used as the object id in
+            `Document.source`. Default: `None` (fall back to the object's
+            position in the file). Prefer this when the JSON has a stable
+            id field and objects may be reordered — position is only
+            stable as long as the array order is.
         ignore_keys: Keys to drop entirely from both content and metadata.
         content_separator: String used to join multiple content-key values.
             Defaults to `"\\n"`.
@@ -37,32 +49,35 @@ class JSONLoader(BaseDocumentLoader):
         FileNotFoundError: If `file_path` does not exist.
         ValueError: If `file_path` points to a file with an unsupported
             extension, the JSON structure is not an object or array of
-            objects, or any key in `content_keys` is not found in a parsed
-            object.
+            objects, or any key in `content_keys` or `id_key` is not
+            found in a parsed object.
     """
 
     def __init__(
         self,
         file_path: str,
         content_keys: list[str] | Literal["*"] = "*",
+        id_key: str | None = None,
         ignore_keys: list[str] | None = None,
         content_separator: str = "\n",
         encoding: str = "utf-8-sig",
     ) -> None:
         self._path = Path(file_path)
         self._content_keys = content_keys
+        self._id_key = id_key
         self._ignore_keys = set(ignore_keys or [])
         self._content_separator = content_separator
         self._encoding = encoding
 
     def _object_to_document(
-        self, obj: dict[str, Any], source: str, index: int
+        self, obj: dict[str, Any], source_prefix: str, index: int
     ) -> Document:
         """Convert a single JSON object to a `Document`.
 
         Args:
             obj: The parsed JSON object.
-            source: The source file path, included in the returned `Document`.
+            source_prefix: The source file path; the returned `Document.source`
+                appends a per-object id suffix.
             index: The zero-based position of this object in the source file,
                 added to `Document.metadata`.
 
@@ -70,7 +85,8 @@ class JSONLoader(BaseDocumentLoader):
             Document: The converted document.
 
         Raises:
-            ValueError: If any key in `content_keys` is not present in `obj`.
+            ValueError: If any key in `content_keys` or `id_key` is not
+                present in `obj`.
         """
         if self._content_keys == "*":
             content = json.dumps(
@@ -82,7 +98,7 @@ class JSONLoader(BaseDocumentLoader):
             unknown = [k for k in self._content_keys if k not in obj]
             if unknown:
                 raise ValueError(
-                    f"content_keys {unknown} not found in object at index {index} in {source}"
+                    f"content_keys {unknown} not found in object at index {index} in {source_prefix}"
                 )
             content = self._content_separator.join(
                 f"{k}: {obj[k]}" for k in self._content_keys
@@ -94,11 +110,17 @@ class JSONLoader(BaseDocumentLoader):
                 if k not in content_key_set and k not in self._ignore_keys
             }
 
+        if self._id_key is not None and self._id_key not in obj:
+            raise ValueError(
+                f"id_key {self._id_key!r} not found in object at index {index} in {source_prefix}"
+            )
+        obj_id = str(obj[self._id_key]) if self._id_key is not None else str(index)
+
         metadata["index"] = index
         return Document(
             content=content,
             type=DocumentType.JSON,
-            source=source,
+            source=f"{source_prefix}#{obj_id}",
             metadata=metadata,
         )
 
@@ -117,7 +139,7 @@ class JSONLoader(BaseDocumentLoader):
             ValueError: If the file does not contain an object or array of
                 objects.
         """
-        source = str(path)
+        source_prefix = str(path)
         raw = await asyncio.to_thread(
             lambda: json.loads(path.read_text(encoding=self._encoding))
         )
@@ -132,7 +154,7 @@ class JSONLoader(BaseDocumentLoader):
             )
 
         for i, obj in enumerate(objects):
-            yield self._object_to_document(obj, source, i)
+            yield self._object_to_document(obj, source_prefix, i)
 
     async def astream(self) -> AsyncGenerator[Document, None]:
         """Stream documents one at a time as each JSON object is parsed.

--- a/packages/railtracks/src/railtracks/retrieval/models.py
+++ b/packages/railtracks/src/railtracks/retrieval/models.py
@@ -17,6 +17,7 @@ class DocumentType(str, Enum):
     PDF = "pdf"
     CSV = "csv"
     JSON = "json"
+    JSONL = "jsonl"
 
 
 @dataclass

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/conftest.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/conftest.py
@@ -62,6 +62,35 @@ def json_dir(tmp_path):
 
 
 @pytest.fixture
+def jsonl_file(tmp_path):
+    """A .jsonl file with three objects and one blank line in the middle."""
+    f = tmp_path / "data.jsonl"
+    f.write_text(
+        "\n".join([
+            json.dumps({"title": "First", "body": "Content 1"}),
+            "",
+            json.dumps({"title": "Second", "body": "Content 2"}),
+            json.dumps({"title": "Third", "body": "Content 3"}),
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    return f
+
+
+@pytest.fixture
+def jsonl_dir(tmp_path):
+    """Directory with a .json file and a .jsonl file in known sorted order."""
+    (tmp_path / "a.json").write_text(
+        json.dumps({"key": "val_a"}), encoding="utf-8"
+    )
+    (tmp_path / "b.jsonl").write_text(
+        json.dumps({"key": "val_b1"}) + "\n" + json.dumps({"key": "val_b2"}) + "\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+@pytest.fixture
 def csv_file(tmp_path):
     """A simple .csv file with headers and two data rows."""
     f = tmp_path / "data.csv"

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_csv_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_csv_loader.py
@@ -16,10 +16,18 @@ class TestCSVLoaderBasic:
         docs = await CSVLoader(str(csv_file)).aload()
         assert all(d.type == DocumentType.CSV for d in docs)
 
-    async def test_source_is_file_path(self, csv_file):
-        """Document source is the absolute file path."""
+    async def test_source_includes_row_index_suffix(self, csv_file):
+        """Document source is the file path plus a per-row suffix."""
         docs = await CSVLoader(str(csv_file)).aload()
-        assert all(d.source == str(csv_file) for d in docs)
+        assert [d.source for d in docs] == [
+            f"{csv_file}#0",
+            f"{csv_file}#1",
+        ]
+
+    async def test_document_ids_are_unique_per_row(self, csv_file):
+        """Per-row sources produce distinct Document IDs (upsert correctness)."""
+        docs = await CSVLoader(str(csv_file)).aload()
+        assert len({d.id for d in docs}) == len(docs)
 
     async def test_default_content_includes_all_columns(self, csv_file):
         """Without content_columns, all columns appear in content."""
@@ -72,6 +80,37 @@ class TestCSVLoaderContentColumns:
         """A content_column that does not exist in the CSV raises ValueError."""
         loader = CSVLoader(str(csv_file), content_columns=["nonexistent"])
         with pytest.raises(ValueError, match="content_columns not found in CSV headers"):
+            await loader.aload()
+
+
+class TestCSVLoaderIdColumn:
+    """Tests for the id_column parameter (per-row source identity)."""
+
+    async def test_id_column_used_in_source(self, tmp_path):
+        """When id_column is set, its value becomes the source suffix."""
+        f = tmp_path / "with_id.csv"
+        f.write_text("id,name\nr1,Alice\nr2,Bob\n", encoding="utf-8")
+        docs = await CSVLoader(str(f), id_column="id").aload()
+        assert [d.source for d in docs] == [f"{f}#r1", f"{f}#r2"]
+
+    async def test_id_column_keeps_ids_stable_across_reorder(self, tmp_path):
+        """Same id_column value → same Document.id when the same file is re-loaded
+        with rows reordered. This is the upsert-correctness contract."""
+        f = tmp_path / "data.csv"
+        f.write_text("id,name\nr1,Alice\nr2,Bob\n", encoding="utf-8")
+        docs1 = await CSVLoader(str(f), id_column="id").aload()
+
+        f.write_text("id,name\nr2,Bob\nr1,Alice\n", encoding="utf-8")
+        docs2 = await CSVLoader(str(f), id_column="id").aload()
+
+        by_id_1 = {d.source.rsplit("#", 1)[1]: d.id for d in docs1}
+        by_id_2 = {d.source.rsplit("#", 1)[1]: d.id for d in docs2}
+        assert by_id_1 == by_id_2
+
+    async def test_unknown_id_column_raises_value_error(self, csv_file):
+        """An id_column not present in the CSV headers raises ValueError."""
+        loader = CSVLoader(str(csv_file), id_column="nonexistent")
+        with pytest.raises(ValueError, match="id_column not found in CSV headers"):
             await loader.aload()
 
 

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
@@ -29,9 +29,9 @@ class _FakeIterableDataset:
 @pytest.fixture
 def fake_rows() -> list[dict]:
     return [
-        {"query": "what is rag", "passage": "Retrieval-augmented generation.", "label": 1, "topic": "ml"},
-        {"query": "what is bm25", "passage": "BM25 is a ranking function.", "label": 0, "topic": "ir"},
-        {"query": "what is dpr", "passage": "Dense passage retrieval.", "label": 1, "topic": "ir"},
+        {"qid": "q1", "query": "what is rag", "passage": "Retrieval-augmented generation.", "label": 1, "topic": "ml"},
+        {"qid": "q2", "query": "what is bm25", "passage": "BM25 is a ranking function.", "label": 0, "topic": "ir"},
+        {"qid": "q3", "query": "what is dpr", "passage": "Dense passage retrieval.", "label": 1, "topic": "ir"},
     ]
 
 
@@ -64,11 +64,33 @@ class TestHuggingFaceLoaderBasic:
         ).aload()
         assert all(d.type == DocumentType.TEXT for d in docs)
 
-    async def test_source_is_dataset_name_and_split(self, mock_load_dataset):
+    async def test_source_defaults_to_row_index_suffix(self, mock_load_dataset, fake_rows):
         docs = await HuggingFaceDatasetLoader(
             "fake/ds", split="validation", content_columns=["query"]
         ).aload()
-        assert all(d.source == "fake/ds/validation" for d in docs)
+        assert [d.source for d in docs] == [
+            f"fake/ds/validation#{i}" for i in range(len(fake_rows))
+        ]
+
+    async def test_document_ids_are_unique_per_row(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"]
+        ).aload()
+        assert len({d.id for d in docs}) == len(docs)
+
+    async def test_id_column_used_in_source_when_provided(self, mock_load_dataset, fake_rows):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"], id_column="qid"
+        ).aload()
+        assert [d.source for d in docs] == [
+            f"fake/ds/train#{r['qid']}" for r in fake_rows
+        ]
+
+    async def test_non_string_id_column_values_are_stringified(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds", split="train", content_columns=["query"], id_column="label"
+        ).aload()
+        assert docs[0].source == "fake/ds/train#1"
 
     async def test_row_index_in_metadata(self, mock_load_dataset, fake_rows):
         docs = await HuggingFaceDatasetLoader(
@@ -158,6 +180,18 @@ class TestHuggingFaceLoaderValidation:
         ):
             await loader.aload()
 
+    async def test_unknown_id_column_raises_value_error(self, mock_load_dataset):
+        loader = HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            id_column="does_not_exist",
+        )
+        with pytest.raises(
+            ValueError, match="id_column not found in dataset schema"
+        ):
+            await loader.aload()
+
 
 class TestHuggingFaceLoaderStreaming:
     """Laziness guarantees and ``load_dataset`` call shape."""
@@ -196,15 +230,16 @@ class TestHuggingFaceLoaderStreaming:
         assert kwargs["name"] == "v2.1"
         assert kwargs["revision"] == "abc"
 
-    async def test_dataset_kwargs_can_override_streaming(self, mock_load_dataset):
-        await HuggingFaceDatasetLoader(
-            "fake/ds",
-            split="train",
-            content_columns=["query"],
-            dataset_kwargs={"streaming": False},
-        ).aload()
+    async def test_dataset_kwargs_streaming_override_is_ignored(self, mock_load_dataset):
+        with pytest.warns(UserWarning, match="streaming.*ignored"):
+            await HuggingFaceDatasetLoader(
+                "fake/ds",
+                split="train",
+                content_columns=["query"],
+                dataset_kwargs={"streaming": False},
+            ).aload()
         _, kwargs = mock_load_dataset.call_args
-        assert kwargs["streaming"] is False
+        assert kwargs["streaming"] is True
 
 
 class TestHuggingFaceLoaderSyncWrapper:

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
@@ -184,6 +184,70 @@ class TestJSONLoaderIgnoreKeys:
         assert "score" not in docs[0].metadata
 
 
+class TestJSONLoaderJSONL:
+    """Tests for JSONLoader with `.jsonl` (JSON Lines) files."""
+
+    async def test_jsonl_yields_one_document_per_line(self, jsonl_file):
+        """Each non-empty line produces exactly one Document."""
+        docs = await JSONLoader(str(jsonl_file)).aload()
+        assert len(docs) == 3
+
+    async def test_jsonl_blank_lines_are_skipped(self, jsonl_file):
+        """Blank lines do not produce empty Documents or shift indices."""
+        docs = await JSONLoader(str(jsonl_file), content_keys=["title"]).aload()
+        assert [d.metadata["index"] for d in docs] == [0, 1, 2]
+        assert "First" in docs[0].content
+        assert "Second" in docs[1].content
+        assert "Third" in docs[2].content
+
+    async def test_jsonl_source_uses_object_index(self, jsonl_file):
+        """Source suffix counts parsed objects (blanks don't bump the index)."""
+        docs = await JSONLoader(str(jsonl_file)).aload()
+        assert [d.source for d in docs] == [
+            f"{jsonl_file}#0",
+            f"{jsonl_file}#1",
+            f"{jsonl_file}#2",
+        ]
+
+    async def test_jsonl_document_type(self, jsonl_file):
+        """Document type is JSONL for `.jsonl` lines."""
+        docs = await JSONLoader(str(jsonl_file)).aload()
+        assert all(d.type == DocumentType.JSONL for d in docs)
+
+    async def test_jsonl_id_key_used_in_source(self, tmp_path):
+        """When id_key is set, its value becomes the source suffix per line."""
+        f = tmp_path / "data.jsonl"
+        f.write_text(
+            json.dumps({"_id": "a1", "body": "x"}) + "\n"
+            + json.dumps({"_id": "a2", "body": "y"}) + "\n",
+            encoding="utf-8",
+        )
+        docs = await JSONLoader(str(f), id_key="_id").aload()
+        assert [d.source for d in docs] == [f"{f}#a1", f"{f}#a2"]
+
+    async def test_jsonl_non_object_line_raises_value_error(self, tmp_path):
+        """A line that parses to a non-object (e.g. an array) raises."""
+        f = tmp_path / "bad.jsonl"
+        f.write_text(
+            json.dumps({"ok": 1}) + "\n" + json.dumps([1, 2, 3]) + "\n",
+            encoding="utf-8",
+        )
+        loader = JSONLoader(str(f))
+        with pytest.raises(ValueError, match="JSONL line must be a JSON object"):
+            await loader.aload()
+
+    async def test_jsonl_invalid_line_raises(self, tmp_path):
+        """A line that is not valid JSON raises (propagated from json.loads)."""
+        f = tmp_path / "broken.jsonl"
+        f.write_text(
+            json.dumps({"ok": 1}) + "\nnot json\n",
+            encoding="utf-8",
+        )
+        loader = JSONLoader(str(f))
+        with pytest.raises(json.JSONDecodeError):
+            await loader.aload()
+
+
 class TestJSONLoaderDirectory:
     """Tests for JSONLoader loading a directory."""
 
@@ -197,6 +261,20 @@ class TestJSONLoaderDirectory:
         docs = await JSONLoader(str(json_dir), content_keys=["key"]).aload()
         assert "val_a" in docs[0].content
         assert "val_b" in docs[1].content
+
+    async def test_directory_loads_json_and_jsonl_together(self, jsonl_dir):
+        """A directory mixing .json and .jsonl files loads both, sorted, and
+        each Document carries the right type for its source file."""
+        docs = await JSONLoader(str(jsonl_dir), content_keys=["key"]).aload()
+        assert len(docs) == 3
+        assert "val_a" in docs[0].content
+        assert "val_b1" in docs[1].content
+        assert "val_b2" in docs[2].content
+        assert [d.type for d in docs] == [
+            DocumentType.JSON,
+            DocumentType.JSONL,
+            DocumentType.JSONL,
+        ]
 
     async def test_empty_directory_returns_empty_list(self, tmp_path):
         """An empty directory yields no documents."""
@@ -214,11 +292,13 @@ class TestJSONLoaderErrors:
             await loader.aload()
 
     async def test_unsupported_extension_raises_value_error(self, tmp_path):
-        """A file with a non-.json extension raises ValueError."""
+        """A file with a non-.json/.jsonl extension raises ValueError."""
         f = tmp_path / "data.txt"
         f.write_text("{}", encoding="utf-8")
         loader = JSONLoader(str(f))
-        with pytest.raises(ValueError, match="JSONLoader expects a .json file"):
+        with pytest.raises(
+            ValueError, match="JSONLoader expects a .json or .jsonl file"
+        ):
             await loader.aload()
 
     async def test_array_of_scalars_raises_value_error(self, tmp_path):

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
@@ -25,10 +25,10 @@ class TestJSONLoaderSingleObject:
         docs = await JSONLoader(str(json_object_file)).aload()
         assert docs[0].type == DocumentType.JSON
 
-    async def test_single_object_source_is_file_path(self, json_object_file):
-        """Document source is the absolute file path."""
+    async def test_single_object_source_includes_index_suffix(self, json_object_file):
+        """Document source is the file path plus the object's index."""
         docs = await JSONLoader(str(json_object_file)).aload()
-        assert docs[0].source == str(json_object_file)
+        assert docs[0].source == f"{json_object_file}#0"
 
     async def test_single_object_index_zero_in_metadata(self, json_object_file):
         """The object's index (0) is stored in metadata."""
@@ -55,6 +55,19 @@ class TestJSONLoaderArray:
         docs = await JSONLoader(str(json_array_file), content_keys=["title"]).aload()
         assert "First" in docs[0].content
         assert "Second" in docs[1].content
+
+    async def test_array_source_includes_index_suffix(self, json_array_file):
+        """Each Document's source carries its array index suffix."""
+        docs = await JSONLoader(str(json_array_file)).aload()
+        assert [d.source for d in docs] == [
+            f"{json_array_file}#0",
+            f"{json_array_file}#1",
+        ]
+
+    async def test_array_document_ids_are_unique_per_object(self, json_array_file):
+        """Per-object sources produce distinct Document IDs (upsert correctness)."""
+        docs = await JSONLoader(str(json_array_file)).aload()
+        assert len({d.id for d in docs}) == len(docs)
 
 
 class TestJSONLoaderContentKeys:
@@ -96,6 +109,57 @@ class TestJSONLoaderContentKeys:
         """A content_key not present in the object raises ValueError."""
         loader = JSONLoader(str(json_object_file), content_keys=["nonexistent"])
         with pytest.raises(ValueError, match="not found in object"):
+            await loader.aload()
+
+
+class TestJSONLoaderIdKey:
+    """Tests for the id_key parameter (per-object source identity)."""
+
+    async def test_id_key_used_in_source(self, tmp_path):
+        """When id_key is set, its value becomes the source suffix."""
+        f = tmp_path / "with_id.json"
+        f.write_text(
+            json.dumps([
+                {"_id": "a1", "body": "first"},
+                {"_id": "a2", "body": "second"},
+            ]),
+            encoding="utf-8",
+        )
+        docs = await JSONLoader(str(f), id_key="_id").aload()
+        assert [d.source for d in docs] == [f"{f}#a1", f"{f}#a2"]
+
+    async def test_id_key_keeps_ids_stable_across_reorder(self, tmp_path):
+        """Same id_key value → same Document.id when the same file is re-loaded
+        with objects reordered. This is the upsert-correctness contract."""
+        f = tmp_path / "data.json"
+        f.write_text(
+            json.dumps([{"_id": "a1", "body": "x"}, {"_id": "a2", "body": "y"}]),
+            encoding="utf-8",
+        )
+        docs1 = await JSONLoader(str(f), id_key="_id").aload()
+
+        f.write_text(
+            json.dumps([{"_id": "a2", "body": "y"}, {"_id": "a1", "body": "x"}]),
+            encoding="utf-8",
+        )
+        docs2 = await JSONLoader(str(f), id_key="_id").aload()
+
+        by_id_1 = {d.source.rsplit("#", 1)[1]: d.id for d in docs1}
+        by_id_2 = {d.source.rsplit("#", 1)[1]: d.id for d in docs2}
+        assert by_id_1 == by_id_2
+
+    async def test_missing_id_key_raises_per_object(self, tmp_path):
+        """id_key validation runs per object: raise when any object lacks the key."""
+        f = tmp_path / "mixed.json"
+        f.write_text(
+            json.dumps([
+                {"_id": "a1", "body": "ok"},
+                {"body": "missing-id"},
+            ]),
+            encoding="utf-8",
+        )
+        loader = JSONLoader(str(f), id_key="_id")
+        with pytest.raises(ValueError, match="id_key '_id' not found in object at index 1"):
             await loader.aload()
 
 


### PR DESCRIPTION
## Summary

- **Per-row Document IDs for row-based loaders.** `CSVLoader`, `JSONLoader`, and `HuggingFaceDatasetLoader` previously set `Document.source` to the file/dataset path, so every row in a file produced the same `Document.id` breaking upsert (`delete_where` on `document_id`). Source is now `"{path}#{row_id}"`, where `row_id` comes from a new `id_column` / `id_key` parameter, falling back to the row's positional index.
- **JSONL support in `JSONLoader`.** `.json` and `.jsonl` are both accepted (single file or directory). JSONL is parsed line by line in a worker thread, so corpora larger than memory stream cleanly. New `DocumentType.JSONL` and `.jsonl → JSONL` mapping in the cloud loader common table.
- **`HuggingFaceDatasetLoader` cleanup.** `streaming=True` is now always set (warns if passed via `dataset_kwargs`); `IterableDatasetDict` is unwrapped to the requested split with a clear error if missing; sentinel is a typed class so `isinstance` checks don't snag on dict rows. Docs gain a warning about the upstream `datasets`/`pyarrow` early-exit hang ([huggingface/datasets#8176](https://github.com/huggingface/datasets/pull/8176)) with the `gc.collect()` workaround.
- **Docs + examples** updated for JSONL and the new id parameter plus a new notebook in the tutorials.

## Test plan

- [ ] `pytest packages/railtracks/tests/unit_tests/retrieval/loaders/` passes
- [ ] Ingest a CSV/JSON/HF dataset twice with `id_column` set; confirm upsert replaces rows instead of duplicating
- [ ] Ingest a `.jsonl` file larger than RAM; confirm streaming (no OOM) and per-line `Document.source` suffix
- [ ] Ingest a directory mixing `.json` and `.jsonl`; confirm both are picked up
