### PR TITLE
Pooria/1182 whole document chunker

### DIFF
--- a/docs/retrieval/components/chunking/methods.md
+++ b/docs/retrieval/components/chunking/methods.md
@@ -1,6 +1,6 @@
 # Chunking: Built-in methods
 
-Five chunkers ship under `railtracks.retrieval.chunking`. Pick one based on
+Six chunkers ship under `railtracks.retrieval.chunking`. Pick one based on
 your source format and whether you need offsets back.
 
 ---
@@ -9,11 +9,40 @@ your source format and whether you need offsets back.
 
 | Chunker | Best for | Offsets on `Chunk`? |
 |---|---|---|
+| `IdentityChunker` | No splitting; entire document as one chunk. Baseline and pass-through. | Yes (full-document span) |
 | `RecursiveCharacterChunker` | **Default choice.** General text and markdown bodies. | Yes (character spans) |
 | `MarkdownHeaderChunker` | Markdown with `#` / `##` hierarchy; header context in metadata. | Yes (when body spans are known) |
 | `SentenceChunker` | Sentence-window retrieval; overlap measured in *sentences*. | Yes |
 | `SemanticChunker` | Topic boundaries via embeddings; variable chunk size. | Yes (unit spans in source text) |
 | `FixedTokenChunker` | Hard token budget per chunk (e.g. matching embedder max). | No (see note) |
+
+---
+
+## `IdentityChunker`
+
+Emits the entire document as a single chunk. No splitting is performed.
+``Chunk.offsets`` spans ``(0, len(document.content))`` so offset-based slicing
+works correctly downstream, just like with every other chunker.
+
+```python
+from railtracks.retrieval.chunking import IdentityChunker
+
+chunker = IdentityChunker()
+chunks = chunker.chunk(document)
+# len(chunks) == 1 (or 0 for empty documents)
+# chunks[0].content == document.content
+```
+
+**When to use:**
+
+- Short documents that must never be split (e.g. individual FAQ entries,
+  product descriptions, code snippets).
+- Baseline experiments: compare retrieval quality against a splitting strategy
+  with no other variables changed.
+- Pipeline pass-through: adapting a loader's output to a ``Chunker``-based
+  interface when the downstream expects chunks but splitting is undesirable.
+
+**Offsets:** Yes. ``Chunk.offsets == (0, len(document.content))``.
 
 ---
 
@@ -133,6 +162,7 @@ limit.
 
 | Situation | Start with |
 |---|---|
+| Short docs that must stay whole, or pipeline pass-through | `IdentityChunker` |
 | Plain text, HTML-to-text, PDF extract, mixed prose | `RecursiveCharacterChunker` |
 | Markdown with real heading structure | `MarkdownHeaderChunker` (optionally + `chunk_size`) |
 | Sentence-aligned retrieval windows | `SentenceChunker` |

--- a/docs/retrieval/components/chunking/methods.md
+++ b/docs/retrieval/components/chunking/methods.md
@@ -25,12 +25,7 @@ Emits the entire document as a single chunk. No splitting is performed.
 works correctly downstream, just like with every other chunker.
 
 ```python
-from railtracks.retrieval.chunking import IdentityChunker
-
-chunker = IdentityChunker()
-chunks = chunker.chunk(document)
-# len(chunks) == 1 (or 0 for empty documents)
-# chunks[0].content == document.content
+--8<-- "docs/scripts/retrieval/chunking.py:identity"
 ```
 
 **When to use:**

--- a/docs/scripts/retrieval/chunking.py
+++ b/docs/scripts/retrieval/chunking.py
@@ -28,6 +28,15 @@ for c in chunks:
 long_text = "..."
 md_text = "..."
 
+# --8<-- [start:identity]
+from railtracks.retrieval.chunking import IdentityChunker
+
+chunker = IdentityChunker()
+chunks = chunker.chunk(doc)
+# len(chunks) == 1 (or 0 for empty documents)
+# chunks[0].content == doc.content
+# --8<-- [end:identity]
+
 # --8<-- [start:recursive]
 from railtracks.retrieval import Document
 from railtracks.retrieval.chunking import RecursiveCharacterChunker

--- a/packages/railtracks/src/railtracks/retrieval/chunking/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/chunking/__init__.py
@@ -5,6 +5,7 @@ Exposes public chunker types and their base abstractions for use in retrieval pi
 
 from .base import Chunker, Splitter
 from .fixed_token import FixedTokenChunker, TiktokenTokenizer, Tokenizer
+from .identity import IdentityChunker
 from .markdown import MarkdownHeaderChunker
 from .recursive import RecursiveCharacterChunker, RecursiveSplitter
 from .semantic_chunker import SemanticChunker
@@ -13,6 +14,7 @@ from .sentence import RegexSentenceSplitter, SentenceChunker
 __all__ = [
     "Chunker",
     "FixedTokenChunker",
+    "IdentityChunker",
     "MarkdownHeaderChunker",
     "RecursiveCharacterChunker",
     "RecursiveSplitter",

--- a/packages/railtracks/src/railtracks/retrieval/chunking/identity.py
+++ b/packages/railtracks/src/railtracks/retrieval/chunking/identity.py
@@ -1,0 +1,17 @@
+from railtracks.retrieval.models import Chunk, Document
+
+from .base import Chunker
+
+
+class IdentityChunker(Chunker):
+    def chunk(self, document: Document) -> list[Chunk]:
+        text = document.content
+        if not text:
+            return []
+
+        pieces = [text]
+        offsets = [(0, len(text))]
+
+        return self._make_chunks(
+            document, pieces, offsets=offsets
+        )

--- a/packages/railtracks/src/railtracks/retrieval/chunking/identity.py
+++ b/packages/railtracks/src/railtracks/retrieval/chunking/identity.py
@@ -1,10 +1,47 @@
+"""Identity (whole-document) chunker.
+
+Emits the entire document as a single chunk. Useful as a baseline, for
+short documents that should never be split, or as a pass-through stage
+in a pipeline that expects chunked input even when no splitting is needed.
+"""
+
 from railtracks.retrieval.models import Chunk, Document
 
 from .base import Chunker
 
 
 class IdentityChunker(Chunker):
+    """Chunker that returns the entire document as a single :class:`Chunk`.
+
+    No splitting is performed. The emitted chunk's ``offsets`` span the full
+    document (``(0, len(document.content))``), so offset-based slicing still
+    works correctly downstream.
+
+    Returns an empty list when ``document.content`` is empty, consistent
+    with every other chunker in the suite.
+
+    This is the recommended starting point when:
+
+    * Documents are already short enough that splitting would harm retrieval.
+    * You need a ``Chunker``-compatible adapter for a pipeline that expects
+      chunks but you want to preserve full-document context.
+    * You are writing a baseline experiment to compare against splitting
+      strategies.
+    """
+
     def chunk(self, document: Document) -> list[Chunk]:
+        """Return the document as a single chunk, or ``[]`` for empty content.
+
+        Args:
+            document: Source document to wrap. ``document.id`` and
+                ``document.metadata`` propagate onto the produced chunk.
+
+        Returns:
+            A list containing exactly one :class:`Chunk` whose ``content``
+            equals ``document.content`` and whose ``offsets`` are
+            ``(0, len(document.content))``, or an empty list when
+            ``document.content`` is falsy.
+        """
         text = document.content
         if not text:
             return []
@@ -12,6 +49,4 @@ class IdentityChunker(Chunker):
         pieces = [text]
         offsets = [(0, len(text))]
 
-        return self._make_chunks(
-            document, pieces, offsets=offsets
-        )
+        return self._make_chunks(document, pieces, offsets=offsets)

--- a/packages/railtracks/tests/unit_tests/retrieval/chunking/test_cross_chunker.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/chunking/test_cross_chunker.py
@@ -15,6 +15,7 @@ from railtracks.retrieval import Document
 from railtracks.retrieval.chunking import (
     Chunker,
     FixedTokenChunker,
+    IdentityChunker,
     MarkdownHeaderChunker,
     RecursiveCharacterChunker,
     SemanticChunker,
@@ -38,6 +39,7 @@ class _FakeEmbedder(Embedding):
 
 ALL_CHUNKERS = [
     lambda: FixedTokenChunker(chunk_size=50, overlap=10),
+    lambda: IdentityChunker(),
     lambda: RecursiveCharacterChunker(chunk_size=80, overlap=20),
     lambda: SentenceChunker(chunk_size=2, overlap=0),
     lambda: MarkdownHeaderChunker(),

--- a/packages/railtracks/tests/unit_tests/retrieval/chunking/test_identity_chunker.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/chunking/test_identity_chunker.py
@@ -1,0 +1,92 @@
+"""Tests for IdentityChunker."""
+
+from __future__ import annotations
+
+import pytest
+from railtracks.retrieval import Document
+from railtracks.retrieval.chunking import IdentityChunker
+
+
+def test_checklist(chunker_checklist, multi_paragraph_doc, short_doc, empty_doc):
+    chunker_checklist(lambda: IdentityChunker(), multi_paragraph_doc, short_doc, empty_doc)
+
+
+def test_empty_document_returns_empty_list(empty_doc):
+    assert IdentityChunker().chunk(empty_doc) == []
+
+
+def test_single_chunk_returned(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert len(chunks) == 1
+
+
+def test_chunk_content_equals_document_content(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert chunks[0].content == multi_paragraph_doc.content
+
+
+def test_offsets_span_full_document(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert chunks[0].offsets == (0, len(multi_paragraph_doc.content))
+
+
+def test_offsets_slice_back_to_content(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    s, e = chunks[0].offsets
+    assert multi_paragraph_doc.content[s:e] == chunks[0].content
+
+
+def test_document_id_propagated(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert chunks[0].document_id == multi_paragraph_doc.id
+
+
+def test_index_is_zero(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert chunks[0].index == 0
+
+
+def test_metadata_inherited(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    for k, v in multi_paragraph_doc.metadata.items():
+        assert chunks[0].metadata[k] == v
+
+
+def test_metadata_is_independent_copy(multi_paragraph_doc):
+    chunks = IdentityChunker().chunk(multi_paragraph_doc)
+    assert chunks[0].metadata is not multi_paragraph_doc.metadata
+
+    snapshot = dict(multi_paragraph_doc.metadata)
+    chunks[0].metadata["_probe"] = True
+    assert multi_paragraph_doc.metadata == snapshot
+
+
+def test_short_doc_single_chunk(short_doc):
+    chunks = IdentityChunker().chunk(short_doc)
+    assert len(chunks) == 1
+    assert chunks[0].content == short_doc.content
+    assert chunks[0].offsets == (0, len(short_doc.content))
+
+
+def test_chunk_text_convenience(multi_paragraph_doc):
+    chunker = IdentityChunker()
+    text = multi_paragraph_doc.content
+    chunks = chunker.chunk_text(text)
+    assert len(chunks) == 1
+    assert chunks[0].content == text
+
+
+@pytest.mark.asyncio
+async def test_achunk_matches_chunk(multi_paragraph_doc):
+    chunker = IdentityChunker()
+    sync_result = chunker.chunk(multi_paragraph_doc)
+    async_result = await chunker.achunk(multi_paragraph_doc)
+    assert len(async_result) == len(sync_result)
+    assert async_result[0].content == sync_result[0].content
+    assert async_result[0].offsets == sync_result[0].offsets
+    assert async_result[0].document_id == sync_result[0].document_id
+
+
+@pytest.mark.asyncio
+async def test_achunk_empty_document(empty_doc):
+    assert await IdentityChunker().achunk(empty_doc) == []


### PR DESCRIPTION
## Summary

Adds `IdentityChunker`, a new chunker that emits the entire document as a
single `Chunk` with no splitting. It populates `Chunk.offsets` with the
full document span `(0, len(document.content))` and returns an empty list
for empty documents, consistent with every other chunker in the suite. The
chunker is exported from `railtracks.retrieval.chunking`, covered by a
dedicated test file, included in the cross-chunker invariant suite, and
documented in the chunking reference with usage guidance.

closes #1182

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

`IdentityChunker` takes no constructor arguments and is a drop-in
`Chunker` subclass, so it works anywhere the other chunkers do —
including `achunk()`, `chunk_text()`, and `astream_documents()`.

Typical use cases: short documents that must stay whole (FAQ entries,
product descriptions, code snippets), pipeline pass-through when a
`Chunker`-compatible interface is required but splitting is undesirable,
and baseline retrieval experiments to compare against splitting strategies.
