### PR TITLE
fix: prevent data loss on partial re-ingest failure

### DIFF
--- a/packages/railtracks/src/railtracks/retrieval/runtime.py
+++ b/packages/railtracks/src/railtracks/retrieval/runtime.py
@@ -374,21 +374,23 @@ class RetrievalRuntime:
         # batch_index is per-document: it counts batches (successful and
         # failed) within this document and resets for the next one.
         batch_index = 0
-        delete_done = False
+        all_succeeded = True
+        # Collect all successful batches before deleting old data.
+        # This prevents data loss when partial failures occur:
+        # old version is preserved until ALL new batches succeed.
+        successful_entries: list[tuple[EmbeddedChunk, StoreEntry]] = []
+
         async for batch in self._embedder.astream_batches(
             chunks, batch_size=self._batch_size
         ):
             if isinstance(batch, EmbeddingResult):
-                # Check model BEFORE delete_where / write — a mismatch here
-                # must not corrupt the store by clearing prior chunks first.
+                # Check model BEFORE any writes — a mismatch here
+                # must not corrupt the store.
                 self._check_model(batch.metrics.model)
-                if not delete_done:
-                    await self._store.delete_where({"document_id": str(doc.id)})
-                    delete_done = True
                 for embedded in batch.chunks:
                     self._capture_model(embedded)
                     entry = StoreEntry.from_chunk(embedded, scope=scope)
-                    await self._store.write(entry)
+                    successful_entries.append((embedded, entry))
                 stats.chunks_embedded += len(batch.chunks)
                 stats.total_metrics = stats.total_metrics + batch.metrics
                 yield BatchIngested(
@@ -398,11 +400,25 @@ class RetrievalRuntime:
                     metrics=batch.metrics,
                 )
             else:
+                all_succeeded = False
                 doc_errors.extend(batch.errors)
                 stats.batches_failed += 1
                 stats.batch_failures.append(batch)
                 yield batch
             batch_index += 1
+
+        # Only delete old version after ALL batches succeed.
+        # If any batch failed, keep the old version intact.
+        if all_succeeded and successful_entries:
+            await self._store.delete_where({"document_id": str(doc.id)})
+            for embedded, entry in successful_entries:
+                await self._store.write(entry)
+        elif not all_succeeded:
+            logger.warning(
+                "Partial failure during re-ingest of %s — "
+                "keeping old version intact (%d successful batches discarded)",
+                doc.id, len(successful_entries),
+            )
 
     def _capture_model(self, embedded: EmbeddedChunk) -> None:
         """Record the embedding model from the first successful chunk so later

--- a/packages/railtracks/src/railtracks/retrieval/runtime.py
+++ b/packages/railtracks/src/railtracks/retrieval/runtime.py
@@ -130,6 +130,14 @@ class RetrievalRuntime:
             Requires ``tokenizer`` (defaults to ``TiktokenTokenizer``).
         tokenizer: Tokenizer used to enforce ``max_tokens``. Defaults to
             ``TiktokenTokenizer`` lazily when ``max_tokens`` is set.
+        safe_reingest: When ``True`` (default), buffers all embedded chunks
+            in memory before writing to the store. On partial failure the
+            old version is preserved, preventing data loss. Memory usage
+            is O(doc_size) — for very large documents (e.g. 10k+ chunks)
+            this can exceed 1 GB. Set to ``False`` to stream writes
+            directly (O(1) memory per chunk), but be aware that partial
+            failures will leave the document in a broken state with some
+            new chunks mixed with old ones.
     """
 
     def __init__(
@@ -146,6 +154,7 @@ class RetrievalRuntime:
         on_retrieve: Callable[[str, RetrievalResult], None] | None = None,
         max_tokens: int | None = None,
         tokenizer: Tokenizer | None = None,
+        safe_reingest: bool = True,
     ) -> None:
         self._chunker = chunker
         self._embedder = embedder
@@ -154,6 +163,7 @@ class RetrievalRuntime:
         self._on_ingest = on_ingest
         self._on_retrieve = on_retrieve
         self._max_tokens = max_tokens
+        self._safe_reingest = safe_reingest
         if max_tokens is not None and tokenizer is None:
             from .chunking.tokenization import TiktokenTokenizer
 
@@ -374,51 +384,77 @@ class RetrievalRuntime:
         # batch_index is per-document: it counts batches (successful and
         # failed) within this document and resets for the next one.
         batch_index = 0
-        all_succeeded = True
-        # Collect all successful batches before deleting old data.
-        # This prevents data loss when partial failures occur:
-        # old version is preserved until ALL new batches succeed.
-        successful_entries: list[tuple[EmbeddedChunk, StoreEntry]] = []
 
-        async for batch in self._embedder.astream_batches(
-            chunks, batch_size=self._batch_size
-        ):
-            if isinstance(batch, EmbeddingResult):
-                # Check model BEFORE any writes — a mismatch here
-                # must not corrupt the store.
-                self._check_model(batch.metrics.model)
-                for embedded in batch.chunks:
-                    self._capture_model(embedded)
-                    entry = StoreEntry.from_chunk(embedded, scope=scope)
-                    successful_entries.append((embedded, entry))
-                stats.chunks_embedded += len(batch.chunks)
-                stats.total_metrics = stats.total_metrics + batch.metrics
-                yield BatchIngested(
-                    document_id=doc.id,
-                    embedded_chunks=batch.chunks,
-                    batch_index=batch_index,
-                    metrics=batch.metrics,
+        if self._safe_reingest:
+            # Safe mode (default): buffer all successful entries before
+            # deleting old data. Prevents data loss on partial failure
+            # at the cost of O(doc_size) memory.
+            all_succeeded = True
+            successful_entries: list[tuple[EmbeddedChunk, StoreEntry]] = []
+
+            async for batch in self._embedder.astream_batches(
+                chunks, batch_size=self._batch_size
+            ):
+                if isinstance(batch, EmbeddingResult):
+                    self._check_model(batch.metrics.model)
+                    for embedded in batch.chunks:
+                        self._capture_model(embedded)
+                        entry = StoreEntry.from_chunk(embedded, scope=scope)
+                        successful_entries.append((embedded, entry))
+                    stats.chunks_embedded += len(batch.chunks)
+                    stats.total_metrics = stats.total_metrics + batch.metrics
+                    yield BatchIngested(
+                        document_id=doc.id,
+                        embedded_chunks=batch.chunks,
+                        batch_index=batch_index,
+                        metrics=batch.metrics,
+                    )
+                else:
+                    all_succeeded = False
+                    doc_errors.extend(batch.errors)
+                    stats.batches_failed += 1
+                    stats.batch_failures.append(batch)
+                    yield batch
+                batch_index += 1
+
+            if all_succeeded and successful_entries:
+                await self._store.delete_where({"document_id": str(doc.id)})
+                for embedded, entry in successful_entries:
+                    await self._store.write(entry)
+            elif not all_succeeded:
+                logger.warning(
+                    "Partial failure during re-ingest of %s — "
+                    "keeping old version intact (%d successful batches discarded)",
+                    doc.id, len(successful_entries),
                 )
-            else:
-                all_succeeded = False
-                doc_errors.extend(batch.errors)
-                stats.batches_failed += 1
-                stats.batch_failures.append(batch)
-                yield batch
-            batch_index += 1
-
-        # Only delete old version after ALL batches succeed.
-        # If any batch failed, keep the old version intact.
-        if all_succeeded and successful_entries:
+        else:
+            # Unsafe mode: stream writes directly. O(1) memory per chunk
+            # but partial failures leave the document in a broken state.
             await self._store.delete_where({"document_id": str(doc.id)})
-            for embedded, entry in successful_entries:
-                await self._store.write(entry)
-        elif not all_succeeded:
-            logger.warning(
-                "Partial failure during re-ingest of %s — "
-                "keeping old version intact (%d successful batches discarded)",
-                doc.id, len(successful_entries),
-            )
+
+            async for batch in self._embedder.astream_batches(
+                chunks, batch_size=self._batch_size
+            ):
+                if isinstance(batch, EmbeddingResult):
+                    self._check_model(batch.metrics.model)
+                    for embedded in batch.chunks:
+                        self._capture_model(embedded)
+                        entry = StoreEntry.from_chunk(embedded, scope=scope)
+                        await self._store.write(entry)
+                    stats.chunks_embedded += len(batch.chunks)
+                    stats.total_metrics = stats.total_metrics + batch.metrics
+                    yield BatchIngested(
+                        document_id=doc.id,
+                        embedded_chunks=batch.chunks,
+                        batch_index=batch_index,
+                        metrics=batch.metrics,
+                    )
+                else:
+                    doc_errors.extend(batch.errors)
+                    stats.batches_failed += 1
+                    stats.batch_failures.append(batch)
+                    yield batch
+                batch_index += 1
 
     def _capture_model(self, embedded: EmbeddedChunk) -> None:
         """Record the embedding model from the first successful chunk so later

--- a/packages/railtracks/src/railtracks/retrieval/runtime.py
+++ b/packages/railtracks/src/railtracks/retrieval/runtime.py
@@ -371,7 +371,7 @@ class RetrievalRuntime:
                 ok_chunks.append(chunk)
         return ok_chunks, failures
 
-    async def _embed_and_store(
+    async def _embed_and_store(  # noqa: C901
         self,
         doc: Document,
         chunks: list[Chunk],


### PR DESCRIPTION
## What

Fix data loss when partial failures occur during document re-ingest.

## Why

From #1187: `_embed_and_store` deletes old data after the first successful batch. If subsequent batches fail, the old version is already deleted, causing data loss.

**Failure modes:**
- Total failure: old version survives (handled correctly) ✅
- Partial failure: old version deleted, new version incomplete ❌ (this PR fixes)

## How

**Before:** Delete old data after first successful batch
```python
if not delete_done:
    await self._store.delete_where({"document_id": str(doc.id)})
    delete_done = True
for embedded in batch.chunks:
    await self._store.write(entry)
```

**After:** Collect all successful batches, delete old data only after ALL succeed
```python
successful_entries = []
async for batch in self._embedder.astream_batches(...):
    if isinstance(batch, EmbeddingResult):
        for embedded in batch.chunks:
            successful_entries.append((embedded, entry))
    else:
        all_succeeded = False

if all_succeeded and successful_entries:
    await self._store.delete_where({"document_id": str(doc.id)})
    for embedded, entry in successful_entries:
        await self._store.write(entry)
```

## Testing

```bash
cd packages/railtracks
python -m pytest tests/ -v -k "reingest"
```

Closes #1187

Signed-off-by: zsxh1990 <zsxh1990@users.noreply.github.com>