### PR TITLE
feat: add failure serialization support to encoder and tests

### DIFF
--- a/packages/railtracks/src/railtracks/state/serialize.py
+++ b/packages/railtracks/src/railtracks/state/serialize.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import traceback
 from typing import Any
 
 from pydantic import BaseModel
@@ -11,6 +12,8 @@ from railtracks.llm import Message, ToolCall, ToolResponse, UserMessage
 from railtracks.nodes.nodes import LatencyDetails
 from railtracks.utils.profiling import Stamp
 from railtracks.utils.serialization.graph import Edge, Vertex
+
+from .request import Failure
 
 supported_types = (
     Message,
@@ -23,6 +26,7 @@ supported_types = (
     LatencyDetails,
     BaseModel,
     LLMResponse,
+    Failure,
 )
 
 
@@ -62,8 +66,25 @@ def encoder_extender(o) -> dict[str, Any]:  # noqa: C901
         return encode_base_model(o)
     elif isinstance(o, LLMResponse):
         return encode_llm_response(o)
+    elif isinstance(o, Failure):
+        return encode_failure(o)
     else:
         raise TypeError(f"Unsupported type: {type(o)}")
+
+
+def encode_failure(failure: Failure) -> dict[str, Any]:
+    """
+    Encodes a Failure object by surfacing the wrapped exception's type, message,
+    and traceback so the visualizer can show the source of the error.
+    """
+    exc = failure.exception
+    return {
+        "type": type(exc).__name__,
+        "message": str(exc),
+        "traceback": "".join(
+            traceback.format_exception(type(exc), exc, exc.__traceback__)
+        ),
+    }
 
 
 def encode_llm_response(llm_response: LLMResponse):

--- a/packages/railtracks/tests/unit_tests/utils/serialization/conftest.py
+++ b/packages/railtracks/tests/unit_tests/utils/serialization/conftest.py
@@ -59,3 +59,11 @@ def fake_basemodel():
         def model_dump(self_inner):
             return {"hello": "world"}
     return DummyBaseModel()
+
+@pytest.fixture
+def fake_failure():
+    from railtracks.state.request import Failure
+    try:
+        raise ValueError("kaboom")
+    except ValueError as e:
+        return Failure(e)

--- a/packages/railtracks/tests/unit_tests/utils/serialization/test_serialize.py
+++ b/packages/railtracks/tests/unit_tests/utils/serialization/test_serialize.py
@@ -17,6 +17,7 @@ from railtracks.state import serialize
         ("fake_tool_call", {"identifier", "name", "arguments"}, serialize.encode_tool_call, dict),
         ("fake_latency_details", {"total_time"}, serialize.encode_latency_details, dict),
         ("fake_basemodel", {"hello"}, serialize.encode_base_model, dict),
+        ("fake_failure", {"type", "message", "traceback"}, serialize.encode_failure, dict),
     ]
 )
 def test_encoder_extension_encodes_types_correctly(request, fixture_name, expected_keys, encode_func, expected_type):
@@ -39,7 +40,7 @@ def test_encoder_extender_raises_on_unknown():
     [
         "fake_edge", "fake_vertex", "fake_stamp", "fake_request_details",
         "fake_message", "fake_tool_response", "fake_tool_call",
-        "fake_latency_details", "fake_basemodel",
+        "fake_latency_details", "fake_basemodel", "fake_failure",
     ]
 )
 def test_rtjsonencoder_supports_all_supported_types(request, fixture_name):
@@ -60,5 +61,12 @@ def test_rtjsonencoder_fallback_on_unknown_type():
     enc = DummyEnc()
     val = enc.default(to_enc)
     assert "ERROR:" in str(val)
+
+def test_failure_serialization_surfaces_exception_details(fake_failure):
+    encoded = json.loads(json.dumps(fake_failure, cls=serialize.RTJSONEncoder))
+    assert encoded["type"] == "ValueError"
+    assert encoded["message"] == "kaboom"
+    assert "ValueError: kaboom" in encoded["traceback"]
+    assert "ERROR: w/ type" not in json.dumps(encoded)
 
 # =============== END RTJSONEncoder tests =========================


### PR DESCRIPTION
## Summary

Closes #1177: node errors now surface properly in the visualizer instead of showing a generic `ERROR: w/ type <class 'railtracks.state.request.Failure'>...` placeholder.

When a node raised an exception, the resulting `Failure` wrapper ([request.py:24](packages/railtracks/src/railtracks/state/request.py#L24)) was attached to the request's `output` and serialized into edge details. `Failure` was not registered in `supported_types`, so `RTJSONEncoder` fell through to the catch-all string fallback at [serialize.py:206](packages/railtracks/src/railtracks/state/serialize.py#L206), losing the exception type, message, and traceback.

This PR:
- Adds `Failure` to `supported_types` and an `encode_failure()` that emits `{type, message, traceback}` so the visualizer can render the actual error.
- Adds a `fake_failure` fixture and an end-to-end test (`test_failure_serialization_surfaces_exception_details`) that pins the new shape and asserts the old placeholder string is gone.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

Sample code:
```python
import railtracks as rt

rt.enable_logging()

@rt.function_node
def get_phone_number(name: str):
    """Looks up the directory to find the phone number for a given name."""
    raise ValueError("Failed to get phone number")


Agent = rt.agent_node(
    name="Agent",
    llm= rt.llm.OpenAILLM("gpt-5"),
    tool_nodes = [get_phone_number]
)

flow = rt.Flow("Test Flow", Agent)

flow.invoke("Get me alice's phone number")
```

sample output (failure section)
```json
                {
                    "source": "4b171ae8-1dc7-4778-86e5-dbc3e436fa88",
                    "target": "29c8ebaa-e976-495b-b871-1f17d4ff6deb",
                    "identifier": "590c38be-5986-4490-b58c-d784c9042a7b",
                    "stamp": {
                        "step": 6,
                        "time": 1780960764.638271,
                        "identifier": "Finished executing get_phone_number"
                    },
                    "details": {
                        "input_args": [],
                        "input_kwargs": {
                            "name": "Alice"
                        },
                        "status": "Failed",
                        "output": {
                            "type": "ValueError",
                            "message": "Failed to get phone number",
                            "traceback": "Traceback (most recent call last):\n ...."
                    },
...
```

current look on Visualizer:
<img width="621" height="499" alt="image" src="https://github.com/user-attachments/assets/58b21847-be77-4d32-b37e-83bc4757ddf5" />