### PR TITLE
[Feature][Evaluations] accept in-memory payload

### DIFF
--- a/docs/evaluations/conductr.md
+++ b/docs/evaluations/conductr.md
@@ -1,0 +1,29 @@
+## Retrieving Agent Runs
+If you have used [**Conductr**](https://conductr.ai/platform/agent-management-suite/agent-observability/) to store your agent runs, you can directly utilize them and perform evaluations by following the simple steps in the snippet below:
+
+```python
+--8<-- "docs/scripts/evaluations/conductr.py:get"
+```
+
+## Sending Evaluations
+Similar to sending your agent runs to **Conductr**, you can upload your agent evaluations by passing the `upload_agent_evaluation` to the `evaluation` function.
+
+```python
+--8<-- "docs/scripts/evaluations/conductr.py:send_evals"
+```
+
+???+ info "Required API Keys"
+    You will need the following keys set up on your project for the above
+    ### Retreiving Agent Runs
+    ```bash
+    CONDUCTR_PROJECT_PAT="..."
+    CONDUCTR_PROJECT_ID="..."
+    RAILTOWN_API_KEY="..."
+    ```
+    ### Sending Agent Evaluations
+    ```bash
+    RAILTOWN_API_KEY="..."
+    EVALUATIONS_API_TOKEN=".."
+    ```
+
+    Please refer to your **Conductr** project page at <https://cndr.railtown.ai/> for more info.

--- a/docs/observability/agenthub/cloud.md
+++ b/docs/observability/agenthub/cloud.md
@@ -1,2 +1,15 @@
 # Conductr Cloud
-Everything in AgentHub is available locally. To share agent runs, evaluations, or logs with your team, see the [Conductr Observability Platform](https://conductr.ai/platform/agent-management-suite/agent-observability/).
+Everything in AgentHub is available locally. However if you need a central repository for sharing results with your team you can use [**Conductr**](https://conductr.ai/platform/agent-management-suite/agent-observability/). You can use the [railtownai](https://pypi.org/project/railtownai/) package by following the snippet below to send your agent runs:
+
+```python
+--8<-- "docs/scripts/evaluations/conductr.py:send_runs"
+```
+???+ info "Required API Keys"
+    You will need the following keys set up on your project for the above
+    ```bash
+    RAILTOWN_API_KEY=".."
+    ```
+
+    Please refer to your **Conductr** project page at <https://cndr.railtown.ai/> for more info.
+
+For more information including deployments, evaluations, or logs, see the [Conductr Observability Platform](https://conductr.ai/platform/agent-management-suite/agent-observability/).

--- a/docs/scripts/evaluations/conductr.py
+++ b/docs/scripts/evaluations/conductr.py
@@ -1,0 +1,46 @@
+
+# --8<-- [start: get]
+import railtownai
+from railtracks import evaluations as evals
+
+# Select your agent run ids:
+AGENT_RUN_IDS: list[str] = [
+"ID_1",
+"ID_2",
+]
+
+# Retrieve the agent runs
+payload = railtownai.get_agent_runs(AGENT_RUN_IDS, skip_errors=True)
+
+# extract `AgentDataPoint`s
+data = evals.extract_agent_data_points(payload)
+
+# Continue with evaluations as before
+# --8<-- [end: get]
+
+t_evaluator = evals.ToolUseEvaluator()
+llm_evaluator = evals.LLMInferenceEvaluator()
+evaluators = [t_evaluator, llm_evaluator]
+
+# --8<-- [start: send_evals]
+from railtownai import upload_agent_evaluation
+
+results = evals.evaluate(
+    data=data,
+    evaluators=evaluators,
+    payload_callback=upload_agent_evaluation, # Your evals will be sent to Conductr automatically
+)
+# --8<-- [end: send_evals]
+import railtracks
+SomeAgent = railtracks.agent_node()
+
+# --8<-- [start: send_runs]
+import railtracks as rt
+from railtownai import upload_agent_run
+
+my_flow = rt.Flow(
+    "Flow Name",
+    entry_point=SomeAgent,
+    payload_callback=upload_agent_run # Your runs will be sent to Conductr automatically
+)
+# --8<-- [end: send_runs]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
       - Preface: evaluations/preface.md
       - Quickstart: evaluations/quickstart.md
       - Visualization: evaluations/visualization.md
+      - Conductr Agent Observability: evaluations/conductr.md
       - Metrics:
           - Metrics Overview: evaluations/metrics/metrics.md
           - Categorical Metrics: evaluations/metrics/categorical.md

--- a/packages/railtracks/src/railtracks/evaluations/point.py
+++ b/packages/railtracks/src/railtracks/evaluations/point.py
@@ -2,7 +2,7 @@ import json
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -230,7 +230,7 @@ def extract_tool_details(
 
 
 def extract_agent_io(
-    sink_list: dict[UUID, list[EdgeDataPoint]], node: NodeDataPoint, file_path: str
+    sink_list: dict[UUID, list[EdgeDataPoint]], node: NodeDataPoint, session_id: str
 ) -> tuple[dict, dict]:
     """
     Extracts the input and output for an agent node based on its incoming edges.
@@ -238,7 +238,7 @@ def extract_agent_io(
     Args:
         sink_list: A dictionary where keys are target node identifiers and values are lists of EdgeDataPoint instances that have that target.
         node: The NodeDataPoint instance representing the agent node for which to extract input and output.
-        file_path: The path to the session file being processed (used for logging).
+        session_id: The id of the session being processed (used for logging).
     Returns:
         A tuple containing:
             - agent_input: A dictionary with "args" and "kwargs" keys representing the input to the agent.
@@ -258,42 +258,42 @@ def extract_agent_io(
                 agent_output = edge.details.get("output", {})
             else:
                 logger.warning(
-                    f"Duplicate edge with id: {edge.identifier} for source: {edge.source} and target: {edge.target} in session file {file_path}."
+                    f"Duplicate edge with id: {edge.identifier} for source: {edge.source} and target: {edge.target} in session {session_id}."
                 )
     return agent_input, agent_output
 
 
-def resolve_file_paths(session_files: list[str] | str) -> list[str]:
-    """Resolves session_files input to a flat list of file paths.
+def resolve_file_paths(sources: list[str] | str) -> list[str]:
+    """Resolves a directory path or list of file paths to a flat list of file paths.
 
     Args:
-        session_files: A single file path, a directory path, or a list of file paths.
+        sources: A directory path (str) whose files will be enumerated, or a list of file paths.
 
     Returns:
         List of resolved file path strings.
 
     Raises:
         FileNotFoundError: If a path does not exist.
-        ValueError: If a list item is a directory or no files are found.
-        TypeError: If session_files is not a str or list.
+        ValueError: If a str is not a directory, if a list item is a directory, or if no files are found.
+        TypeError: If sources is not a str or list.
     """
     file_paths: list[str] = []
 
-    if isinstance(session_files, str):
-        path = Path(session_files)
-        if path.is_dir():
-            file_paths = [
-                str(f)
-                for f in path.iterdir()
-                if f.is_file() and not f.name.startswith(".")
-            ]
-            logger.info(f"Found {len(file_paths)} files in directory: {session_files}")
-        elif path.is_file():
-            file_paths = [session_files]
-        else:
-            raise FileNotFoundError(f"Path does not exist: {session_files}")
-    elif isinstance(session_files, list):
-        for item in session_files:
+    if isinstance(sources, str):
+        path = Path(sources)
+        if not path.exists():
+            raise FileNotFoundError(f"Path does not exist: {sources}")
+        if not path.is_dir():
+            raise ValueError(
+                f"A single string source must be a directory path; got a file: {sources}. "
+                f'Wrap single files in a list: ["{sources}"].'
+            )
+        file_paths = [
+            str(f) for f in path.iterdir() if f.is_file() and not f.name.startswith(".")
+        ]
+        logger.info(f"Found {len(file_paths)} files in directory: {sources}")
+    elif isinstance(sources, list):
+        for item in sources:
             item_path = Path(item)
             if item_path.is_dir():
                 raise ValueError(
@@ -301,10 +301,10 @@ def resolve_file_paths(session_files: list[str] | str) -> list[str]:
                 )
             if not item_path.is_file():
                 raise FileNotFoundError(f"File does not exist: {item}")
-        file_paths = session_files
+        file_paths = sources
     else:
         raise TypeError(
-            f"session_files must be a string or list of strings, got {type(session_files)}"
+            f"sources must be a string (directory) or list, got {type(sources)}"
         )
 
     if not file_paths:
@@ -313,100 +313,119 @@ def resolve_file_paths(session_files: list[str] | str) -> list[str]:
     return file_paths
 
 
-def extract_agent_data_points(session_files: list[str] | str) -> list[AgentDataPoint]:
-    """
-    Extract AgentDataPoint instances from session JSON files.
-
-    This function processes Railtracks session JSON files and creates AgentDataPoint
-    instances for each agent execution found. It extracts agent inputs, outputs, and
-    internals (including LLM metrics if available).
+def _data_points_from_payload(payload: dict) -> list[AgentDataPoint]:
+    """Parse one in-memory session payload into a list of AgentDataPoint instances.
 
     Args:
-        session_files: List of paths to session JSON files, a single file path, or a directory path.
-                      If a directory is provided, all files within it will be processed.
+        payload: A session dict with the shape produced by load_session (and by
+            railtownai.get_agent_runs): {"session_id": ..., "runs": [...]}.
 
     Returns:
-        List of AgentDataPoint instances, one for each agent execution found in the files.
-        Returns empty list if no valid agent data is found.
+        AgentDataPoint instances for every agent execution in the payload. Empty list if
+        the payload has no session_id or no runs.
     """
-    file_paths = resolve_file_paths(session_files)
-    data_points = []
+    session_id = payload.get("session_id")
+    if session_id is None:
+        logger.warning("no session_id found in payload, skipping.")
+        return []
 
-    for file_path in file_paths:
-        try:
-            session_data = load_session(file_path)
-        except (FileNotFoundError, ValueError) as e:
-            logger.error(str(e))
-            continue
+    runs = payload.get("runs", [])
+    if len(runs) == 0:
+        logger.warning(f"Session {session_id} contains no runs")
+    if len(runs) > 1:
+        logger.warning(f"Session {session_id} contains multiple runs")
 
-        session_id = session_data.get("session_id")
-        if session_id is None:
-            logger.warning(f"no session_id found in file: {file_path}, skipping file.")
-            continue
+    data_points: list[AgentDataPoint] = []
+    for run in runs:
+        nodes = {
+            UUID(node["identifier"]): NodeDataPoint(
+                identifier=node["identifier"],
+                node_type=NodeType(node["node_type"]),
+                name=node["name"],
+                details=node.get("details", {}),
+            )
+            for node in run.get("nodes", [])
+        }
 
-        runs = session_data.get("runs", [])
+        edges: dict[tuple[UUID | None, UUID], EdgeDataPoint] = {}
+        for edge in run.get("edges", []):
+            key = (
+                (UUID(edge["source"]), UUID(edge["target"]))
+                if edge["source"] is not None
+                else (None, UUID(edge["target"]))
+            )
+            edges[key] = EdgeDataPoint(
+                identifier=UUID(edge["identifier"]),
+                source=UUID(edge["source"]) if edge["source"] is not None else None,
+                target=UUID(edge["target"]),
+                details=edge.get("details", {}),
+            )
 
-        if len(runs) == 0:
-            logger.warning(f"Session file {file_path} contains no runs")
-        if len(runs) > 1:
-            logger.warning(f"Session file {file_path} contains multiple runs")
+        graph, sink_list = construct_graph(edges)
 
-        for run in runs:
-            nodes = {
-                UUID(node["identifier"]): NodeDataPoint(
-                    identifier=node["identifier"],
-                    node_type=NodeType(node["node_type"]),
-                    name=node["name"],
-                    details=node.get("details", {}),
+        for node in nodes.values():
+            if node.node_type == NodeType.AGENT:
+                llm_details_dict = node.details.get("internals", {}).get(
+                    "llm_details", []
                 )
-                for node in run.get("nodes", [])
-            }
-
-            edges: dict[tuple[UUID | None, UUID], EdgeDataPoint] = {}
-            for edge in run.get("edges", []):
-                key = (
-                    (UUID(edge["source"]), UUID(edge["target"]))
-                    if edge["source"] is not None
-                    else (None, UUID(edge["target"]))
-                )
-                edges[key] = EdgeDataPoint(
-                    identifier=UUID(edge["identifier"]),
-                    source=UUID(edge["source"]) if edge["source"] is not None else None,
-                    target=UUID(edge["target"]),
-                    details=edge.get("details", {}),
+                llm_details = (
+                    extract_llm_details(llm_details_dict)
+                    if llm_details_dict
+                    else LLMDetails(calls=[])
                 )
 
-            graph, sink_list = construct_graph(edges)
+                tool_details = extract_tool_details(
+                    nodes, edges, graph, node.identifier
+                )
 
-            for node in nodes.values():
-                if node.node_type == NodeType.AGENT:
-                    llm_details_dict = node.details.get("internals", {}).get(
-                        "llm_details", []
-                    )
-                    llm_details = (
-                        extract_llm_details(llm_details_dict)
-                        if llm_details_dict
-                        else LLMDetails(calls=[])
-                    )
+                agent_input, agent_output = extract_agent_io(
+                    sink_list, node, session_id
+                )
 
-                    tool_details = extract_tool_details(
-                        nodes, edges, graph, node.identifier
+                data_points.append(
+                    AgentDataPoint(
+                        identifier=node.identifier,
+                        session_id=UUID(session_id),
+                        agent_name=node.name,
+                        agent_input=agent_input,
+                        agent_output=agent_output,
+                        llm_details=llm_details,
+                        tool_details=tool_details,
                     )
+                )
 
-                    agent_input, agent_output = extract_agent_io(
-                        sink_list, node, file_path
-                    )
+    return data_points
 
-                    data_points.append(
-                        AgentDataPoint(
-                            identifier=node.identifier,
-                            session_id=UUID(session_id),
-                            agent_name=node.name,
-                            agent_input=agent_input,
-                            agent_output=agent_output,
-                            llm_details=llm_details,
-                            tool_details=tool_details,
-                        )
-                    )
 
+def extract_agent_data_points(
+    sources: list[str] | str | list[dict],
+) -> list[AgentDataPoint]:
+    """Extract AgentDataPoint instances from session payloads or session JSON files.
+
+    Args:
+        sources: One of:
+            - list[dict]: in-memory session payloads (e.g. from railtownai.get_agent_runs).
+            - list[str]: file paths to session JSON files.
+            - str: a directory path; all files inside are loaded.
+            A single file or single payload must be wrapped in a list. Mixed lists of
+            files and payloads are not supported.
+
+    Returns:
+        List of AgentDataPoint instances, one per agent execution found across all
+        provided payloads. Returns an empty list if no valid agent data is found.
+    """
+    if isinstance(sources, list) and sources and isinstance(sources[0], dict):
+        payloads: list[dict] = cast(list[dict], sources)
+    else:
+        file_sources = cast("list[str] | str", sources)
+        payloads = []
+        for file_path in resolve_file_paths(file_sources):
+            try:
+                payloads.append(load_session(file_path))
+            except (FileNotFoundError, ValueError) as e:
+                logger.error(str(e))
+
+    data_points: list[AgentDataPoint] = []
+    for payload in payloads:
+        data_points.extend(_data_points_from_payload(payload))
     return data_points

--- a/packages/railtracks/tests/integration_tests/evaluations/test_evaluations.py
+++ b/packages/railtracks/tests/integration_tests/evaluations/test_evaluations.py
@@ -18,7 +18,7 @@ from .conftest import AGENT_ID_1, AGENT_ID_2, SESSION_ID_1, SESSION_ID_2, make_s
 
 def test_correct_llm_values_extracted_from_session(session_file):
     """Values written into the session JSON reach the AgentDataPoint unchanged."""
-    adps = extract_agent_data_points(str(session_file))
+    adps = extract_agent_data_points([str(session_file)])
     call = adps[0].llm_details.calls[0]
     assert call.model_name == "gpt-4"
     assert call.model_provider == "OpenAI"
@@ -30,7 +30,7 @@ def test_correct_llm_values_extracted_from_session(session_file):
 
 def test_correct_tool_values_extracted_from_session(session_file):
     """Tool name and runtime from the session JSON are reflected in the AgentDataPoint."""
-    adps = extract_agent_data_points(str(session_file))
+    adps = extract_agent_data_points([str(session_file)])
     assert "get_stock_price" in adps[0].tool_details.tool_names
     call = adps[0].tool_details.calls[0]
     assert call.name == "get_stock_price"
@@ -39,14 +39,14 @@ def test_correct_tool_values_extracted_from_session(session_file):
 
 def test_agent_io_extracted_from_session(session_file):
     """Agent input and output are parsed from the session edge details."""
-    adps = extract_agent_data_points(str(session_file))
+    adps = extract_agent_data_points([str(session_file)])
     assert "What is the stock price?" in adps[0].agent_input["args"]
     assert adps[0].agent_output == {"answer": "The stock is $100."}
 
 
 def test_session_and_agent_ids_preserved(session_file):
     """UUIDs from the session file are faithfully stored on the AgentDataPoint."""
-    adps = extract_agent_data_points(str(session_file))
+    adps = extract_agent_data_points([str(session_file)])
     assert adps[0].session_id == UUID(SESSION_ID_1)
     assert adps[0].identifier == UUID(AGENT_ID_1)
 

--- a/packages/railtracks/tests/unit_tests/evaluations/conftest.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/conftest.py
@@ -153,4 +153,4 @@ def agent_data_point(tmp_path, session_json):
     """A fully parsed AgentDataPoint, ready to use as input for evaluator tests."""
     path = tmp_path / "session.json"
     path.write_text(json.dumps(session_json))
-    return extract_agent_data_points(str(path))[0]
+    return extract_agent_data_points([str(path)])[0]

--- a/packages/railtracks/tests/unit_tests/evaluations/test_point.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/test_point.py
@@ -160,13 +160,13 @@ def test_extract_tool_details_call_fields(agent_node, tool_nodes, edges):
 
 def test_extract_agent_io_completed_edge(agent_node, edges):
     _, sink_list = construct_graph(edges)
-    agent_input, agent_output = extract_agent_io(sink_list, agent_node, "test.json")
+    agent_input, agent_output = extract_agent_io(sink_list, agent_node, str(SESSION_ID))
     assert agent_input["args"] == ["What is the stock price?"]
     assert agent_output == {"answer": "Here is the stock info"}
 
 
 def test_extract_agent_io_no_edges(agent_node):
-    agent_input, agent_output = extract_agent_io(defaultdict(list), agent_node, "test.json")
+    agent_input, agent_output = extract_agent_io(defaultdict(list), agent_node, str(SESSION_ID))
     assert agent_input == {}
     assert agent_output == {}
 
@@ -182,7 +182,7 @@ def test_extract_agent_io_ignores_failed_edge(agent_node):
             )
         ]
     }
-    agent_input, agent_output = extract_agent_io(failed_sink, agent_node, "test.json")
+    agent_input, agent_output = extract_agent_io(failed_sink, agent_node, str(SESSION_ID))
     assert agent_input == {}
     assert agent_output == {}
 
@@ -190,11 +190,11 @@ def test_extract_agent_io_ignores_failed_edge(agent_node):
 # ── resolve_file_paths ───────────────────────────────────────────────────────
 
 
-def test_resolve_file_paths_single_file(tmp_path, session_json):
+def test_resolve_file_paths_single_file_raises(tmp_path, session_json):
     path = tmp_path / "session.json"
     path.write_text(json.dumps(session_json))
-    result = resolve_file_paths(str(path))
-    assert result == [str(path)]
+    with pytest.raises(ValueError, match="must be a directory"):
+        resolve_file_paths(str(path))
 
 
 def test_resolve_file_paths_list(tmp_path, session_json):
@@ -211,7 +211,7 @@ def test_resolve_file_paths_directory(tmp_path, session_json):
     assert len(result) == 2
 
 
-def test_resolve_file_paths_missing_file():
+def test_resolve_file_paths_missing_path():
     with pytest.raises(FileNotFoundError):
         resolve_file_paths("/nonexistent/path/session.json")
 
@@ -232,7 +232,7 @@ def test_resolve_file_paths_directory_in_list(tmp_path):
 def test_extract_agent_data_points_from_file(tmp_path, session_json):
     path = tmp_path / "session.json"
     path.write_text(json.dumps(session_json))
-    data_points = extract_agent_data_points(str(path))
+    data_points = extract_agent_data_points([str(path)])
     assert len(data_points) == 1
     dp = data_points[0]
     assert dp.agent_name == "TestAgent"
@@ -243,8 +243,39 @@ def test_extract_agent_data_points_from_file(tmp_path, session_json):
 def test_extract_agent_data_points_tool_details(tmp_path, session_json):
     path = tmp_path / "session.json"
     path.write_text(json.dumps(session_json))
-    data_points = extract_agent_data_points(str(path))
+    data_points = extract_agent_data_points([str(path)])
     dp = data_points[0]
     assert "get_stock_price" in dp.tool_details.tool_names
     assert len(dp.tool_details.calls) == 1
     assert dp.tool_details.calls[0].output == 214.88
+
+
+def test_extract_agent_data_points_from_payload_list(session_json):
+    """In-memory payload list works without touching disk."""
+    data_points = extract_agent_data_points([session_json])
+    assert len(data_points) == 1
+    dp = data_points[0]
+    assert dp.agent_name == "TestAgent"
+    assert dp.session_id == SESSION_ID
+    assert len(dp.llm_details.calls) == 1
+
+
+def test_extract_agent_data_points_from_multiple_payloads(session_json):
+    """Each payload in the list yields its own AgentDataPoint(s)."""
+    data_points = extract_agent_data_points([session_json, session_json])
+    assert len(data_points) == 2
+    assert all(dp.session_id == SESSION_ID for dp in data_points)
+
+
+def test_extract_agent_data_points_empty_list_raises():
+    """An empty list still raises (file-path fallthrough preserved)."""
+    with pytest.raises(ValueError):
+        extract_agent_data_points([])
+
+
+def test_extract_agent_data_points_str_file_raises(tmp_path, session_json):
+    """A bare string file path is rejected; str inputs must be directories."""
+    path = tmp_path / "session.json"
+    path.write_text(json.dumps(session_json))
+    with pytest.raises(ValueError, match="must be a directory"):
+        extract_agent_data_points(str(path))


### PR DESCRIPTION
As of the most recent update of the [`railtownai-2.0.14`](https://pypi.org/project/railtownai/) package, users who have previously sent agent runs to Conductr are able to retrieve them.  

This PR users to be able to run evaluations directly on the retrieved payloads by adding support to the `evaluations.extract_agent_data_points`

```python
import railtownai
from railtracks import evaluations as evals

# Select your agent run ids:
AGENT_RUN_IDS: list[str] = [
"ID_1",
"ID_2",
]

# Retrieve the agent runs
payload = railtownai.get_agent_runs(AGENT_RUN_IDS, skip_errors=True)

# extract `AgentDataPoint`s
data = evals.extract_agent_data_points(payload)
# Continue with evalautions as before
```
