### PR TITLE
Fixed rt.function_node for class and instance methods

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
@@ -214,8 +214,15 @@ def function_node(
 
     # assign the correct node class based on whether the function is async or sync
     if asyncio.iscoroutinefunction(func):
+        if inspect.ismethod(func):
+            func = _function_preserving_metadata(func)
         node_class = AsyncDynamicFunctionNode
     elif inspect.isfunction(func):
+        node_class = SyncDynamicFunctionNode
+    elif inspect.ismethod(func):
+        # Bound methods can't hold attributes, so wrap in a plain function first.
+        # functools.wraps preserves __name__, __doc__, and __wrapped__ for the NodeBuilder.
+        func = _function_preserving_metadata(func)
         node_class = SyncDynamicFunctionNode
     elif inspect.isbuiltin(func):
         # builtin functions are written in C and do not have space for the addition of metadata like our node type.

--- a/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/conftest.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/conftest.py
@@ -17,8 +17,8 @@ def mock_schema():
 
 @pytest.fixture
 def mock_function():
-    def f(x : int) -> int:
-        return x
+    def f(x : int, y : int) -> int:
+        return x + y
     return f
 
 @pytest.fixture

--- a/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/conftest.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/conftest.py
@@ -52,6 +52,9 @@ def mock_manifest():
                 name="x",
                 description="Input to the tool",
                 param_type="integer",
-            )]
+            ), Parameter(
+                name="y",
+                description="Another input to the tool",
+                param_type="integer",)]
             )
     return tool_manifest

--- a/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/test_function.py
@@ -1,6 +1,22 @@
+import inspect
 import pytest
 from unittest.mock import patch, MagicMock
 from railtracks.built_nodes.easy_usage_wrappers.function import function_node, _function_preserving_metadata
+
+
+class _SimpleCalc:
+    """Minimal class used to produce bound methods for testing."""
+
+    def __init__(self, offset: int = 0):
+        self.offset = offset
+
+    def add(self, x: int, y: int) -> int:
+        """Add two numbers and apply offset."""
+        return x + y + self.offset
+
+    async def async_add(self, x: int, y: int) -> int:
+        """Async variant."""
+        return x + y + self.offset
 
 @pytest.mark.asyncio
 async def async_func(x):
@@ -45,3 +61,41 @@ def test_function_preserving_metadata():
     wrapped = _function_preserving_metadata(f)
     assert wrapped.__name__ == f.__name__
     assert wrapped(2) == 3
+
+
+# --- Bound method tests ---
+
+def test_function_node_sync_bound_method():
+    # inspect.ismethod() is True for bound methods; inspect.isfunction() is False.
+    # function_node must handle this case without raising NodeCreationError.
+    calc = _SimpleCalc(offset=5)
+    assert inspect.ismethod(calc.add)
+    node = function_node(calc.add)
+    assert hasattr(node, "node_type")
+
+
+def test_function_node_sync_bound_method_preserves_name():
+    calc = _SimpleCalc()
+    node = function_node(calc.add)
+    assert node.__name__ == "add"
+
+
+def test_function_node_sync_bound_method_remains_callable():
+    calc = _SimpleCalc(offset=10)
+    node = function_node(calc.add)
+    assert node(1, 2) == 13
+
+
+def test_function_node_sync_bound_method_with_manifest(mock_manifest):
+    calc = _SimpleCalc()
+    node = function_node(calc.add, manifest=mock_manifest)
+    assert hasattr(node, "node_type")
+
+
+
+
+@pytest.mark.asyncio
+async def test_function_node_async_bound_method():
+    calc = _SimpleCalc(offset=1)
+    node = function_node(calc.async_add)
+    assert hasattr(node, "node_type")

--- a/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/easy_usage_wrappers/test_function.py
@@ -19,7 +19,7 @@ class _SimpleCalc:
         return x + y + self.offset
 
 @pytest.mark.asyncio
-async def async_func(x):
+async def async_func(x, y):
     return x
 
 def test_function_node_sync(mock_function, mock_manifest):


### PR DESCRIPTION
## Summary

Before this PR, you could not wrap methods in rt.function_node after they were bound to an object. this PR allows that to be possible. 

## Type of change

-  [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [x] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
