### PR TITLE
pooria/chroma cloud support

### DIFF
--- a/docs/retrieval/components/stores/backends.md
+++ b/docs/retrieval/components/stores/backends.md
@@ -22,9 +22,9 @@ all of them. The choice is about where you want the index to live.
 
 ## Initialization
 
-`ChromaBackend` and `PgvectorBackend` must be initialised before use.
-Both expose an async `create(...)` factory that constructs and initialises
-in one call. 
+`ChromaBackend`, `ChromaCloudBackend`, and `PgvectorBackend` must be
+initialised before use. All three expose an async `create(...)` factory
+that constructs and initialises in one call.
 
 **Prefer `create()`** over manual `__init__` + `initialize()`:
 
@@ -96,7 +96,7 @@ outgrown this backend.
 
 Backend powered by [Chroma](https://www.trychroma.com/). Supports
 ephemeral (in-process), persistent (on-disk), and HTTP (remote server)
-client modes.
+client modes. For Chroma Cloud, use [`ChromaCloudBackend`](#chromacloudbackend).
 
 ```bash
 pip install "railtracks[stores-chroma]"
@@ -138,10 +138,58 @@ changed later**. Pick at create time:
 | Install | `pip install "railtracks[stores-chroma]"` |
 | Persistence | Via client mode |
 | Distance metrics | COSINE, L2, IP |
-| Suitable for | Prototyping, moderate corpora, managed Chroma Cloud |
+| Suitable for | Prototyping, moderate corpora, self-hosted Chroma |
 
 **When to use:** standalone apps where you want a real vector index
-without standing up Postgres, or when you already use Chroma Cloud.
+without standing up Postgres.
+
+---
+
+## `ChromaCloudBackend`
+
+Backend for [Chroma Cloud](https://www.trychroma.com/) — the managed
+Chroma service. Uses the same `stores-chroma` install as `ChromaBackend`
+but has a distinct constructor because the connection args are
+incompatible with local/HTTP modes.
+
+```bash
+pip install "railtracks[stores-chroma]"
+```
+
+```python
+--8<-- "docs/scripts/retrieval/store.py:chroma_cloud"
+```
+
+An `embedding_function` must be provided explicitly. Chroma Cloud stores
+the EF configuration server-side and the local SDK may fail to
+reconstruct it, so passing the object directly bypasses that code path.
+Any Chroma-compatible embedding function works.
+
+### Distance metric
+
+For Cloud collections, `metric` controls the **score conversion formula
+only** — the `hnsw:space` is managed server-side and cannot be set at
+collection creation time.
+
+```python
+--8<-- "docs/scripts/retrieval/store.py:chroma_cloud_metric"
+```
+
+| `DistanceMetric` | Score formula |
+|---|---|
+| `COSINE` (default) | `1 - distance` |
+| `L2` | `1 / (1 + sqrt(distance))` |
+| `IP` | `1 - distance` |
+
+| Property | Value |
+|---|---|
+| Install | `pip install "railtracks[stores-chroma]"` |
+| Persistence | Managed by Chroma Cloud |
+| Distance metrics | COSINE, L2, IP |
+| Suitable for | Managed Chroma Cloud deployments |
+
+**When to use:** when you want a fully managed vector store with no
+infrastructure to run. Requires a Chroma Cloud account.
 
 ---
 
@@ -202,13 +250,13 @@ unless you have a strong reason for a managed vector DB.
 
 ## Choosing a backend
 
-|  | InMemory | Chroma | Pgvector |
-|---|---|---|---|
-| Extra install | None | `stores-chroma` | `stores-vector` |
-| Persistence | Optional snapshot | Client-dependent | Postgres |
-| Scale | Small (in-process) | Medium–Large | Large |
-| Infrastructure | None | Chroma server (optional) | Postgres + pgvector |
-| Best for | Tests & dev | Standalone apps | Postgres-native stacks |
+|  | InMemory | Chroma | ChromaCloud | Pgvector |
+|---|---|---|---|---|
+| Extra install | None | `stores-chroma` | `stores-chroma` | `stores-vector` |
+| Persistence | Optional snapshot | Client-dependent | Managed | Postgres |
+| Scale | Small (in-process) | Medium–Large | Large | Large |
+| Infrastructure | None | Chroma server (optional) | Chroma Cloud account | Postgres + pgvector |
+| Best for | Tests & dev | Standalone apps | Managed vector DB | Postgres-native stacks |
 
 ---
 

--- a/docs/retrieval/components/stores/backends.md
+++ b/docs/retrieval/components/stores/backends.md
@@ -160,10 +160,26 @@ pip install "railtracks[stores-chroma]"
 --8<-- "docs/scripts/retrieval/store.py:chroma_cloud"
 ```
 
-An `embedding_function` must be provided explicitly. Chroma Cloud stores
-the EF configuration server-side and the local SDK may fail to
-reconstruct it, so passing the object directly bypasses that code path.
-Any Chroma-compatible embedding function works.
+`embedding_function` is optional. Pass it to register or reuse a
+specific EF on the collection. When provided, Chroma Cloud stores the EF
+configuration server-side — passing the object directly avoids a known
+SDK reconstruction issue with certain EF configs. Omit it if the
+collection was already created with an EF and you don't need to
+reference it locally.
+
+### Server-side embeddings
+
+When `embedding_function` is configured, Chroma Cloud can embed content
+automatically — no client-side embedder required.
+
+Pass `vector=None` to `upsert` (via `VectorStore.write` or directly) and
+Chroma will embed the document from the `content` field. For search, pass
+`query_text` instead of a pre-computed vector:
+
+```python
+--8<-- "docs/scripts/retrieval/store.py:chroma_cloud_server_embeddings"
+```
+
 
 ### Distance metric
 

--- a/docs/retrieval/components/stores/backends.md
+++ b/docs/retrieval/components/stores/backends.md
@@ -120,11 +120,10 @@ pip install "railtracks[stores-chroma]"
 
 ### Documents and content
 
-Chroma stores text alongside each vector as a *document*. Both Chroma
+Chroma stores text alongside each vector as a *Document*. Both Chroma
 backends map `StoreEntry.content` (equivalently, `Chunk.content`) to this
 field automatically — you don't need to set it separately. This is what
-Chroma displays in its UI and what server-side embedding functions receive
-as input when no pre-computed vector is provided.
+Chroma displays in its UI and what server-side embedding functions receive.
 
 ### Distance metric
 
@@ -168,27 +167,16 @@ pip install "railtracks[stores-chroma]"
 --8<-- "docs/scripts/retrieval/store.py:chroma_cloud"
 ```
 
-`embedding_function` is optional. Pass it to register or reuse a
-specific EF on the collection. When provided, Chroma Cloud stores the EF
-configuration server-side — passing the object directly avoids a known
-SDK reconstruction issue with certain EF configs. Omit it if the
-collection was already created with an EF and you don't need to
-reference it locally.
+Embeddings must be generated client-side (e.g. via a railtracks embedder)
+and passed as `vector` on every write and search, exactly like the local
+`ChromaBackend`.
 
-### Server-side embeddings
-
-When `embedding_function` is configured, Chroma Cloud can embed content
-automatically — no client-side embedder required.
-
-Pass `vector=None` to `upsert` (via `VectorStore.write` or directly) and
-Chroma will embed the Chroma document — i.e. `StoreEntry.content` — using
-the configured EF. For search, pass `query_text` instead of a
-pre-computed vector:
-
-```python
---8<-- "docs/scripts/retrieval/store.py:chroma_cloud_server_embeddings"
-```
-
+!!! note "Chroma Dashboard semantic search"
+    The Chroma Cloud dashboard's built-in semantic search requires an
+    embedding model to be configured on the collection server-side. If you
+    want that UI feature to work, make sure the model you use to embed your
+    chunks is available as a Chroma-supported embedding function and
+    configure it on the collection directly via the Chroma Cloud console.
 
 ### Distance metric
 

--- a/docs/retrieval/components/stores/backends.md
+++ b/docs/retrieval/components/stores/backends.md
@@ -118,6 +118,14 @@ pip install "railtracks[stores-chroma]"
 --8<-- "docs/scripts/retrieval/store.py:servers"
 ```
 
+### Documents and content
+
+Chroma stores text alongside each vector as a *document*. Both Chroma
+backends map `StoreEntry.content` (equivalently, `Chunk.content`) to this
+field automatically — you don't need to set it separately. This is what
+Chroma displays in its UI and what server-side embedding functions receive
+as input when no pre-computed vector is provided.
+
 ### Distance metric
 
 Chroma's `hnsw:space` is set at collection creation and **cannot be
@@ -173,8 +181,9 @@ When `embedding_function` is configured, Chroma Cloud can embed content
 automatically — no client-side embedder required.
 
 Pass `vector=None` to `upsert` (via `VectorStore.write` or directly) and
-Chroma will embed the document from the `content` field. For search, pass
-`query_text` instead of a pre-computed vector:
+Chroma will embed the Chroma document — i.e. `StoreEntry.content` — using
+the configured EF. For search, pass `query_text` instead of a
+pre-computed vector:
 
 ```python
 --8<-- "docs/scripts/retrieval/store.py:chroma_cloud_server_embeddings"

--- a/docs/scripts/retrieval/store.py
+++ b/docs/scripts/retrieval/store.py
@@ -172,6 +172,47 @@ def distance():
     # --8<-- [end:distance]
 
 
+# --8<-- [start:chroma_cloud]
+from railtracks.retrieval.stores import ChromaCloudBackend, VectorStore
+
+
+async def chroma_cloud():
+    # Any Chroma-compatible embedding function works here.
+    # It must be passed explicitly — Chroma Cloud stores the EF config
+    # server-side, and providing the object directly avoids a known
+    # reconstruction issue with certain EF configurations.
+    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+    ef = DefaultEmbeddingFunction()
+
+    backend = await ChromaCloudBackend.create(
+        "my-collection",
+        api_key="chk-...",
+        tenant="my-tenant",
+        database="my-database",
+        embedding_function=ef,
+    )
+    store = VectorStore(backend)
+# --8<-- [end:chroma_cloud]
+
+
+def chroma_cloud_metric():
+    # --8<-- [start:chroma_cloud_metric]
+    from railtracks.retrieval.stores import ChromaCloudBackend, DistanceMetric
+
+    # metric controls the score conversion formula only —
+    # the hnsw:space is managed server-side for Cloud collections.
+    backend = ChromaCloudBackend(
+        "my-collection",
+        api_key="chk-...",
+        tenant="my-tenant",
+        database="my-database",
+        embedding_function=...,
+        metric=DistanceMetric.L2,
+    )
+    # --8<-- [end:chroma_cloud_metric]
+
+
 # --8<-- [start:custom]
 from railtracks.retrieval.stores import VectorStore
 

--- a/docs/scripts/retrieval/store.py
+++ b/docs/scripts/retrieval/store.py
@@ -177,61 +177,14 @@ from railtracks.retrieval.stores import ChromaCloudBackend, VectorStore
 
 
 async def chroma_cloud():
-    # Any Chroma-compatible embedding function works here.
-    # It must be passed explicitly — Chroma Cloud stores the EF config
-    # server-side, and providing the object directly avoids a known
-    # reconstruction issue with certain EF configurations.
-    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
-
-    ef = DefaultEmbeddingFunction()
-
     backend = await ChromaCloudBackend.create(
         "my-collection",
         api_key="chk-...",
         tenant="my-tenant",
         database="my-database",
-        embedding_function=ef,
     )
     store = VectorStore(backend)
 # --8<-- [end:chroma_cloud]
-
-
-# --8<-- [start:chroma_cloud_server_embeddings]
-async def chroma_cloud_server_embeddings():
-    import uuid
-
-    from railtracks.retrieval.stores import StoreEntry
-    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
-
-    ef = DefaultEmbeddingFunction()
-    backend = await ChromaCloudBackend.create(
-        "my-collection",
-        api_key="chk-...",
-        tenant="my-tenant",
-        database="my-database",
-        embedding_function=ef,
-    )
-    store = VectorStore(backend)
-
-    # Write — vector=None tells Chroma to embed the content server-side.
-    entry = StoreEntry(
-        id=uuid.uuid4(),
-        content="The quick brown fox jumps over the lazy dog.",
-        vector=None,
-        embedding_model="chroma-cloud-builtin",
-        chunk_id=uuid.uuid4(),
-        document_id=uuid.uuid4(),
-    )
-    await store.write(entry)
-
-    # Search — pass query_text directly to the backend for server-side embedding.
-    results = await backend.search(
-        vector=None,
-        top_k=5,
-        filters={},
-        query_text="fast animal",
-    )
-# --8<-- [end:chroma_cloud_server_embeddings]
 
 
 def chroma_cloud_metric():
@@ -245,7 +198,6 @@ def chroma_cloud_metric():
         api_key="chk-...",
         tenant="my-tenant",
         database="my-database",
-        embedding_function=...,
         metric=DistanceMetric.L2,
     )
     # --8<-- [end:chroma_cloud_metric]

--- a/docs/scripts/retrieval/store.py
+++ b/docs/scripts/retrieval/store.py
@@ -196,6 +196,44 @@ async def chroma_cloud():
 # --8<-- [end:chroma_cloud]
 
 
+# --8<-- [start:chroma_cloud_server_embeddings]
+async def chroma_cloud_server_embeddings():
+    import uuid
+
+    from railtracks.retrieval.stores import StoreEntry
+    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction
+
+    ef = DefaultEmbeddingFunction()
+    backend = await ChromaCloudBackend.create(
+        "my-collection",
+        api_key="chk-...",
+        tenant="my-tenant",
+        database="my-database",
+        embedding_function=ef,
+    )
+    store = VectorStore(backend)
+
+    # Write — vector=None tells Chroma to embed the content server-side.
+    entry = StoreEntry(
+        id=uuid.uuid4(),
+        content="The quick brown fox jumps over the lazy dog.",
+        vector=None,
+        embedding_model="chroma-cloud-builtin",
+        chunk_id=uuid.uuid4(),
+        document_id=uuid.uuid4(),
+    )
+    await store.write(entry)
+
+    # Search — pass query_text directly to the backend for server-side embedding.
+    results = await backend.search(
+        vector=None,
+        top_k=5,
+        filters={},
+        query_text="fast animal",
+    )
+# --8<-- [end:chroma_cloud_server_embeddings]
+
+
 def chroma_cloud_metric():
     # --8<-- [start:chroma_cloud_metric]
     from railtracks.retrieval.stores import ChromaCloudBackend, DistanceMetric

--- a/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
@@ -7,11 +7,12 @@ from .models import (
 )
 from .protocol import Store
 from .vector import VectorStore
-from .vector.backends import ChromaBackend, DistanceMetric, PgvectorBackend
+from .vector.backends import ChromaBackend, DistanceMetric, PgvectorBackend, ChromaCloudBackend
 from .vector.backends import InMemoryBackend as InMemoryVectorBackend
 
 __all__ = [
     "ChromaBackend",
+    "ChromaCloudBackend",
     "DistanceMetric",
     "Entity",
     "InMemoryVectorBackend",

--- a/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
@@ -7,7 +7,12 @@ from .models import (
 )
 from .protocol import Store
 from .vector import VectorStore
-from .vector.backends import ChromaBackend, DistanceMetric, PgvectorBackend, ChromaCloudBackend
+from .vector.backends import (
+    ChromaBackend,
+    ChromaCloudBackend,
+    DistanceMetric,
+    PgvectorBackend,
+)
 from .vector.backends import InMemoryBackend as InMemoryVectorBackend
 
 __all__ = [

--- a/packages/railtracks/src/railtracks/retrieval/stores/models.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/models.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from ..models import EmbeddedChunk
 

--- a/packages/railtracks/src/railtracks/retrieval/stores/models.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/models.py
@@ -80,7 +80,7 @@ class StoreEntry:
     ) -> StoreEntry:
         chunk = embedded_chunk.chunk
         return cls(
-            id=uuid4(),
+            id=chunk.id,
             content=chunk.content,
             vector=embedded_chunk.vector,
             embedding_model=embedded_chunk.embedding_model,

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/__init__.py
@@ -1,6 +1,6 @@
 from ..metric import DistanceMetric
-from .chroma import ChromaBackend
+from .chroma import ChromaBackend, ChromaCloudBackend
 from .in_memory import InMemoryBackend
 from .pgvector import PgvectorBackend
 
-__all__ = ["ChromaBackend", "DistanceMetric", "InMemoryBackend", "PgvectorBackend"]
+__all__ = ["ChromaBackend", "ChromaCloudBackend", "DistanceMetric", "InMemoryBackend", "PgvectorBackend"]

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/__init__.py
@@ -3,4 +3,10 @@ from .chroma import ChromaBackend, ChromaCloudBackend
 from .in_memory import InMemoryBackend
 from .pgvector import PgvectorBackend
 
-__all__ = ["ChromaBackend", "ChromaCloudBackend", "DistanceMetric", "InMemoryBackend", "PgvectorBackend"]
+__all__ = [
+    "ChromaBackend",
+    "ChromaCloudBackend",
+    "DistanceMetric",
+    "InMemoryBackend",
+    "PgvectorBackend",
+]

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
@@ -208,9 +208,21 @@ class ChromaCloudBackend(_ChromaBase):
     runs in a thread via asyncio.to_thread. Call initialize() before any other
     method.
 
-    An embedding_function must be provided explicitly — Chroma Cloud stores the
-    EF configuration server-side and the local SDK may fail to reconstruct it,
-    so passing the object directly bypasses that code path entirely.
+    Server-side embeddings
+    ----------------------
+    Chroma Cloud collections can have a built-in embedding function (EF)
+    configured server-side.  When you want Chroma to handle all embedding:
+
+    - Pass ``embedding_function`` to register (or reuse) the EF on the
+      collection.  Omit it if the collection was already created with an EF
+      and you don't want to reconstruct it locally.
+    - Call ``upsert`` with ``vector=None`` — Chroma embeds the document text
+      (the ``content`` field in the payload) automatically.
+    - Call ``search`` with ``vector=None, query_text="..."`` — Chroma embeds
+      the query text automatically.
+
+    When ``vector`` is provided it is always used as-is, regardless of whether
+    an EF is configured.
     """
 
     _NOT_INITIALIZED = (
@@ -225,7 +237,7 @@ class ChromaCloudBackend(_ChromaBase):
         api_key: str,
         tenant: str,
         database: str,
-        embedding_function: Any,
+        embedding_function: Any | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> None:
         self._collection_name = collection_name
@@ -244,7 +256,7 @@ class ChromaCloudBackend(_ChromaBase):
         api_key: str,
         tenant: str,
         database: str,
-        embedding_function: Any,
+        embedding_function: Any | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> Self:
         """Create and initialize a ChromaCloudBackend in one step."""
@@ -281,9 +293,70 @@ class ChromaCloudBackend(_ChromaBase):
                 tenant=tenant,
                 database=database,
             )
-            return client.get_or_create_collection(
-                collection_name,
-                embedding_function=embedding_function,
-            )
+            kwargs: dict[str, Any] = {}
+            if embedding_function is not None:
+                kwargs["embedding_function"] = embedding_function
+            return client.get_or_create_collection(collection_name, **kwargs)
 
         self._collection = await asyncio.to_thread(_setup)
+
+    async def upsert(self, id: str, vector: list[float] | None, payload: dict) -> None:
+        self._require_initialized()
+        collection = self._collection
+        content = payload.get("content")
+        if vector is None and content is None:
+            raise ValueError(
+                "ChromaCloudBackend requires either a vector or a 'content' value in "
+                "the payload for server-side embedding."
+            )
+        await asyncio.to_thread(
+            collection.upsert,
+            ids=[id],
+            embeddings=[vector] if vector is not None else None,
+            documents=[content] if content is not None else None,
+            metadatas=[payload],
+        )
+
+    async def search(
+        self,
+        vector: list[float] | None,
+        top_k: int,
+        filters: dict,
+        *,
+        query_text: str | None = None,
+    ) -> list[tuple[str, float, dict]]:
+        if vector is None and query_text is None:
+            raise ValueError(
+                "ChromaCloudBackend requires either a vector or query_text to search. "
+                "Pass query_text to use server-side embedding."
+            )
+        self._require_initialized()
+        collection = self._collection
+
+        count = await asyncio.to_thread(collection.count)
+        if count == 0:
+            return []
+
+        n_results = min(top_k, count)
+        where = _to_chroma_where(filters) if filters else None
+
+        query_kwargs: dict[str, Any] = {
+            "n_results": n_results,
+            "where": where,
+            "include": ["metadatas", "distances"],
+        }
+        if vector is not None:
+            query_kwargs["query_embeddings"] = [vector]
+        else:
+            query_kwargs["query_texts"] = [query_text]
+
+        results = await asyncio.to_thread(collection.query, **query_kwargs)
+
+        hits: list[tuple[str, float, dict]] = []
+        for id_, distance, metadata in zip(
+            results["ids"][0],
+            results["distances"][0],
+            results["metadatas"][0],
+        ):
+            hits.append((id_, _chroma_to_score(self._metric, distance), dict(metadata)))
+        return hits

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
@@ -220,21 +220,9 @@ class ChromaCloudBackend(_ChromaBase):
     runs in a thread via asyncio.to_thread. Call initialize() before any other
     method.
 
-    Server-side embeddings
-    ----------------------
-    Chroma Cloud collections can have a built-in embedding function (EF)
-    configured server-side.  When you want Chroma to handle all embedding:
-
-    - Pass ``embedding_function`` to register (or reuse) the EF on the
-      collection.  Omit it if the collection was already created with an EF
-      and you don't want to reconstruct it locally.
-    - Call ``upsert`` with ``vector=None`` — Chroma embeds the document text
-      (the ``content`` field in the payload) automatically.
-    - Call ``search`` with ``vector=None, query_text="..."`` — Chroma embeds
-      the query text automatically.
-
-    When ``vector`` is provided it is always used as-is, regardless of whether
-    an EF is configured.
+    Embeddings must be generated client-side (e.g. via a railtracks embedder)
+    and passed as ``vector`` to every ``upsert`` and ``search`` call, just like
+    the local ``ChromaBackend``.
     """
 
     _NOT_INITIALIZED = (
@@ -249,23 +237,15 @@ class ChromaCloudBackend(_ChromaBase):
         api_key: str,
         tenant: str,
         database: str,
-        embedding_function: Any | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> None:
         """
         Args:
             collection_name: Name of the Chroma Cloud collection to get or
                 create.
-            api_key: Chroma Cloud API key (``ck-...``).
+            api_key: Chroma Cloud API key (``chk-...``).
             tenant: Chroma Cloud tenant ID.
             database: Chroma Cloud database name.
-            embedding_function: A Chroma-compatible embedding function to
-                register on the collection. Pass it to use server-side
-                embeddings — Chroma will embed documents and queries
-                automatically, and you can then call ``upsert`` with
-                ``vector=None`` and ``search`` with ``query_text``. Omit if
-                the collection was already created with an EF and you don't
-                need to reference it locally.
             metric: Distance metric used for score conversion. Unlike local
                 backends, this does **not** set ``hnsw:space`` — the index
                 space is managed server-side. Defaults to cosine.
@@ -274,7 +254,6 @@ class ChromaCloudBackend(_ChromaBase):
         self._api_key = api_key
         self._tenant = tenant
         self._database = database
-        self._embedding_function = embedding_function
         self._metric = metric
         self._collection = None
 
@@ -286,7 +265,6 @@ class ChromaCloudBackend(_ChromaBase):
         api_key: str,
         tenant: str,
         database: str,
-        embedding_function: Any | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> Self:
         """Create and initialize a ChromaCloudBackend in one step."""
@@ -295,7 +273,6 @@ class ChromaCloudBackend(_ChromaBase):
             api_key=api_key,
             tenant=tenant,
             database=database,
-            embedding_function=embedding_function,
             metric=metric,
         )
         await backend.initialize()
@@ -314,7 +291,6 @@ class ChromaCloudBackend(_ChromaBase):
         api_key = self._api_key
         tenant = self._tenant
         database = self._database
-        embedding_function = self._embedding_function
         collection_name = self._collection_name
 
         def _setup():
@@ -323,70 +299,6 @@ class ChromaCloudBackend(_ChromaBase):
                 tenant=tenant,
                 database=database,
             )
-            kwargs: dict[str, Any] = {}
-            if embedding_function is not None:
-                kwargs["embedding_function"] = embedding_function
-            return client.get_or_create_collection(collection_name, **kwargs)
+            return client.get_or_create_collection(collection_name)
 
         self._collection = await asyncio.to_thread(_setup)
-
-    async def upsert(self, id: str, vector: list[float] | None, payload: dict) -> None:
-        self._require_initialized()
-        collection = self._collection
-        content = payload.get("content")
-        if vector is None and content is None:
-            raise ValueError(
-                "ChromaCloudBackend requires either a vector or a 'content' value in "
-                "the payload for server-side embedding."
-            )
-        await asyncio.to_thread(
-            collection.upsert,
-            ids=[id],
-            embeddings=[vector] if vector is not None else None,
-            documents=[content] if content is not None else None,
-            metadatas=[payload],
-        )
-
-    async def search(
-        self,
-        vector: list[float] | None,
-        top_k: int,
-        filters: dict,
-        *,
-        query_text: str | None = None,
-    ) -> list[tuple[str, float, dict]]:
-        if vector is None and query_text is None:
-            raise ValueError(
-                "ChromaCloudBackend requires either a vector or query_text to search. "
-                "Pass query_text to use server-side embedding."
-            )
-        self._require_initialized()
-        collection = self._collection
-
-        count = await asyncio.to_thread(collection.count)
-        if count == 0:
-            return []
-
-        n_results = min(top_k, count)
-        where = _to_chroma_where(filters) if filters else None
-
-        query_kwargs: dict[str, Any] = {
-            "n_results": n_results,
-            "where": where,
-            "include": ["metadatas", "distances"],
-        }
-        if vector is not None:
-            query_kwargs["query_embeddings"] = [vector]
-        else:
-            query_kwargs["query_texts"] = [query_text]
-
-        results = await asyncio.to_thread(collection.query, **query_kwargs)
-
-        hits: list[tuple[str, float, dict]] = []
-        for id_, distance, metadata in zip(
-            results["ids"][0],
-            results["distances"][0],
-            results["metadatas"][0],
-        ):
-            hits.append((id_, _chroma_to_score(self._metric, distance), dict(metadata)))
-        return hits

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
@@ -152,6 +152,18 @@ class ChromaBackend(_ChromaBase):
         port: int | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> None:
+        """
+        Args:
+            collection_name: Name of the Chroma collection to get or create.
+            path: Local directory for a PersistentClient. Mutually exclusive
+                with ``host``/``port``. Omit for an in-process EphemeralClient.
+            host: Hostname of a remote Chroma server (HttpClient). Requires
+                ``port``.
+            port: Port of the remote Chroma server. Requires ``host``.
+            metric: Distance metric used for similarity search. Sets the
+                ``hnsw:space`` metadata on the collection at creation time and
+                cannot be changed afterwards. Defaults to cosine.
+        """
         self._collection_name = collection_name
         self._path = path
         self._host = host
@@ -240,6 +252,24 @@ class ChromaCloudBackend(_ChromaBase):
         embedding_function: Any | None = None,
         metric: DistanceMetric = DistanceMetric.COSINE,
     ) -> None:
+        """
+        Args:
+            collection_name: Name of the Chroma Cloud collection to get or
+                create.
+            api_key: Chroma Cloud API key (``ck-...``).
+            tenant: Chroma Cloud tenant ID.
+            database: Chroma Cloud database name.
+            embedding_function: A Chroma-compatible embedding function to
+                register on the collection. Pass it to use server-side
+                embeddings — Chroma will embed documents and queries
+                automatically, and you can then call ``upsert`` with
+                ``vector=None`` and ``search`` with ``query_text``. Omit if
+                the collection was already created with an EF and you don't
+                need to reference it locally.
+            metric: Distance metric used for score conversion. Unlike local
+                backends, this does **not** set ``hnsw:space`` — the index
+                space is managed server-side. Defaults to cosine.
+        """
         self._collection_name = collection_name
         self._api_key = api_key
         self._tenant = tenant

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/backends/chroma.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import math
+from typing import Any
 
 from typing_extensions import Self
 
 from ..metric import DistanceMetric
-
-_NOT_INITIALIZED = (
-    "ChromaBackend is not initialized — "
-    "call await ChromaBackend.create(...) or await backend.initialize() first"
-)
 
 
 def _to_chroma_where(filters: dict) -> dict:
@@ -34,86 +30,26 @@ def _chroma_to_score(metric: DistanceMetric, distance: float) -> float:
     return 1.0 - distance  # COSINE and IP share the same formula
 
 
-class ChromaBackend:
-    """Chroma VectorBackend.
+class _ChromaBase:
+    """Shared Chroma I/O operations. Subclasses supply __init__ and initialize()."""
 
-    Wraps a single Chroma collection. All Chroma I/O is synchronous and runs
-    in a thread via asyncio.to_thread. Call initialize() before any other method.
-
-    Three client modes are selected by the constructor arguments:
-      - no path/host/port  → EphemeralClient (in-process, no persistence)
-      - path only          → PersistentClient (local disk)
-      - host + port        → HttpClient (remote server)
-    """
-
-    def __init__(
-        self,
-        collection_name: str,
-        *,
-        path: str | None = None,
-        host: str | None = None,
-        port: int | None = None,
-        metric: DistanceMetric = DistanceMetric.COSINE,
-    ) -> None:
-        self._collection_name = collection_name
-        self._path = path
-        self._host = host
-        self._port = port
-        self._metric = metric
-        self._collection = None
+    _NOT_INITIALIZED: str = "Chroma backend is not initialized"
+    _metric: DistanceMetric
+    _collection: Any
 
     def _require_initialized(self) -> None:
         if self._collection is None:
-            raise RuntimeError(_NOT_INITIALIZED)
-
-    @classmethod
-    async def create(
-        cls,
-        collection_name: str,
-        *,
-        path: str | None = None,
-        host: str | None = None,
-        port: int | None = None,
-        metric: DistanceMetric = DistanceMetric.COSINE,
-    ) -> Self:
-        """Create and initialize a ChromaBackend in one step."""
-        backend = cls(collection_name, path=path, host=host, port=port, metric=metric)
-        await backend.initialize()
-        return backend
-
-    async def initialize(self) -> None:
-        """Create the Chroma client and collection."""
-        try:
-            import chromadb
-        except ImportError:
-            raise ImportError(
-                "chromadb is required for ChromaBackend. "
-                "Install it with: pip install railtracks[stores-chroma]"
-            ) from None
-
-        metric = self._metric
-
-        def _setup():
-            if self._path:
-                client = chromadb.PersistentClient(path=self._path)
-            elif self._host and self._port:
-                client = chromadb.HttpClient(host=self._host, port=self._port)
-            else:
-                client = chromadb.EphemeralClient()
-            return client.get_or_create_collection(
-                self._collection_name,
-                metadata={"hnsw:space": metric.value},
-            )
-
-        self._collection = await asyncio.to_thread(_setup)
+            raise RuntimeError(self._NOT_INITIALIZED)
 
     async def upsert(self, id: str, vector: list[float], payload: dict) -> None:
         self._require_initialized()
         collection = self._collection
+        content = payload.get("content")
         await asyncio.to_thread(
             collection.upsert,
             ids=[id],
             embeddings=[vector],
+            documents=[content] if content is not None else None,
             metadatas=[payload],
         )
 
@@ -186,3 +122,168 @@ class ChromaBackend:
             include=[],
         )
         return len(result["ids"])
+
+
+class ChromaBackend(_ChromaBase):
+    """Chroma VectorBackend for local and self-hosted deployments.
+
+    Wraps a single Chroma collection. All Chroma I/O is synchronous and runs
+    in a thread via asyncio.to_thread. Call initialize() before any other method.
+
+    Three client modes are selected by the constructor arguments:
+      - no path/host/port  → EphemeralClient (in-process, no persistence)
+      - path only          → PersistentClient (local disk)
+      - host + port        → HttpClient (remote server)
+
+    For Chroma Cloud, use ChromaCloudBackend instead.
+    """
+
+    _NOT_INITIALIZED = (
+        "ChromaBackend is not initialized — "
+        "call await ChromaBackend.create(...) or await backend.initialize() first"
+    )
+
+    def __init__(
+        self,
+        collection_name: str,
+        *,
+        path: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        metric: DistanceMetric = DistanceMetric.COSINE,
+    ) -> None:
+        self._collection_name = collection_name
+        self._path = path
+        self._host = host
+        self._port = port
+        self._metric = metric
+        self._collection = None
+
+    @classmethod
+    async def create(
+        cls,
+        collection_name: str,
+        *,
+        path: str | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        metric: DistanceMetric = DistanceMetric.COSINE,
+    ) -> Self:
+        """Create and initialize a ChromaBackend in one step."""
+        backend = cls(collection_name, path=path, host=host, port=port, metric=metric)
+        await backend.initialize()
+        return backend
+
+    async def initialize(self) -> None:
+        """Create the Chroma client and collection."""
+        try:
+            import chromadb
+        except ImportError:
+            raise ImportError(
+                "chromadb is required for ChromaBackend. "
+                "Install it with: pip install railtracks[stores-chroma]"
+            ) from None
+
+        metric = self._metric
+
+        def _setup():
+            if self._path:
+                client = chromadb.PersistentClient(path=self._path)
+            elif self._host and self._port:
+                client = chromadb.HttpClient(host=self._host, port=self._port)
+            else:
+                client = chromadb.EphemeralClient()
+            return client.get_or_create_collection(
+                self._collection_name,
+                metadata={"hnsw:space": metric.value},
+            )
+
+        self._collection = await asyncio.to_thread(_setup)
+
+
+class ChromaCloudBackend(_ChromaBase):
+    """Chroma VectorBackend for Chroma Cloud.
+
+    Wraps a single Chroma Cloud collection. All Chroma I/O is synchronous and
+    runs in a thread via asyncio.to_thread. Call initialize() before any other
+    method.
+
+    An embedding_function must be provided explicitly — Chroma Cloud stores the
+    EF configuration server-side and the local SDK may fail to reconstruct it,
+    so passing the object directly bypasses that code path entirely.
+    """
+
+    _NOT_INITIALIZED = (
+        "ChromaCloudBackend is not initialized — "
+        "call await ChromaCloudBackend.create(...) or await backend.initialize() first"
+    )
+
+    def __init__(
+        self,
+        collection_name: str,
+        *,
+        api_key: str,
+        tenant: str,
+        database: str,
+        embedding_function: Any,
+        metric: DistanceMetric = DistanceMetric.COSINE,
+    ) -> None:
+        self._collection_name = collection_name
+        self._api_key = api_key
+        self._tenant = tenant
+        self._database = database
+        self._embedding_function = embedding_function
+        self._metric = metric
+        self._collection = None
+
+    @classmethod
+    async def create(
+        cls,
+        collection_name: str,
+        *,
+        api_key: str,
+        tenant: str,
+        database: str,
+        embedding_function: Any,
+        metric: DistanceMetric = DistanceMetric.COSINE,
+    ) -> Self:
+        """Create and initialize a ChromaCloudBackend in one step."""
+        backend = cls(
+            collection_name,
+            api_key=api_key,
+            tenant=tenant,
+            database=database,
+            embedding_function=embedding_function,
+            metric=metric,
+        )
+        await backend.initialize()
+        return backend
+
+    async def initialize(self) -> None:
+        """Create the Chroma Cloud client and collection."""
+        try:
+            import chromadb
+        except ImportError:
+            raise ImportError(
+                "chromadb is required for ChromaCloudBackend. "
+                "Install it with: pip install railtracks[stores-chroma]"
+            ) from None
+
+        api_key = self._api_key
+        tenant = self._tenant
+        database = self._database
+        embedding_function = self._embedding_function
+        collection_name = self._collection_name
+
+        def _setup():
+            client = chromadb.CloudClient(
+                api_key=api_key,
+                tenant=tenant,
+                database=database,
+            )
+            return client.get_or_create_collection(
+                collection_name,
+                embedding_function=embedding_function,
+            )
+
+        self._collection = await asyncio.to_thread(_setup)

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/base.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/base.py
@@ -191,10 +191,9 @@ class VectorStore:
 
     async def write(self, entry: StoreEntry) -> str:
         if entry.vector is None:
-            logger.debug(
-                "VectorStore.write called with entry.vector=None (entry_id=%s); "
-                "the backend is expected to handle embedding server-side.",
-                entry.id,
+            raise ValueError(
+                f"VectorStore.write requires entry.vector to be set "
+                f"(entry_id={entry.id}); embed the chunk before writing."
             )
         await self._backend.upsert(
             str(entry.id), entry.vector, _entry_to_payload(entry)

--- a/packages/railtracks/src/railtracks/retrieval/stores/vector/base.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/vector/base.py
@@ -191,15 +191,10 @@ class VectorStore:
 
     async def write(self, entry: StoreEntry) -> str:
         if entry.vector is None:
-            logger.error(
-                "VectorStore.write called with entry.vector=None (entry_id=%s, "
-                "chunk_id=%s); the entry must be embedded before writing.",
+            logger.debug(
+                "VectorStore.write called with entry.vector=None (entry_id=%s); "
+                "the backend is expected to handle embedding server-side.",
                 entry.id,
-                entry.chunk_id,
-            )
-            raise ValueError(
-                f"VectorStore.write requires entry.vector to be set "
-                f"(entry_id={entry.id}); embed the chunk before writing."
             )
         await self._backend.upsert(
             str(entry.id), entry.vector, _entry_to_payload(entry)

--- a/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
@@ -386,13 +386,11 @@ async def test_vector_store_write_read_via_chroma():
 
 
 def _cloud_backend(collection: MagicMock | None = None) -> ChromaCloudBackend:
-    ef = MagicMock()
     backend = ChromaCloudBackend(
         "my-collection",
         api_key="chk-key",
         tenant="my-tenant",
         database="my-db",
-        embedding_function=ef,
     )
     backend._collection = collection
     return backend
@@ -456,13 +454,11 @@ async def test_cloud_initialize_uses_cloud_client():
     mock_collection = MagicMock()
     mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = mock_collection
 
-    ef = MagicMock()
     backend = ChromaCloudBackend(
         "my-collection",
         api_key="chk-key",
         tenant="my-tenant",
         database="my-db",
-        embedding_function=ef,
     )
 
     with patch.dict("sys.modules", {"chromadb": mock_chroma}):
@@ -476,25 +472,20 @@ async def test_cloud_initialize_uses_cloud_client():
     assert backend._collection is mock_collection
 
 
-async def test_cloud_initialize_passes_embedding_function_not_metadata():
+async def test_cloud_initialize_calls_get_or_create_without_metadata():
     mock_chroma = MagicMock()
     mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
 
-    ef = MagicMock()
     backend = ChromaCloudBackend(
-        "my-collection",
-        api_key="chk-key",
-        tenant="my-tenant",
-        database="my-db",
-        embedding_function=ef,
+        "my-collection", api_key="chk-key", tenant="my-tenant", database="my-db"
     )
 
     with patch.dict("sys.modules", {"chromadb": mock_chroma}):
         await backend.initialize()
 
+    # hnsw:space is not set — the index space is managed server-side for Cloud collections.
     mock_chroma.CloudClient.return_value.get_or_create_collection.assert_called_once_with(
-        "my-collection",
-        embedding_function=ef,
+        "my-collection"
     )
 
 
@@ -502,9 +493,7 @@ async def test_cloud_initialize_does_not_call_ephemeral_or_http_client():
     mock_chroma = MagicMock()
     mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
 
-    backend = ChromaCloudBackend(
-        "col", api_key="k", tenant="t", database="d", embedding_function=MagicMock()
-    )
+    backend = ChromaCloudBackend("col", api_key="k", tenant="t", database="d")
 
     with patch.dict("sys.modules", {"chromadb": mock_chroma}):
         await backend.initialize()
@@ -523,127 +512,13 @@ async def test_cloud_create_factory_returns_initialized_backend():
     mock_chroma = MagicMock()
     mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
 
-    ef = MagicMock()
-
     with patch.dict("sys.modules", {"chromadb": mock_chroma}):
         backend = await ChromaCloudBackend.create(
             "my-collection",
             api_key="chk-key",
             tenant="my-tenant",
             database="my-db",
-            embedding_function=ef,
         )
 
     assert isinstance(backend, ChromaCloudBackend)
     assert backend._collection is not None
-
-
-async def test_cloud_create_factory_without_embedding_function():
-    mock_chroma = MagicMock()
-    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
-
-    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
-        backend = await ChromaCloudBackend.create(
-            "my-collection",
-            api_key="chk-key",
-            tenant="my-tenant",
-            database="my-db",
-        )
-
-    # embedding_function should NOT be passed to get_or_create_collection
-    mock_chroma.CloudClient.return_value.get_or_create_collection.assert_called_once_with(
-        "my-collection"
-    )
-    assert isinstance(backend, ChromaCloudBackend)
-
-
-# ---------------------------------------------------------------------------
-# ChromaCloudBackend — server-side embeddings: upsert
-# ---------------------------------------------------------------------------
-
-
-async def test_cloud_upsert_omits_embeddings_when_vector_is_none():
-    col = MagicMock()
-    backend = _cloud_backend(collection=col)
-
-    await backend.upsert("entry-1", None, {"content": "hello world", "scope_user_id": "alice"})
-
-    col.upsert.assert_called_once_with(
-        ids=["entry-1"],
-        embeddings=None,
-        documents=["hello world"],
-        metadatas=[{"content": "hello world", "scope_user_id": "alice"}],
-    )
-
-
-async def test_cloud_upsert_passes_embeddings_when_vector_provided():
-    col = MagicMock()
-    backend = _cloud_backend(collection=col)
-
-    await backend.upsert("entry-1", [0.1, 0.2], {"content": "hello", "scope_user_id": "alice"})
-
-    col.upsert.assert_called_once_with(
-        ids=["entry-1"],
-        embeddings=[[0.1, 0.2]],
-        documents=["hello"],
-        metadatas=[{"content": "hello", "scope_user_id": "alice"}],
-    )
-
-
-async def test_cloud_upsert_raises_when_no_vector_and_no_content():
-    col = MagicMock()
-    backend = _cloud_backend(collection=col)
-
-    with pytest.raises(ValueError, match="content"):
-        await backend.upsert("entry-1", None, {"scope_user_id": "alice"})
-
-
-# ---------------------------------------------------------------------------
-# ChromaCloudBackend — server-side embeddings: search
-# ---------------------------------------------------------------------------
-
-
-async def test_cloud_search_uses_query_texts_when_vector_is_none():
-    col = MagicMock()
-    col.count.return_value = 1
-    col.query.return_value = {
-        "ids": [["a"]],
-        "distances": [[0.1]],
-        "metadatas": [[{"content": "hello"}]],
-    }
-    backend = _cloud_backend(collection=col)
-
-    results = await backend.search(None, top_k=5, filters={}, query_text="find me something")
-
-    _, call_kwargs = col.query.call_args
-    assert "query_texts" in call_kwargs
-    assert call_kwargs["query_texts"] == ["find me something"]
-    assert "query_embeddings" not in call_kwargs
-    assert len(results) == 1
-
-
-async def test_cloud_search_uses_query_embeddings_when_vector_provided():
-    col = MagicMock()
-    col.count.return_value = 1
-    col.query.return_value = {
-        "ids": [["a"]],
-        "distances": [[0.1]],
-        "metadatas": [[{"content": "hello"}]],
-    }
-    backend = _cloud_backend(collection=col)
-
-    await backend.search([0.1, 0.2], top_k=5, filters={})
-
-    _, call_kwargs = col.query.call_args
-    assert "query_embeddings" in call_kwargs
-    assert call_kwargs["query_embeddings"] == [[0.1, 0.2]]
-    assert "query_texts" not in call_kwargs
-
-
-async def test_cloud_search_raises_when_no_vector_and_no_query_text():
-    col = MagicMock()
-    col.count.return_value = 1
-    backend = _cloud_backend(collection=col)
-
-    with pytest.raises(ValueError, match="query_text"):
-        await backend.search(None, top_k=5, filters={})

--- a/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
@@ -536,3 +536,114 @@ async def test_cloud_create_factory_returns_initialized_backend():
 
     assert isinstance(backend, ChromaCloudBackend)
     assert backend._collection is not None
+
+
+async def test_cloud_create_factory_without_embedding_function():
+    mock_chroma = MagicMock()
+    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
+
+    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
+        backend = await ChromaCloudBackend.create(
+            "my-collection",
+            api_key="chk-key",
+            tenant="my-tenant",
+            database="my-db",
+        )
+
+    # embedding_function should NOT be passed to get_or_create_collection
+    mock_chroma.CloudClient.return_value.get_or_create_collection.assert_called_once_with(
+        "my-collection"
+    )
+    assert isinstance(backend, ChromaCloudBackend)
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — server-side embeddings: upsert
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_upsert_omits_embeddings_when_vector_is_none():
+    col = MagicMock()
+    backend = _cloud_backend(collection=col)
+
+    await backend.upsert("entry-1", None, {"content": "hello world", "scope_user_id": "alice"})
+
+    col.upsert.assert_called_once_with(
+        ids=["entry-1"],
+        embeddings=None,
+        documents=["hello world"],
+        metadatas=[{"content": "hello world", "scope_user_id": "alice"}],
+    )
+
+
+async def test_cloud_upsert_passes_embeddings_when_vector_provided():
+    col = MagicMock()
+    backend = _cloud_backend(collection=col)
+
+    await backend.upsert("entry-1", [0.1, 0.2], {"content": "hello", "scope_user_id": "alice"})
+
+    col.upsert.assert_called_once_with(
+        ids=["entry-1"],
+        embeddings=[[0.1, 0.2]],
+        documents=["hello"],
+        metadatas=[{"content": "hello", "scope_user_id": "alice"}],
+    )
+
+
+async def test_cloud_upsert_raises_when_no_vector_and_no_content():
+    col = MagicMock()
+    backend = _cloud_backend(collection=col)
+
+    with pytest.raises(ValueError, match="content"):
+        await backend.upsert("entry-1", None, {"scope_user_id": "alice"})
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — server-side embeddings: search
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_search_uses_query_texts_when_vector_is_none():
+    col = MagicMock()
+    col.count.return_value = 1
+    col.query.return_value = {
+        "ids": [["a"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"content": "hello"}]],
+    }
+    backend = _cloud_backend(collection=col)
+
+    results = await backend.search(None, top_k=5, filters={}, query_text="find me something")
+
+    _, call_kwargs = col.query.call_args
+    assert "query_texts" in call_kwargs
+    assert call_kwargs["query_texts"] == ["find me something"]
+    assert "query_embeddings" not in call_kwargs
+    assert len(results) == 1
+
+
+async def test_cloud_search_uses_query_embeddings_when_vector_provided():
+    col = MagicMock()
+    col.count.return_value = 1
+    col.query.return_value = {
+        "ids": [["a"]],
+        "distances": [[0.1]],
+        "metadatas": [[{"content": "hello"}]],
+    }
+    backend = _cloud_backend(collection=col)
+
+    await backend.search([0.1, 0.2], top_k=5, filters={})
+
+    _, call_kwargs = col.query.call_args
+    assert "query_embeddings" in call_kwargs
+    assert call_kwargs["query_embeddings"] == [[0.1, 0.2]]
+    assert "query_texts" not in call_kwargs
+
+
+async def test_cloud_search_raises_when_no_vector_and_no_query_text():
+    col = MagicMock()
+    col.count.return_value = 1
+    backend = _cloud_backend(collection=col)
+
+    with pytest.raises(ValueError, match="query_text"):
+        await backend.search(None, top_k=5, filters={})

--- a/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/stores/test_chroma_backend.py
@@ -1,4 +1,4 @@
-"""Tests for ChromaBackend — mocked, no chromadb install required."""
+"""Tests for ChromaBackend and ChromaCloudBackend — mocked, no chromadb install required."""
 
 from __future__ import annotations
 
@@ -14,6 +14,7 @@ from railtracks.retrieval.stores.models import (
 )
 from railtracks.retrieval.stores.vector.backends.chroma import (
     ChromaBackend,
+    ChromaCloudBackend,
     _chroma_to_score,
     _to_chroma_where,
 )
@@ -195,7 +196,22 @@ async def test_upsert_calls_collection_with_correct_args():
     col.upsert.assert_called_once_with(
         ids=["entry-1"],
         embeddings=[[0.1, 0.2]],
+        documents=None,
         metadatas=[{"scope_user_id": "alice"}],
+    )
+
+
+async def test_upsert_passes_documents_when_content_in_payload():
+    col = _make_collection()
+    backend = _injected_backend(col)
+
+    await backend.upsert("entry-1", [0.1, 0.2], {"content": "hello world", "scope_user_id": "alice"})
+
+    col.upsert.assert_called_once_with(
+        ids=["entry-1"],
+        embeddings=[[0.1, 0.2]],
+        documents=["hello world"],
+        metadatas=[{"content": "hello world", "scope_user_id": "alice"}],
     )
 
 
@@ -362,3 +378,161 @@ async def test_vector_store_write_read_via_chroma():
     assert results[0].entry.id == entry.id
     assert results[0].score == pytest.approx(0.95)
     assert results[0].entry.content == "hello"
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend helpers
+# ---------------------------------------------------------------------------
+
+
+def _cloud_backend(collection: MagicMock | None = None) -> ChromaCloudBackend:
+    ef = MagicMock()
+    backend = ChromaCloudBackend(
+        "my-collection",
+        api_key="chk-key",
+        tenant="my-tenant",
+        database="my-db",
+        embedding_function=ef,
+    )
+    backend._collection = collection
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — not-initialized guard
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_not_initialized_raises_on_upsert():
+    backend = _cloud_backend(collection=None)
+    with pytest.raises(RuntimeError, match="initialize"):
+        await backend.upsert("id", [0.1], {})
+
+
+async def test_cloud_not_initialized_raises_on_search():
+    backend = _cloud_backend(collection=None)
+    with pytest.raises(RuntimeError, match="initialize"):
+        await backend.search([0.1], 5, {})
+
+
+async def test_cloud_not_initialized_raises_on_delete():
+    backend = _cloud_backend(collection=None)
+    with pytest.raises(RuntimeError, match="initialize"):
+        await backend.delete("id")
+
+
+async def test_cloud_not_initialized_raises_on_delete_where():
+    backend = _cloud_backend(collection=None)
+    with pytest.raises(RuntimeError, match="initialize"):
+        await backend.delete_where({"scope_user_id": "alice"})
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — ImportError guard
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_initialize_raises_import_error_without_chromadb():
+    backend = _cloud_backend(collection=None)
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "chromadb":
+            raise ImportError("no module named chromadb")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        with pytest.raises(ImportError, match="railtracks\\[stores-chroma\\]"):
+            await backend.initialize()
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — initialize: uses CloudClient, not EphemeralClient
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_initialize_uses_cloud_client():
+    mock_chroma = MagicMock()
+    mock_collection = MagicMock()
+    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = mock_collection
+
+    ef = MagicMock()
+    backend = ChromaCloudBackend(
+        "my-collection",
+        api_key="chk-key",
+        tenant="my-tenant",
+        database="my-db",
+        embedding_function=ef,
+    )
+
+    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
+        await backend.initialize()
+
+    mock_chroma.CloudClient.assert_called_once_with(
+        api_key="chk-key",
+        tenant="my-tenant",
+        database="my-db",
+    )
+    assert backend._collection is mock_collection
+
+
+async def test_cloud_initialize_passes_embedding_function_not_metadata():
+    mock_chroma = MagicMock()
+    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
+
+    ef = MagicMock()
+    backend = ChromaCloudBackend(
+        "my-collection",
+        api_key="chk-key",
+        tenant="my-tenant",
+        database="my-db",
+        embedding_function=ef,
+    )
+
+    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
+        await backend.initialize()
+
+    mock_chroma.CloudClient.return_value.get_or_create_collection.assert_called_once_with(
+        "my-collection",
+        embedding_function=ef,
+    )
+
+
+async def test_cloud_initialize_does_not_call_ephemeral_or_http_client():
+    mock_chroma = MagicMock()
+    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
+
+    backend = ChromaCloudBackend(
+        "col", api_key="k", tenant="t", database="d", embedding_function=MagicMock()
+    )
+
+    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
+        await backend.initialize()
+
+    mock_chroma.EphemeralClient.assert_not_called()
+    mock_chroma.HttpClient.assert_not_called()
+    mock_chroma.PersistentClient.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ChromaCloudBackend — create() factory
+# ---------------------------------------------------------------------------
+
+
+async def test_cloud_create_factory_returns_initialized_backend():
+    mock_chroma = MagicMock()
+    mock_chroma.CloudClient.return_value.get_or_create_collection.return_value = MagicMock()
+
+    ef = MagicMock()
+
+    with patch.dict("sys.modules", {"chromadb": mock_chroma}):
+        backend = await ChromaCloudBackend.create(
+            "my-collection",
+            api_key="chk-key",
+            tenant="my-tenant",
+            database="my-db",
+            embedding_function=ef,
+        )
+
+    assert isinstance(backend, ChromaCloudBackend)
+    assert backend._collection is not None


### PR DESCRIPTION
## Summary

Adds `ChromaCloudBackend` for [Chroma Cloud](https://www.trychroma.com/) support. Previously there was no way to connect to Chroma Cloud. (closes #1111)

This PR introduces a clean split:
- `ChromaCloudBackend` — new class for Chroma Cloud (`api_key`, `tenant`, `database`, `embedding_function`); uses `CloudClient` and passes `embedding_function` directly to avoid a known server-side EF reconstruction issue
- `ChromaBackend` — unchanged API, now explicitly scoped to local/self-hosted modes (ephemeral, persistent, HTTP); updated docstring points users to `ChromaCloudBackend` for cloud
- Shared `_ChromaBase` — private base class holding all I/O methods (`upsert`, `search`, `delete`, `delete_where`, `list_where`, `count`) so there is no duplication between the two classes
- `upsert` now forwards `documents=[content]` when `content` is present in the payload because Chroma has a default built-in `Document`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

`ChromaCloudBackend` is exported from `railtracks.retrieval.stores` alongside `ChromaBackend`. Usage:

```python
from railtracks.retrieval.stores import ChromaCloudBackend, VectorStore

backend = await ChromaCloudBackend.create(
    "my-collection",
    api_key="chk-...",
    tenant="my-tenant",
    database="my-database",
    embedding_function=ef,   # any Chroma-compatible EF
)
store = VectorStore(backend)
