### PR TITLE
Removing requirement for `ToolUseEvaluator` to need more than 1 agent run

### DIFF
--- a/packages/railtracks/src/railtracks/evaluations/evaluators/tool_use_evaluator.py
+++ b/packages/railtracks/src/railtracks/evaluations/evaluators/tool_use_evaluator.py
@@ -253,10 +253,6 @@ class ToolUseEvaluator(Evaluator):
                 tool_breakdown[agg.tool_name].append(agg)
 
         for tool_name in tool_breakdown:
-            if len(tool_breakdown[tool_name]) < 2:
-                raise ValueError(
-                    f"Expected multiple aggregate nodes for tool '{tool_name}' to perform cross-run aggregation, but found only one. Found nodes: {[agg.identifier for agg in tool_breakdown[tool_name]]}"
-                )
             parent = ToolAggregateNode(
                 name=f"Aggregate/{METRICS['Runtime'].name}",
                 metric=METRICS["Runtime"],

--- a/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_tool_use_evaluator.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_tool_use_evaluator.py
@@ -35,13 +35,11 @@ def test_run_failure_rate_zero_when_all_completed(two_agent_data_points):
 
 def test_run_failure_rate_nonzero_when_tool_fails():
     failed = make_tool_call(name="get_price", status=Status.FAILED)
-    adp1 = make_agent_data_point(tool_calls=[failed])
-    # second data point needed for cross-run aggregation
-    adp2 = make_agent_data_point(tool_calls=[make_tool_call(name="get_price")])
-    result = ToolUseEvaluator().run([adp1, adp2])
+    adp = make_agent_data_point(tool_calls=[failed])
+    result = ToolUseEvaluator().run([adp])
     failure_rates = [r for r in result.metric_results if r.result_name.startswith("FailureRate")]
     values = [r.value for r in failure_rates]
-    assert 1.0 in values  # adp1's tool failed
+    assert 1.0 in values
 
 
 def test_run_runtime_results_use_tool_runtime(two_agent_data_points):
@@ -55,11 +53,29 @@ def test_run_aggregate_forest_has_roots(two_agent_data_points):
     assert len(result.aggregate_results.roots) > 0
 
 
-def test_run_single_data_point_raises():
-    """Cross-run Runtime aggregation requires 2+ per-run nodes per tool."""
+def test_run_single_data_point_single_tool_call():
     adp = make_agent_data_point(tool_calls=[make_tool_call(name="get_price")])
-    with pytest.raises(ValueError, match="Expected multiple aggregate nodes"):
-        ToolUseEvaluator().run([adp])
+    result = ToolUseEvaluator().run([adp])
+    metric_names = {m.name for m in result.metrics}
+    assert {"ToolFailure", "Runtime", "FailureRate", "UsageCount"}.issubset(metric_names)
+    assert len(result.aggregate_results.roots) > 0
+
+
+def test_run_single_data_point_multiple_calls_same_tool():
+    adp = make_agent_data_point(
+        tool_calls=[
+            make_tool_call(name="get_price", runtime=0.1),
+            make_tool_call(name="get_price", runtime=0.3),
+            make_tool_call(name="get_price", runtime=0.5),
+        ]
+    )
+    result = ToolUseEvaluator().run([adp])
+
+    usage = [r for r in result.metric_results if r.result_name.startswith("UsageCount")]
+    assert [r.value for r in usage] == [3]
+
+    runtimes = {r.value for r in result.metric_results if r.result_name.startswith("Runtime")}
+    assert runtimes == {0.1, 0.3, 0.5}
 
 
 def test_run_multiple_tools():


### PR DESCRIPTION
Closes #1181 