### PR TITLE
Pooria/rag skill

### DIFF
--- a/docs/documentation/getting_started/ai_setup.md
+++ b/docs/documentation/getting_started/ai_setup.md
@@ -78,6 +78,7 @@ railtracks add --force claude:agent-builder
 | Skill | Description |
 |---|---|
 | `agent-builder` | Build agents, tools, flows, and multi-agent workflows with railtracks |
+| `rag-pipeline` | Build retrieval-augmented generation (RAG) pipelines with loaders, chunkers, embedders, and vector stores |
 
 
 ## How It Works
@@ -103,3 +104,17 @@ Build me a railtracks agent that searches the web and summarises results
 ```
 
 Your assistant will use the skill to generate correct `rt.function_node` tools, a properly configured `rt.agent_node`, and a `rt.Flow` with a runnable `__main__` block without you having to paste docs into the chat.
+
+## Example: Building a RAG Pipeline
+
+Install the RAG skill and ask your assistant to wire up a pipeline over your data:
+
+```bash
+railtracks add claude:rag-pipeline
+```
+
+```
+Build a RAG pipeline that ingests my PDF docs folder and answers questions about them
+```
+
+Your assistant will set up the correct loader, chunker, embedder, and vector store, wire them into a `RetrievalRuntime`, and expose retrieval as a tool in an agent — without you having to look up import paths or constructor signatures.

--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -443,6 +443,18 @@ def _print_help():
             "Install agent-builder skill for Cursor",
         )
     )
+    print(
+        example(
+            f"{cli_name} add claude:rag-pipeline",
+            "Install RAG pipeline skill for Claude Code",
+        )
+    )
+    print(
+        example(
+            f"{cli_name} add copilot:rag-pipeline",
+            "Install RAG pipeline skill for GitHub Copilot",
+        )
+    )
     print()
 
 

--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -61,6 +61,15 @@ SKILLS = {
         ),
         "argument_hint": "[describe what the agent should do]",
     },
+    "rag-pipeline": {
+        "name": "rag-pipeline",
+        "description": (
+            "Build a RAG (retrieval-augmented generation) pipeline using railtracks. "
+            "Use when the user wants to ingest documents into a vector store and retrieve "
+            "relevant passages to answer questions."
+        ),
+        "argument_hint": "[describe the data source and what you want to retrieve]",
+    },
 }
 
 SUPPORTED_TOOLS = ("claude", "copilot", "cursor")

--- a/packages/railtracks/src/railtracks/cli/skills/rag-pipeline.md
+++ b/packages/railtracks/src/railtracks/cli/skills/rag-pipeline.md
@@ -1,68 +1,129 @@
 # Build a Railtracks RAG Pipeline
 
-The user wants to build a retrieval-augmented generation (RAG) pipeline using railtracks: $ARGUMENTS
+The user wants to build a retrieval-augmented generation (RAG) pipeline using the railtracks framework: $ARGUMENTS
 
 ## How railtracks retrieval works
-- **Loaders** read source documents (files, PDFs, CSVs, cloud storage, databases) and yield `Document` objects.
-- **Chunkers** split each document into smaller overlapping `Chunk` objects that fit inside an embedding window.
-- **Embedders** convert chunks (and later, queries) into dense vectors.
-- **Stores** persist chunks with their vectors and support nearest-neighbour lookup.
-- **`RetrievalRuntime`** wires loader → chunker → embedder → store into `ingest_all()` and `retrieve()` calls.
 
-### Loader Selection
-| Source | Class | Key params |
-|---|---|---|
-| `.txt` / `.md` file | `TextLoader` | `file_path` |
-| PDF | `PyPDFLoader` | `file_path`, `breakdown_strategy="page"\|"document"` |
-| PDF + OCR fallback | `PyPDFOCRLoader` | `file_path`, `force_ocr=False` |
-| CSV | `CSVLoader` | `file_path`, `content_columns`, `ignore_columns` |
-| JSON | `JSONLoader` | `file_path`, `content_keys="*"` |
-| AWS S3 | `S3Loader` | `bucket`, `prefix`, `keys` |
-| SQL database | `SQLLoader` | `connection_string`, `table_or_query`, `content_column` |
+The pipeline has two paths:
 
-### Chunker Selection
-| Use case | Class | Key params |
-|---|---|---|
-| General prose (recommended default) | `RecursiveCharacterChunker` | `chunk_size=1000`, `overlap=200` |
-| Sentence-boundary aware | `SentenceChunker` | `chunk_size=5` (sentences), `overlap=1` |
-| Token-precise | `FixedTokenChunker` | `chunk_size=400`, `overlap=200` |
-| Markdown / structured docs | `MarkdownHeaderChunker` | `chunk_size=1000` |
-| Semantic topic boundaries | `SemanticChunker` | `embedder=<same embedder>`, `threshold_percentile=95.0` |
+**Write path (ingestion):** `Loader → Chunker → Embedder → VectorStore`
+**Read path (retrieval):** `query → Embedder → VectorStore.search → RetrievalResult`
 
-### Embedder Selection
-| Provider | Class | Key params |
-|---|---|---|
-| OpenAI | `OpenAIEmbedding` | `model="text-embedding-3-small"`, `dimensions` |
-| Azure OpenAI | `AzureEmbedding` | `deployment`, `api_base`, `api_version` |
-| Ollama (local) | `OllamaEmbedding` | `model="nomic-embed-text"`, `api_base` |
-| Any LiteLLM provider | `LiteLLMEmbedding` | `model="provider/model-name"` |
+`RetrievalRuntime` orchestrates both paths. It takes a chunker, embedder, and store at construction time, then exposes `ingest_all()` / `ingest()` for writes and `retrieve()` for reads.
 
-### Vector Store / Backend Selection
-| Backend | Class | When to use |
-|---|---|---|
-| Local disk (development) | `ChromaBackend(path="./db")` | No infra needed, persists between runs |
-| In-process ephemeral | `ChromaBackend()` | Testing / one-shot scripts |
-| Remote Chroma server | `ChromaBackend(host=..., port=...)` | Shared/production Chroma |
-| PostgreSQL + pgvector | `PgvectorBackend(dsn=...)` | Production, existing Postgres |
-| In-memory with snapshot | `InMemoryBackend(snapshot_path=...)` | Lightweight local dev |
+### Core data flow
+| Stage | Input | Output |
+|-------|-------|--------|
+| Loader | source (file, URL, dataset) | `Document` |
+| Chunker | `Document` | `Chunk` |
+| Embedder | `Chunk.content` | `EmbeddedChunk` |
+| Store | `EmbeddedChunk` | stored `StoreEntry` |
+| Retrieve | query string | `RetrievalResult` (ranked `RetrievedChunk` list) |
+
+---
+
+## Component reference
+
+### Loaders
+```python
+from railtracks.retrieval.loaders import (
+    TextLoader,                  # .txt / .md files
+    CSVLoader,                   # rows → documents; configure content_col, metadata_cols
+    JSONLoader,                  # .json / .jsonl files
+    PyPDFLoader,                 # PDF; strategy="page" (default) or "document"
+    HuggingFaceDatasetLoader,    # HF Hub datasets; pass dataset_name, split, text_column
+    LangChainLoaderAdapter,      # wrap any LangChain document loader
+)
+```
+
+### Chunkers
+```python
+from railtracks.retrieval.chunking import (
+    RecursiveCharacterChunker,  # general text; chunk_size (chars), overlap
+    MarkdownHeaderChunker,      # heading-aware splits for .md content
+    SentenceChunker,            # sentence windows; chunk_size (# sentences), overlap
+    SemanticChunker,            # embedding-driven breakpoints; variable chunk size
+    FixedTokenChunker,          # hard token budget; chunk_size (tokens), overlap
+)
+```
+
+### Embedders
+```python
+from railtracks.retrieval.embedding import (
+    OpenAIEmbedding,    # default model: "text-embedding-3-small"
+    AzureEmbedding,     # Azure OpenAI routing
+    OllamaEmbedding,    # local dev; model, base_url
+    LiteLLMEmbedding,   # any LiteLLM-supported provider
+)
+```
+
+### Store backends
+```python
+from railtracks.retrieval.stores import (
+    VectorStore,              # store implementation; wraps a backend
+    InMemoryVectorBackend,    # tests and small corpora; no persistence by default
+    ChromaBackend,            # local / persistent / HTTP modes
+    ChromaCloudBackend,       # managed Chroma Cloud
+    PgvectorBackend,          # Postgres + pgvector; production
+)
+```
+
+### Installation extras
+```
+pip install "railtracks[retrieval-core]"   # minimum (no connectors)
+pip install "railtracks[retrieval]"        # all connectors
+pip install "railtracks[chroma]"           # Chroma only
+pip install "railtracks[huggingface]"      # HuggingFace datasets
+pip install "railtracks[ocr]"             # PyPDF + OCR (requires Tesseract)
+```
 
 ---
 
 ## Steps
-1. **Read the existing code** — check what files already exist in the project before writing anything.
-2. **Choose your components** — pick a loader, chunker, embedder, and backend from the tables above. Ask the user to clarify if the source format or provider is not obvious from `$ARGUMENTS`.
-3. **Create the runtime** — instantiate `ChromaBackend` (or another backend) with `await Backend.create(...)`, wrap it in `VectorStore`, and pass both with the chunker and embedder to `RetrievalRuntime`.
-4. **Ingest documents** — call `await runtime.ingest_all(loader=...)`. Print `stats.documents_loaded`, `stats.chunks_embedded`, and `stats.documents_skipped` so the user can confirm it worked.
-5. **Retrieve** — call `await runtime.retrieve(query=..., top_k=5)`. The result is a `RetrievalResult`; the matched text lives in `result.chunks[i].chunk.content`.
-6. **Wire into an agent (optional)** — if the user wants an LLM to answer questions, wrap `retrieve` in a `@rt.function_node` tool and pass it to `rt.agent_node()`.
-7. **Add invocation code** — include a `if __name__ == "__main__":` block with `asyncio.run(...)` calls for both ingestion and retrieval so the user can run it immediately.
-8. **Check imports** — all retrieval classes live under `railtracks.retrieval` and its sub-modules. Import `asyncio` for `asyncio.run()`.
+
+1. **Read the existing code** — check what files already exist. Understand what data source, chunking strategy, and query pattern the user needs before writing anything.
+2. **Choose a loader** — match the source type (file, PDF, CSV, HuggingFace dataset, etc.). Ask the user to clarify if not obvious from `$ARGUMENTS`.
+3. **Choose a chunker** — default to `RecursiveCharacterChunker` for plain text, `MarkdownHeaderChunker` for structured docs, `SentenceChunker` for narrative text. Use `SemanticChunker` only when chunk boundaries matter semantically.
+4. **Choose an embedder** — default to `OpenAIEmbedding()` (text-embedding-3-small). Use `OllamaEmbedding` for local/offline dev.
+5. **Choose a backend** — `InMemoryVectorBackend` for demos/tests, `ChromaBackend` for local persistence, `PgvectorBackend` for production.
+6. **Construct `RetrievalRuntime`** — pass chunker, embedder, store. Initialize async backends with `await backend.initialize()` or the `ChromaBackend.create()` factory.
+7. **Ingest documents** — call `runtime.ingest_all(loader=...)`. Print stats. Handle `documents_failed` gracefully.
+8. **Add a retrieve function** — call `runtime.retrieve(query, top_k=...)`. Return or format `result.chunks`.
+9. **Wire into an agent (if needed)** — expose `retrieve` as a `@rt.function_node` tool, or call it in a pre-invoke hook.
+10. **Add a `if __name__ == "__main__":` block** — include both an ingest path and a query example so the user can run it immediately.
 
 ---
 
-## Patterns to Follow
+## Patterns to follow
 
-### Runtime Setup
+### Minimal pipeline (in-memory, for demos/tests)
+```python
+import asyncio
+from railtracks.retrieval import RetrievalRuntime
+from railtracks.retrieval.loaders import TextLoader
+from railtracks.retrieval.chunking import RecursiveCharacterChunker
+from railtracks.retrieval.embedding import OpenAIEmbedding
+from railtracks.retrieval.stores import VectorStore, InMemoryVectorBackend
+
+async def main():
+    runtime = RetrievalRuntime(
+        chunker=RecursiveCharacterChunker(chunk_size=1000, overlap=200),
+        embedder=OpenAIEmbedding(),
+        store=VectorStore(InMemoryVectorBackend()),
+        batch_size=100,
+    )
+    stats = await runtime.ingest_all(loader=TextLoader("data/my_file.txt"))
+    print(f"chunks embedded: {stats.chunks_embedded}")
+
+    result = await runtime.retrieve("your question here", top_k=5)
+    for rc in result.chunks:
+        print(f"[rank={rc.rank} score={rc.score:.3f}] {rc.chunk.content[:200]}")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### Persistent pipeline (Chroma, recommended for local dev)
 ```python
 import asyncio
 from railtracks.retrieval import RetrievalRuntime
@@ -74,97 +135,156 @@ from railtracks.retrieval.stores import VectorStore, ChromaBackend
 async def create_runtime() -> RetrievalRuntime:
     backend = await ChromaBackend.create(
         collection_name="my-collection",
-        path="./my_db/"         # omit for ephemeral in-memory
+        path="./my_db",
     )
     return RetrievalRuntime(
         chunker=RecursiveCharacterChunker(chunk_size=1000, overlap=200),
-        embedder=OpenAIEmbedding(),
-        store=VectorStore(backend=backend),
-        batch_size=64,
+        embedder=OpenAIEmbedding(model="text-embedding-3-small"),
+        store=VectorStore(backend),
+        batch_size=100,
     )
-```
 
-### Ingestion
-```python
-async def ingest(runtime: RetrievalRuntime) -> None:
-    stats = await runtime.ingest_all(
-        loader=TextLoader("data/my-file.txt")
-    )
-    print(
-        f"loaded={stats.documents_loaded} "
-        f"chunks={stats.chunks_embedded} "
-        f"skipped={stats.documents_skipped}"
-    )
-```
+async def main():
+    runtime = await create_runtime()
+    stats = await runtime.ingest_all(loader=TextLoader("data/my_file.txt"))
+    print(f"loaded={stats.documents_loaded} chunks={stats.chunks_embedded} skipped={stats.documents_skipped}")
 
-### Retrieval
-```python
-async def retrieve(runtime: RetrievalRuntime, query: str, top_k: int = 5) -> list[str]:
-    result = await runtime.retrieve(query=query, top_k=top_k)
-    return [rc.chunk.content for rc in result.chunks]
-```
-
-### RAG Agent (retrieval as a tool)
-```python
-import railtracks as rt
-
-# Build runtime once at module level (shared across calls)
-_runtime: RetrievalRuntime | None = None
-
-@rt.function_node
-async def search_documents(query: str) -> str:
-    """Search the document store and return relevant text passages.
-    Args:
-        query: The question or topic to look up.
-    Returns:
-        Relevant passages joined by newlines.
-    """
-    result = await _runtime.retrieve(query=query, top_k=5)
-    return "\n---\n".join(rc.chunk.content for rc in result.chunks)
-
-RAGAgent = rt.agent_node(
-    "RAG Agent",
-    tool_nodes=[search_documents],
-    llm=rt.llm.AnthropicLLM("claude-sonnet-4-6"),
-    system_message=(
-        "You are a helpful assistant. Use the search_documents tool to look up "
-        "information before answering. Always ground your answer in retrieved passages."
-    ),
-)
-flow = rt.Flow(name="RAG Flow", entry_point=RAGAgent)
+    result = await runtime.retrieve("your question here", top_k=5)
+    for rc in result.chunks:
+        print(f"[rank={rc.rank} score={rc.score:.3f}]\n{rc.chunk.content}\n")
 
 if __name__ == "__main__":
-    async def main():
-        global _runtime
-        _runtime = await create_runtime()
-        # Ingest once, then query
-        await ingest(_runtime)
-        result = flow.invoke("Your question here")
-        print(result)
     asyncio.run(main())
 ```
 
-### Streaming Ingestion Events
+### Streaming ingestion events (for progress / error handling)
 ```python
-async def ingest_streaming(runtime: RetrievalRuntime) -> None:
-    async for event in runtime.ingest(loader=TextLoader("data/large-file.txt")):
-        print(event)   # BatchIngested | EmbeddingFailure | DocumentFailed | DocumentSkipped
+from railtracks.retrieval import RetrievalRuntime
+from railtracks.retrieval.runtime import BatchIngested, DocumentFailed, DocumentSkipped
+
+async def ingest_with_progress(runtime: RetrievalRuntime, loader) -> None:
+    async for event in runtime.ingest(loader=loader):
+        if isinstance(event, BatchIngested):
+            print(f"batch {event.batch}: {event.chunks_written} chunks written")
+        elif isinstance(event, DocumentFailed):
+            print(f"FAILED: {event.document_id} — {event.error}")
+        elif isinstance(event, DocumentSkipped):
+            print(f"skipped (unchanged): {event.document_id}")
 ```
 
-### Multiple Queries
+### PDF ingestion
 ```python
-async def ask_many(runtime: RetrievalRuntime, queries: list[str], top_k: int = 5):
-    return [
-        await runtime.retrieve(query=q, top_k=top_k)
-        for q in queries
-    ]
+from railtracks.retrieval.loaders import PyPDFLoader
+from railtracks.retrieval.chunking import RecursiveCharacterChunker
+
+# strategy="page" (default): one Document per page
+# strategy="document": one Document for the whole PDF
+loader = PyPDFLoader("data/report.pdf", strategy="page")
+chunker = RecursiveCharacterChunker(chunk_size=800, overlap=100)
+```
+
+### CSV / structured data ingestion
+```python
+from railtracks.retrieval.loaders import CSVLoader
+
+# content_col: the column whose text gets embedded
+# metadata_cols: columns stored as metadata for filtering
+loader = CSVLoader(
+    file_path="data/products.csv",
+    content_col="description",
+    metadata_cols=["product_id", "category", "price"],
+)
+```
+
+### HuggingFace dataset ingestion
+```python
+from railtracks.retrieval.loaders import HuggingFaceDatasetLoader
+
+loader = HuggingFaceDatasetLoader(
+    dataset_name="squad",
+    split="train",
+    text_column="context",
+)
+```
+
+### Multi-tenancy with StoreScope
+```python
+from railtracks.retrieval.stores import StoreScope
+
+user_scope = StoreScope(labels={"user_id": "u123", "org_id": "acme"})
+
+# Write: ingest only into this scope
+stats = await runtime.ingest_all(loader=loader, scope=user_scope)
+
+# Read: retrieve only from this scope
+result = await runtime.retrieve("question", top_k=5, scope=user_scope)
+
+# Delete all documents for this scope
+await runtime.store.clear(user_scope)
+```
+
+### RAG as an agent tool
+```python
+import railtracks as rt
+from railtracks.retrieval import RetrievalRuntime
+
+runtime: RetrievalRuntime = ...  # constructed at startup
+
+@rt.function_node
+async def search_knowledge_base(query: str) -> str:
+    """Search the knowledge base for relevant context.
+    Args:
+        query: The natural language question to look up.
+    Returns:
+        Relevant excerpts from the knowledge base, ranked by similarity.
+    """
+    result = await runtime.retrieve(query, top_k=5)
+    if not result.chunks:
+        return "No relevant documents found."
+    return "\n\n---\n\n".join(
+        f"[score={rc.score:.3f}]\n{rc.chunk.content}"
+        for rc in result.chunks
+    )
+
+RagAgent = rt.agent_node(
+    "RAG Agent",
+    tool_nodes=[search_knowledge_base],
+    llm=rt.llm.AnthropicLLM("claude-sonnet-4-6"),
+    system_message="You are a helpful assistant. Always search the knowledge base before answering.",
+)
+flow = rt.Flow(name="RAG Flow", entry_point=RagAgent)
+```
+
+### Sentence chunking (narrative / long-form text)
+```python
+from railtracks.retrieval.chunking import SentenceChunker
+
+# chunk_size: number of sentences per chunk
+# overlap: number of sentences shared between consecutive chunks
+chunker = SentenceChunker(chunk_size=6, overlap=1)
+```
+
+### Local/offline embeddings with Ollama
+```python
+from railtracks.retrieval.embedding import OllamaEmbedding
+
+embedder = OllamaEmbedding(model="nomic-embed-text", base_url="http://localhost:11434")
+```
+
+### Delete a document from the store
+```python
+# Re-ingest will upsert (content-hash skips unchanged docs)
+# To explicitly remove:
+await runtime.delete_document(document_id="doc-uuid-here")
 ```
 
 ---
 
-## Things to Avoid
-- Don't re-create `RetrievalRuntime` on every query — instantiate it once and reuse it.
-- Don't skip `await Backend.create(...)` — backends are async-initialized; constructing them directly without `create()` leaves them unready.
-- Don't ignore `stats.documents_skipped` — skipped documents usually mean duplicate IDs; the store de-dupes by content hash so re-running ingestion is safe.
-- Don't use `SemanticChunker` with a different embedder than the one used for retrieval — the vector spaces must match.
-- Don't hardcode the collection name across ingest and retrieve calls — put it in one place so they stay in sync.
+## Things to avoid
+- Don't call `ChromaBackend(...)` without `await backend.initialize()` — use `await ChromaBackend.create(...)` as the factory instead, it handles initialization.
+- Don't mix embedding models across ingest and retrieve calls on the same collection — railtracks raises `EmbeddingModelMismatchError` to prevent silent vector corruption.
+- Don't buffer the entire corpus in memory before ingesting — use `ingest_all()` with a loader that streams (`astream()`); never call `loader.aload()` manually and pass the list directly.
+- Don't skip `documents_failed` in ingestion stats — always check and surface failures to the user.
+- Don't use `InMemoryVectorBackend` in production — vectors are lost on process restart; use `ChromaBackend` with a `path` or `PgvectorBackend`.
+- Don't construct `RetrievalRuntime` inside a request handler on every call — build it once at startup and reuse it.
+- Don't pass raw document text directly to `retrieve()` as a query — `retrieve()` takes the user's natural language question, not a chunk.

--- a/packages/railtracks/src/railtracks/cli/skills/rag-pipeline.md
+++ b/packages/railtracks/src/railtracks/cli/skills/rag-pipeline.md
@@ -1,0 +1,170 @@
+# Build a Railtracks RAG Pipeline
+
+The user wants to build a retrieval-augmented generation (RAG) pipeline using railtracks: $ARGUMENTS
+
+## How railtracks retrieval works
+- **Loaders** read source documents (files, PDFs, CSVs, cloud storage, databases) and yield `Document` objects.
+- **Chunkers** split each document into smaller overlapping `Chunk` objects that fit inside an embedding window.
+- **Embedders** convert chunks (and later, queries) into dense vectors.
+- **Stores** persist chunks with their vectors and support nearest-neighbour lookup.
+- **`RetrievalRuntime`** wires loader → chunker → embedder → store into `ingest_all()` and `retrieve()` calls.
+
+### Loader Selection
+| Source | Class | Key params |
+|---|---|---|
+| `.txt` / `.md` file | `TextLoader` | `file_path` |
+| PDF | `PyPDFLoader` | `file_path`, `breakdown_strategy="page"\|"document"` |
+| PDF + OCR fallback | `PyPDFOCRLoader` | `file_path`, `force_ocr=False` |
+| CSV | `CSVLoader` | `file_path`, `content_columns`, `ignore_columns` |
+| JSON | `JSONLoader` | `file_path`, `content_keys="*"` |
+| AWS S3 | `S3Loader` | `bucket`, `prefix`, `keys` |
+| SQL database | `SQLLoader` | `connection_string`, `table_or_query`, `content_column` |
+
+### Chunker Selection
+| Use case | Class | Key params |
+|---|---|---|
+| General prose (recommended default) | `RecursiveCharacterChunker` | `chunk_size=1000`, `overlap=200` |
+| Sentence-boundary aware | `SentenceChunker` | `chunk_size=5` (sentences), `overlap=1` |
+| Token-precise | `FixedTokenChunker` | `chunk_size=400`, `overlap=200` |
+| Markdown / structured docs | `MarkdownHeaderChunker` | `chunk_size=1000` |
+| Semantic topic boundaries | `SemanticChunker` | `embedder=<same embedder>`, `threshold_percentile=95.0` |
+
+### Embedder Selection
+| Provider | Class | Key params |
+|---|---|---|
+| OpenAI | `OpenAIEmbedding` | `model="text-embedding-3-small"`, `dimensions` |
+| Azure OpenAI | `AzureEmbedding` | `deployment`, `api_base`, `api_version` |
+| Ollama (local) | `OllamaEmbedding` | `model="nomic-embed-text"`, `api_base` |
+| Any LiteLLM provider | `LiteLLMEmbedding` | `model="provider/model-name"` |
+
+### Vector Store / Backend Selection
+| Backend | Class | When to use |
+|---|---|---|
+| Local disk (development) | `ChromaBackend(path="./db")` | No infra needed, persists between runs |
+| In-process ephemeral | `ChromaBackend()` | Testing / one-shot scripts |
+| Remote Chroma server | `ChromaBackend(host=..., port=...)` | Shared/production Chroma |
+| PostgreSQL + pgvector | `PgvectorBackend(dsn=...)` | Production, existing Postgres |
+| In-memory with snapshot | `InMemoryBackend(snapshot_path=...)` | Lightweight local dev |
+
+---
+
+## Steps
+1. **Read the existing code** — check what files already exist in the project before writing anything.
+2. **Choose your components** — pick a loader, chunker, embedder, and backend from the tables above. Ask the user to clarify if the source format or provider is not obvious from `$ARGUMENTS`.
+3. **Create the runtime** — instantiate `ChromaBackend` (or another backend) with `await Backend.create(...)`, wrap it in `VectorStore`, and pass both with the chunker and embedder to `RetrievalRuntime`.
+4. **Ingest documents** — call `await runtime.ingest_all(loader=...)`. Print `stats.documents_loaded`, `stats.chunks_embedded`, and `stats.documents_skipped` so the user can confirm it worked.
+5. **Retrieve** — call `await runtime.retrieve(query=..., top_k=5)`. The result is a `RetrievalResult`; the matched text lives in `result.chunks[i].chunk.content`.
+6. **Wire into an agent (optional)** — if the user wants an LLM to answer questions, wrap `retrieve` in a `@rt.function_node` tool and pass it to `rt.agent_node()`.
+7. **Add invocation code** — include a `if __name__ == "__main__":` block with `asyncio.run(...)` calls for both ingestion and retrieval so the user can run it immediately.
+8. **Check imports** — all retrieval classes live under `railtracks.retrieval` and its sub-modules. Import `asyncio` for `asyncio.run()`.
+
+---
+
+## Patterns to Follow
+
+### Runtime Setup
+```python
+import asyncio
+from railtracks.retrieval import RetrievalRuntime
+from railtracks.retrieval.loaders import TextLoader
+from railtracks.retrieval.chunking import RecursiveCharacterChunker
+from railtracks.retrieval.embedding import OpenAIEmbedding
+from railtracks.retrieval.stores import VectorStore, ChromaBackend
+
+async def create_runtime() -> RetrievalRuntime:
+    backend = await ChromaBackend.create(
+        collection_name="my-collection",
+        path="./my_db/"         # omit for ephemeral in-memory
+    )
+    return RetrievalRuntime(
+        chunker=RecursiveCharacterChunker(chunk_size=1000, overlap=200),
+        embedder=OpenAIEmbedding(),
+        store=VectorStore(backend=backend),
+        batch_size=64,
+    )
+```
+
+### Ingestion
+```python
+async def ingest(runtime: RetrievalRuntime) -> None:
+    stats = await runtime.ingest_all(
+        loader=TextLoader("data/my-file.txt")
+    )
+    print(
+        f"loaded={stats.documents_loaded} "
+        f"chunks={stats.chunks_embedded} "
+        f"skipped={stats.documents_skipped}"
+    )
+```
+
+### Retrieval
+```python
+async def retrieve(runtime: RetrievalRuntime, query: str, top_k: int = 5) -> list[str]:
+    result = await runtime.retrieve(query=query, top_k=top_k)
+    return [rc.chunk.content for rc in result.chunks]
+```
+
+### RAG Agent (retrieval as a tool)
+```python
+import railtracks as rt
+
+# Build runtime once at module level (shared across calls)
+_runtime: RetrievalRuntime | None = None
+
+@rt.function_node
+async def search_documents(query: str) -> str:
+    """Search the document store and return relevant text passages.
+    Args:
+        query: The question or topic to look up.
+    Returns:
+        Relevant passages joined by newlines.
+    """
+    result = await _runtime.retrieve(query=query, top_k=5)
+    return "\n---\n".join(rc.chunk.content for rc in result.chunks)
+
+RAGAgent = rt.agent_node(
+    "RAG Agent",
+    tool_nodes=[search_documents],
+    llm=rt.llm.AnthropicLLM("claude-sonnet-4-6"),
+    system_message=(
+        "You are a helpful assistant. Use the search_documents tool to look up "
+        "information before answering. Always ground your answer in retrieved passages."
+    ),
+)
+flow = rt.Flow(name="RAG Flow", entry_point=RAGAgent)
+
+if __name__ == "__main__":
+    async def main():
+        global _runtime
+        _runtime = await create_runtime()
+        # Ingest once, then query
+        await ingest(_runtime)
+        result = flow.invoke("Your question here")
+        print(result)
+    asyncio.run(main())
+```
+
+### Streaming Ingestion Events
+```python
+async def ingest_streaming(runtime: RetrievalRuntime) -> None:
+    async for event in runtime.ingest(loader=TextLoader("data/large-file.txt")):
+        print(event)   # BatchIngested | EmbeddingFailure | DocumentFailed | DocumentSkipped
+```
+
+### Multiple Queries
+```python
+async def ask_many(runtime: RetrievalRuntime, queries: list[str], top_k: int = 5):
+    return [
+        await runtime.retrieve(query=q, top_k=top_k)
+        for q in queries
+    ]
+```
+
+---
+
+## Things to Avoid
+- Don't re-create `RetrievalRuntime` on every query — instantiate it once and reuse it.
+- Don't skip `await Backend.create(...)` — backends are async-initialized; constructing them directly without `create()` leaves them unready.
+- Don't ignore `stats.documents_skipped` — skipped documents usually mean duplicate IDs; the store de-dupes by content hash so re-running ingestion is safe.
+- Don't use `SemanticChunker` with a different embedder than the one used for retrieval — the vector spaces must match.
+- Don't hardcode the collection name across ingest and retrieve calls — put it in one place so they stay in sync.


### PR DESCRIPTION
## Summary

Adds a `rag-pipeline` skill for AI coding assistants that teaches them how to build retrieval-augmented generation pipelines with railtracks — covering loaders, chunkers, embedders, vector store backends, `RetrievalRuntime`, ingestion event streaming, multi-tenancy via `StoreScope`, and RAG-as-agent-tool patterns.

- `packages/railtracks/src/railtracks/cli/skills/rag-pipeline.md` — new skill file with component reference, 10-step guide, 7 runnable code patterns, and a "things to avoid" section
- `docs/documentation/getting_started/ai_setup.md` — adds `rag-pipeline` to the Available Skills table and adds an installation + prompt example section
- `packages/railtracks/src/railtracks/cli/__init__.py` — adds two CLI help examples for `railtracks add claude:rag-pipeline` and `railtracks add copilot:rag-pipeline`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

The skill is content-only (no new Python code), so no tests are required. Once merged, users can install it with:

```bash
railtracks add claude:rag-pipeline
railtracks add copilot:rag-pipeline
railtracks add cursor:rag-pipeline
