### PR TITLE
pooria/1205 memory tool

### DIFF
--- a/docs/documentation/agent_design/tools/prebuilt/key_value_memory.md
+++ b/docs/documentation/agent_design/tools/prebuilt/key_value_memory.md
@@ -19,7 +19,7 @@ You will usually want to tell the agent how to use memory in your prompt. We pro
 
 ## The Tools
 
-The toolset exposes five tools to the agent:
+The toolset exposes six tools to the agent:
 
 | Tool | Purpose |
 |---|---|

--- a/docs/documentation/agent_design/tools/prebuilt/key_value_memory.md
+++ b/docs/documentation/agent_design/tools/prebuilt/key_value_memory.md
@@ -1,0 +1,60 @@
+# Key-Value Memory Tooling
+A common addition to your agent is a place to remember facts and read them back later — the user's timezone, a project deadline, a preference. Railtracks provides a built-in key-value memory tool you can drop into your agent right away.
+
+## Usage
+Adding the memory tool to your agent is super easy.
+
+```python
+--8<-- "docs/scripts/key_value_memory.py:kv_memory"
+```
+
+!!! Warning
+    Memory is scoped to the `KeyValueMemoryToolSet` instance — all tools returned from the same instance share one namespace. To keep separate memories for different agents, create a separate `KeyValueMemoryToolSet` (with its own store) for each.
+
+You will usually want to tell the agent how to use memory in your prompt. We provide a helper that returns a ready-made guidance string:
+
+```python
+--8<-- "docs/scripts/key_value_memory.py:kv_memory_prompt"
+```
+
+## The Tools
+
+The toolset exposes five tools to the agent:
+
+| Tool | Purpose |
+|---|---|
+| `remember(key, value)` | Save a fact under a key. Re-calling with the same key overwrites the value, so keys should be short and stable (e.g. `user_timezone`). |
+| `recall(key)` | Read back the value stored under a key, or a clear "not found" message. |
+| `forget(key)` | Delete the fact under a key. Forgetting an absent key is a reported no-op. |
+| `list_keys()` | List just the stored keys, without their values — cheaper on context than `list_memories()` when the agent only needs to see what exists. |
+| `list_memories()` | List every stored `key: value` pair. |
+| `search_memories(query)` | Find entries by case-insensitive substring across keys and values — useful when the agent recalls roughly what a fact was about but not the exact key. |
+
+## Persistence
+
+By default the toolset uses a fresh in-process store, so memory lasts only for the life of the object. To persist memory across runs, pass an `InMemoryKeyValueStore` constructed with a `snapshot_path` — the store loads from that file on startup and flushes to it after every change, with no external dependencies.
+
+```python
+--8<-- "docs/scripts/key_value_memory.py:kv_memory_persistent"
+```
+
+The `store` argument accepts any object implementing the
+[`KeyValueStore`][railtracks.retrieval.stores.key_value.KeyValueStore] protocol,
+so you can supply your own backend (a database, Redis, etc.) without changing
+the toolset.
+
+## Connecting memory to a larger system
+
+The `on_change` callback fires after every mutation, letting the outer system react in real time — push to a UI, mirror to a database, or trigger a notification. It is called as `on_change(key, value)`, where `value` is the new value on a save and `None` on a forget.
+
+```python
+--8<-- "docs/scripts/key_value_memory.py:kv_memory_callback"
+```
+
+You can also inspect memory directly at any point via the toolset's `store` —
+useful for logging, assertions, or driving downstream logic once the agent
+finishes. The store is async:
+
+```python
+--8<-- "docs/scripts/key_value_memory.py:kv_memory_inspection"
+```

--- a/docs/documentation/agent_design/tools/prebuilt/overview.md
+++ b/docs/documentation/agent_design/tools/prebuilt/overview.md
@@ -3,3 +3,4 @@ Railtracks provides a set of built-in tools that help you skip the engineering p
 
 ## Overview of Pre-Built Tools
 - [To Do Tool](todos.md): A tool for your agent to track and plan out todo's. This tool allows your agent to create, manage, and persist to do items across interactions.
+- [Key-Value Memory Tool](key_value_memory.md): A tool for your agent to remember facts under keys and recall them later. Supports listing, substring search, and optional persistence across runs.

--- a/docs/scripts/key_value_memory.py
+++ b/docs/scripts/key_value_memory.py
@@ -1,0 +1,57 @@
+# --8<-- [start: kv_memory]
+import railtracks as rt
+
+# create your key-value memory toolset (defaults to an in-process store)
+memory = rt.prebuilt.KeyValueMemoryToolSet()
+
+agent = rt.agent_node(
+    name="Memory Agent",
+    tool_nodes=[*memory.tool_set()],  # the tools your agent can call
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message="...",
+)
+# --8<-- [end: kv_memory]
+
+# --8<-- [start: kv_memory_prompt]
+# the tool set provides a class method returning a prompt that guides the agent.
+rt.prebuilt.KeyValueMemoryToolSet.prompt()
+# --8<-- [end: kv_memory_prompt]
+
+# --8<-- [start: kv_memory_persistent]
+import railtracks as rt
+from railtracks.retrieval.stores.key_value import InMemoryKeyValueStore
+
+# pass a store with a snapshot_path to persist memory across runs
+memory = rt.prebuilt.KeyValueMemoryToolSet(
+    store=InMemoryKeyValueStore(snapshot_path="memory.json"),
+)
+
+agent = rt.agent_node(
+    name="Memory Agent",
+    tool_nodes=[*memory.tool_set()],
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message=rt.prebuilt.KeyValueMemoryToolSet.prompt(),
+)
+# --8<-- [end: kv_memory_persistent]
+
+# --8<-- [start: kv_memory_callback]
+import railtracks as rt
+
+# called after every save (value=<new value>) and forget (value=None) —
+# use it to mirror memory to a UI, a database, or a log.
+def on_change(key: str, value: str | None):
+    if value is None:
+        print(f"Agent forgot {key!r}")
+    else:
+        print(f"Agent remembered {key!r} = {value!r}")
+
+memory = rt.prebuilt.KeyValueMemoryToolSet(on_change=on_change)
+# --8<-- [end: kv_memory_callback]
+
+# --8<-- [start: kv_memory_inspection]
+# inspect memory directly at any point (the store is async)
+import asyncio
+
+print(asyncio.run(memory.store.items()))
+# {"user_timezone": "PST", "project_deadline": "2026-07-01"}
+# --8<-- [end: kv_memory_inspection]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ nav:
               - Prebuilt Tools:
                   - Overview: documentation/agent_design/tools/prebuilt/overview.md
                   - To Do Tool: documentation/agent_design/tools/prebuilt/todos.md
+                  - Key-Value Memory Tool: documentation/agent_design/tools/prebuilt/key_value_memory.md
               - Function Tools: documentation/agent_design/tools/function_tools.md
               - Agents as Tools: documentation/agent_design/tools/agents_as_tools.md
               - MCP: documentation/agent_design/tools/mcp.md

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -104,7 +104,7 @@ retrieval = [
     "railtracks[stores-all]",
 ]
 
-all = ["railtracks[visual]", "railtracks[portkey]"]
+all = ["railtracks[visual]", "railtracks[portkey]", "railtracks[retrieval]"]
 
 [project.scripts]
 railtracks = "railtracks.cli:main"

--- a/packages/railtracks/src/railtracks/prebuilt/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/__init__.py
@@ -1,6 +1,8 @@
 ######## This package contains a suite of pre-built ready to use agents designed to help you build faster #########
+from .tools.memory import KeyValueMemoryToolSet
 from .tools.todos import ToDoToolSet
 
 __all__ = [
+    "KeyValueMemoryToolSet",
     "ToDoToolSet",
 ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/memory/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/memory/__init__.py
@@ -1,0 +1,5 @@
+from .key_value import KeyValueMemoryToolSet
+
+__all__ = [
+    "KeyValueMemoryToolSet",
+]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
@@ -121,6 +121,21 @@ class KeyValueMemoryToolSet(ToolSet):
             return "No memories stored."
         return "\n".join(f"- {key}: {value}" for key, value in items.items())
 
+    async def list_keys(self) -> str:
+        """List just the keys currently held in memory, without their values.
+
+        Prefer this over list_memories() to see what is stored without pulling
+        every value into context; then recall(key) only the ones you need.
+
+        Returns:
+            A newline-separated list of keys, or a message saying memory is
+            empty.
+        """
+        keys = await self.store.keys()
+        if not keys:
+            return "No memories stored."
+        return "\n".join(f"- {key}" for key in keys)
+
     async def search_memories(self, query: str) -> str:
         """Search stored memories for a substring across keys and values.
 
@@ -151,7 +166,8 @@ class KeyValueMemoryToolSet(ToolSet):
             "Call remember(key, value) to save a fact under a short, stable, descriptive key; "
             "re-calling remember() with the same key overwrites the old value. "
             "Call recall(key) to read a fact back, and forget(key) to delete one. "
-            "If you are unsure of the exact key, call search_memories() to find by substring "
+            "If you are unsure of the exact key, call search_memories() to find by substring, "
+            "list_keys() to see what is stored without pulling in every value, "
             "or list_memories() to see everything stored. "
             "Save anything the user tells you that may be useful later (preferences, names, goals, "
             "constraints), and recall before asking the user to repeat themselves."
@@ -162,6 +178,7 @@ class KeyValueMemoryToolSet(ToolSet):
             self.remember,
             self.recall,
             self.forget,
+            self.list_keys,
             self.list_memories,
             self.search_memories,
         ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import railtracks as rt
+from railtracks.built_nodes.concrete.function_base import RTFunction
+from railtracks.retrieval.stores.key_value import (
+    InMemoryKeyValueStore,
+    KeyValueStore,
+)
+from railtracks.utils.logging.create import get_rt_logger
+
+from .._base import ToolSet
+
+logger = get_rt_logger(__name__)
+
+
+class KeyValueMemoryToolSet(ToolSet):
+    """Prebuilt key-value memory tools for an agent.
+
+    Gives an agent a persistent, exact-match scratch pad: save a fact under a
+    key, read it back later, forget it, list everything, or search. State lives
+    in the injected :class:`~railtracks.retrieval.stores.key_value.KeyValueStore`
+    (defaults to an in-process :class:`InMemoryKeyValueStore`). Pass a store
+    constructed with a ``snapshot_path`` for persistence across runs::
+
+        store = InMemoryKeyValueStore(snapshot_path="memory.json")
+        toolset = KeyValueMemoryToolSet(store=store)
+
+    All memory in a toolset shares one namespace. To keep separate memories for
+    different agents, give each its own ``KeyValueMemoryToolSet`` (and its own
+    store).
+
+    Args:
+        store: Backing key-value store. Defaults to a fresh, ephemeral
+            ``InMemoryKeyValueStore``.
+        on_change: Optional callback fired after every mutation, letting an
+            outer system react (push to a UI, mirror to a database, log).
+            Called as ``on_change(key, value)`` where ``value`` is the new
+            value on a save and ``None`` on a forget. Exceptions raised by the
+            callback are logged and swallowed so they never break a tool call.
+    """
+
+    def __init__(
+        self,
+        store: KeyValueStore | None = None,
+        on_change: Callable[[str, str | None], None] | None = None,
+    ) -> None:
+        self.store: KeyValueStore = (
+            store if store is not None else InMemoryKeyValueStore()
+        )
+        self.on_change = on_change
+
+    def _notify(self, key: str, value: str | None) -> None:
+        if self.on_change is None:
+            return
+        try:
+            self.on_change(key, value)
+        except Exception as e:
+            logger.error(f"Error in on_change callback for key {key!r}: {e}")
+
+    async def remember(self, key: str, value: str) -> str:
+        """Save a fact to memory under a key, for recall later.
+
+        If the key already holds a value it is overwritten, so use a stable,
+        descriptive key (e.g. "user_timezone", "project_deadline") and re-call
+        remember() to update a fact.
+
+        Args:
+            key: Short, stable identifier for the fact (used to recall it).
+            value: The fact to store, as a self-contained string.
+
+        Returns:
+            A confirmation that the fact was stored.
+        """
+        await self.store.set(key, value)
+        self._notify(key, value)
+        return f"Remembered '{key}': {value}"
+
+    async def recall(self, key: str) -> str:
+        """Recall the value previously stored under a key.
+
+        Args:
+            key: The exact key the fact was stored under.
+
+        Returns:
+            The stored value, or a message saying nothing is stored under that
+            key. Use list_memories() if you are unsure of the exact key.
+        """
+        value = await self.store.get(key)
+        if value is None:
+            return f"No memory found under key '{key}'."
+        return value
+
+    async def forget(self, key: str) -> str:
+        """Delete the fact stored under a key.
+
+        Args:
+            key: The key to remove. Forgetting a key that does not exist is a
+                no-op and is reported as such.
+
+        Returns:
+            A confirmation describing what happened.
+        """
+        existed = await self.store.get(key) is not None
+        await self.store.delete(key)
+        self._notify(key, None)
+        if existed:
+            return f"Forgot '{key}'."
+        return f"Nothing was stored under '{key}'; nothing to forget."
+
+    async def list_memories(self) -> str:
+        """List every key and value currently held in memory.
+
+        Returns:
+            A newline-separated "key: value" listing, or a message saying
+            memory is empty.
+        """
+        items = await self.store.items()
+        if not items:
+            return "No memories stored."
+        return "\n".join(f"- {key}: {value}" for key, value in items.items())
+
+    async def search_memories(self, query: str) -> str:
+        """Search stored memories for a substring across keys and values.
+
+        Use this when you remember roughly what a fact was about but not the
+        exact key. Matching is case-insensitive.
+
+        Args:
+            query: Substring to look for in keys and values.
+
+        Returns:
+            Matching "key: value" entries, or a message saying nothing matched.
+        """
+        needle = query.casefold()
+        items = await self.store.items()
+        matches = [
+            f"- {key}: {value}"
+            for key, value in items.items()
+            if needle in key.casefold() or needle in value.casefold()
+        ]
+        if not matches:
+            return f"No memories matched '{query}'."
+        return "\n".join(matches)
+
+    @classmethod
+    def prompt(cls) -> str:
+        return (
+            "Use the memory tools to remember facts across the conversation. "
+            "Call remember(key, value) to save a fact under a short, stable, descriptive key; "
+            "re-calling remember() with the same key overwrites the old value. "
+            "Call recall(key) to read a fact back, and forget(key) to delete one. "
+            "If you are unsure of the exact key, call search_memories() to find by substring "
+            "or list_memories() to see everything stored. "
+            "Save anything the user tells you that may be useful later (preferences, names, goals, "
+            "constraints), and recall before asking the user to repeat themselves."
+        )
+
+    def tool_set(self) -> list[RTFunction]:
+        functions = [
+            self.remember,
+            self.recall,
+            self.forget,
+            self.list_memories,
+            self.search_memories,
+        ]
+        return [rt.function_node(func) for func in functions]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/memory/key_value.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import railtracks as rt
 from railtracks.built_nodes.concrete.function_base import RTFunction
-from railtracks.retrieval.stores.key_value import (
-    InMemoryKeyValueStore,
-    KeyValueStore,
-)
 from railtracks.utils.logging.create import get_rt_logger
 
 from .._base import ToolSet
 
+if TYPE_CHECKING:
+    from railtracks.retrieval.stores.key_value import KeyValueStore
+
 logger = get_rt_logger(__name__)
+
+
+def _default_store() -> KeyValueStore:
+    from railtracks.retrieval.stores.key_value import InMemoryKeyValueStore
+
+    return InMemoryKeyValueStore()
 
 
 class KeyValueMemoryToolSet(ToolSet):
@@ -46,9 +51,7 @@ class KeyValueMemoryToolSet(ToolSet):
         store: KeyValueStore | None = None,
         on_change: Callable[[str, str | None], None] | None = None,
     ) -> None:
-        self.store: KeyValueStore = (
-            store if store is not None else InMemoryKeyValueStore()
-        )
+        self.store: KeyValueStore = store if store is not None else _default_store()
         self.on_change = on_change
 
     def _notify(self, key: str, value: str | None) -> None:

--- a/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/__init__.py
@@ -1,3 +1,4 @@
+from .key_value import InMemoryKeyValueStore, KeyValueStore
 from .models import (
     Entity,
     RetrievedStoreEntry,
@@ -20,7 +21,9 @@ __all__ = [
     "ChromaCloudBackend",
     "DistanceMetric",
     "Entity",
+    "InMemoryKeyValueStore",
     "InMemoryVectorBackend",
+    "KeyValueStore",
     "PgvectorBackend",
     "RetrievedStoreEntry",
     "Store",

--- a/packages/railtracks/src/railtracks/retrieval/stores/key_value/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/key_value/__init__.py
@@ -1,0 +1,7 @@
+from .in_memory import InMemoryKeyValueStore
+from .protocol import KeyValueStore
+
+__all__ = [
+    "InMemoryKeyValueStore",
+    "KeyValueStore",
+]

--- a/packages/railtracks/src/railtracks/retrieval/stores/key_value/in_memory.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/key_value/in_memory.py
@@ -21,9 +21,7 @@ class InMemoryKeyValueStore:
     def __init__(self, snapshot_path: str | Path | None = None) -> None:
         self._data: dict[str, str] = {}
         self._lock = asyncio.Lock()
-        self._snapshot_path = (
-            Path(snapshot_path) if snapshot_path is not None else None
-        )
+        self._snapshot_path = Path(snapshot_path) if snapshot_path is not None else None
 
         if self._snapshot_path is not None and self._snapshot_path.exists():
             self._data = json.loads(self._snapshot_path.read_text())

--- a/packages/railtracks/src/railtracks/retrieval/stores/key_value/in_memory.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/key_value/in_memory.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+
+class InMemoryKeyValueStore:
+    """Reference :class:`KeyValueStore` backed by an in-process dict.
+
+    Thread-safe via ``asyncio.Lock``. When ``snapshot_path`` is provided the
+    state is loaded from that file on construction and flushed back to it after
+    every mutating operation (``set``, ``delete``, ``clear``), giving
+    lightweight persistence with no external dependencies. This mirrors the
+    persistence model of the vector
+    :class:`~railtracks.retrieval.stores.vector.backends.in_memory.InMemoryBackend`:
+    leave ``snapshot_path`` unset for an ephemeral store, pass a path for a
+    persistent one.
+    """
+
+    def __init__(self, snapshot_path: str | Path | None = None) -> None:
+        self._data: dict[str, str] = {}
+        self._lock = asyncio.Lock()
+        self._snapshot_path = (
+            Path(snapshot_path) if snapshot_path is not None else None
+        )
+
+        if self._snapshot_path is not None and self._snapshot_path.exists():
+            self._data = json.loads(self._snapshot_path.read_text())
+
+    async def set(self, key: str, value: str) -> None:
+        async with self._lock:
+            self._data[key] = value
+            await self._flush()
+
+    async def get(self, key: str) -> str | None:
+        async with self._lock:
+            return self._data.get(key)
+
+    async def delete(self, key: str) -> None:
+        async with self._lock:
+            self._data.pop(key, None)
+            await self._flush()
+
+    async def keys(self) -> list[str]:
+        async with self._lock:
+            return list(self._data.keys())
+
+    async def items(self) -> dict[str, str]:
+        async with self._lock:
+            return dict(self._data)
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._data.clear()
+            await self._flush()
+
+    async def _flush(self) -> None:
+        """Persist current state to ``snapshot_path``. Must hold ``_lock``.
+
+        The JSON encode runs on the event loop (the snapshot is consistent with
+        the in-memory state held by the lock); the disk write is offloaded to a
+        thread so the event loop is not blocked on I/O.
+        """
+        if self._snapshot_path is None:
+            return
+        payload = json.dumps(self._data)
+        await asyncio.to_thread(self._snapshot_path.write_text, payload)

--- a/packages/railtracks/src/railtracks/retrieval/stores/key_value/protocol.py
+++ b/packages/railtracks/src/railtracks/retrieval/stores/key_value/protocol.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KeyValueStore(Protocol):
+    """Exact-match key-value persistence.
+
+    A deliberately separate contract from the vector
+    :class:`~railtracks.retrieval.stores.protocol.Store` protocol. Key-value
+    access is exact lookup by key — no similarity search, embeddings, vectors,
+    or scope filtering — so it neither does nor should conform to the vector
+    ``Store`` protocol. Keeping the two contracts distinct is what stops the
+    key-value layer from entangling with the retrieval runtime.
+
+    All methods are ``async`` so a remote backend (Redis, a database) can
+    satisfy the same contract without changing callers.
+    """
+
+    async def set(self, key: str, value: str) -> None:
+        """Store ``value`` under ``key``, overwriting any existing value."""
+        ...
+
+    async def get(self, key: str) -> str | None:
+        """Return the value stored under ``key``, or ``None`` if absent."""
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Remove ``key``. A no-op when the key is absent."""
+        ...
+
+    async def keys(self) -> list[str]:
+        """Return all stored keys."""
+        ...
+
+    async def items(self) -> dict[str, str]:
+        """Return a snapshot copy of all key-value pairs."""
+        ...
+
+    async def clear(self) -> None:
+        """Remove every entry."""
+        ...

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_key_value_memory.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_key_value_memory.py
@@ -1,0 +1,168 @@
+from unittest.mock import MagicMock
+
+import pytest
+from railtracks.prebuilt.tools.memory import KeyValueMemoryToolSet
+from railtracks.retrieval.stores.key_value import InMemoryKeyValueStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ts():
+    return KeyValueMemoryToolSet()
+
+
+# ---------------------------------------------------------------------------
+# remember / recall
+# ---------------------------------------------------------------------------
+
+
+async def test_remember_then_recall(ts):
+    await ts.remember("user_timezone", "PST")
+    assert await ts.recall("user_timezone") == "PST"
+
+
+async def test_recall_missing_key(ts):
+    out = await ts.recall("nope")
+    assert "No memory found" in out
+    assert "nope" in out
+
+
+async def test_remember_overwrites(ts):
+    await ts.remember("goal", "buy a house")
+    await ts.remember("goal", "buy a boat")
+    assert await ts.recall("goal") == "buy a boat"
+
+
+async def test_remember_returns_confirmation(ts):
+    out = await ts.remember("k", "v")
+    assert "k" in out and "v" in out
+
+
+# ---------------------------------------------------------------------------
+# forget
+# ---------------------------------------------------------------------------
+
+
+async def test_forget_existing_key(ts):
+    await ts.remember("debt", "10k")
+    out = await ts.forget("debt")
+    assert "Forgot" in out
+    assert await ts.recall("debt") == "No memory found under key 'debt'."
+
+
+async def test_forget_missing_key_is_noop(ts):
+    out = await ts.forget("never-set")
+    assert "Nothing was stored" in out
+
+
+# ---------------------------------------------------------------------------
+# list_memories / search_memories
+# ---------------------------------------------------------------------------
+
+
+async def test_list_memories_empty(ts):
+    assert await ts.list_memories() == "No memories stored."
+
+
+async def test_list_memories_populated(ts):
+    await ts.remember("a", "1")
+    await ts.remember("b", "2")
+    out = await ts.list_memories()
+    assert "a: 1" in out
+    assert "b: 2" in out
+
+
+async def test_search_matches_key_and_value_case_insensitive(ts):
+    await ts.remember("favorite_color", "blue")
+    await ts.remember("pet", "a Blue parrot")
+    out = await ts.search_memories("BLUE")
+    assert "favorite_color: blue" in out
+    assert "pet: a Blue parrot" in out
+
+
+async def test_search_no_match(ts):
+    await ts.remember("a", "1")
+    out = await ts.search_memories("zzz")
+    assert "No memories matched" in out
+
+
+# ---------------------------------------------------------------------------
+# Store injection / persistence / isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_defaults_to_in_memory_store(ts):
+    assert isinstance(ts.store, InMemoryKeyValueStore)
+
+
+async def test_injected_store_is_used():
+    store = InMemoryKeyValueStore()
+    ts = KeyValueMemoryToolSet(store=store)
+    await ts.remember("k", "v")
+    assert await store.get("k") == "v"
+
+
+async def test_persistence_via_snapshot_path(tmp_path):
+    path = tmp_path / "memory.json"
+    ts1 = KeyValueMemoryToolSet(store=InMemoryKeyValueStore(snapshot_path=path))
+    await ts1.remember("salary", "80k")
+
+    ts2 = KeyValueMemoryToolSet(store=InMemoryKeyValueStore(snapshot_path=path))
+    assert await ts2.recall("salary") == "80k"
+
+
+async def test_instances_are_isolated():
+    t1 = KeyValueMemoryToolSet()
+    t2 = KeyValueMemoryToolSet()
+    await t1.remember("k", "v")
+    assert await t2.list_memories() == "No memories stored."
+
+
+# ---------------------------------------------------------------------------
+# on_change callback
+# ---------------------------------------------------------------------------
+
+
+async def test_on_change_fires_on_remember_and_forget():
+    cb = MagicMock()
+    ts = KeyValueMemoryToolSet(on_change=cb)
+    await ts.remember("k", "v")
+    cb.assert_called_with("k", "v")
+    await ts.forget("k")
+    cb.assert_called_with("k", None)
+
+
+async def test_on_change_exception_is_swallowed():
+    cb = MagicMock(side_effect=RuntimeError("boom"))
+    ts = KeyValueMemoryToolSet(on_change=cb)
+    # Should not raise despite the callback blowing up.
+    out = await ts.remember("k", "v")
+    assert "k" in out
+    assert await ts.recall("k") == "v"
+
+
+# ---------------------------------------------------------------------------
+# tool_set() / prompt()
+# ---------------------------------------------------------------------------
+
+
+def test_tool_set_returns_rt_functions(ts):
+    tools = ts.tool_set()
+    assert len(tools) == 5
+    assert all(hasattr(t, "node_type") for t in tools)
+
+
+async def test_tool_set_bound_to_instance():
+    t1 = KeyValueMemoryToolSet()
+    remember_tool = t1.tool_set()[0]
+    await remember_tool("k", "v")
+    assert await t1.recall("k") == "v"
+
+
+def test_prompt_is_non_empty_string():
+    result = KeyValueMemoryToolSet.prompt()
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_key_value_memory.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_key_value_memory.py
@@ -75,6 +75,21 @@ async def test_list_memories_populated(ts):
     assert "b: 2" in out
 
 
+async def test_list_keys_empty(ts):
+    assert await ts.list_keys() == "No memories stored."
+
+
+async def test_list_keys_populated(ts):
+    await ts.remember("a", "1")
+    await ts.remember("b", "2")
+    out = await ts.list_keys()
+    assert "- a" in out
+    assert "- b" in out
+    # values must not leak into a keys-only listing
+    assert "1" not in out
+    assert "2" not in out
+
+
 async def test_search_matches_key_and_value_case_insensitive(ts):
     await ts.remember("favorite_color", "blue")
     await ts.remember("pet", "a Blue parrot")
@@ -151,7 +166,7 @@ async def test_on_change_exception_is_swallowed():
 
 def test_tool_set_returns_rt_functions(ts):
     tools = ts.tool_set()
-    assert len(tools) == 5
+    assert len(tools) == 6
     assert all(hasattr(t, "node_type") for t in tools)
 
 

--- a/packages/railtracks/tests/unit_tests/retrieval/stores/test_key_value_store.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/stores/test_key_value_store.py
@@ -1,0 +1,145 @@
+"""Tests for retrieval/stores/key_value — KeyValueStore + InMemoryKeyValueStore."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from railtracks.retrieval.stores.key_value import (
+    InMemoryKeyValueStore,
+    KeyValueStore,
+)
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class _IncompleteStore:
+    async def set(self, key: str, value: str) -> None:
+        pass
+
+    async def get(self, key: str) -> str | None:
+        return None
+
+    # missing delete, keys, items, clear
+
+
+def test_in_memory_store_satisfies_protocol():
+    assert isinstance(InMemoryKeyValueStore(), KeyValueStore)
+
+
+def test_incomplete_implementation_fails_protocol():
+    assert not isinstance(_IncompleteStore(), KeyValueStore)
+
+
+# ---------------------------------------------------------------------------
+# Core read/write behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_set_get_roundtrip():
+    store = InMemoryKeyValueStore()
+    await store.set("salary", "80k/year")
+    assert await store.get("salary") == "80k/year"
+
+
+async def test_get_missing_returns_none():
+    store = InMemoryKeyValueStore()
+    assert await store.get("nope") is None
+
+
+async def test_set_overwrites():
+    store = InMemoryKeyValueStore()
+    await store.set("goal", "buy a house")
+    await store.set("goal", "buy a boat")
+    assert await store.get("goal") == "buy a boat"
+
+
+async def test_delete_removes_key():
+    store = InMemoryKeyValueStore()
+    await store.set("debt", "10k")
+    await store.delete("debt")
+    assert await store.get("debt") is None
+
+
+async def test_delete_missing_is_noop():
+    store = InMemoryKeyValueStore()
+    # Should not raise.
+    await store.delete("never-set")
+
+
+async def test_keys_and_items():
+    store = InMemoryKeyValueStore()
+    await store.set("a", "1")
+    await store.set("b", "2")
+    assert sorted(await store.keys()) == ["a", "b"]
+    assert await store.items() == {"a": "1", "b": "2"}
+
+
+async def test_items_returns_copy():
+    store = InMemoryKeyValueStore()
+    await store.set("a", "1")
+    snapshot = await store.items()
+    snapshot["a"] = "mutated"
+    snapshot["b"] = "injected"
+    assert await store.items() == {"a": "1"}
+
+
+async def test_clear():
+    store = InMemoryKeyValueStore()
+    await store.set("a", "1")
+    await store.set("b", "2")
+    await store.clear()
+    assert await store.keys() == []
+    assert await store.items() == {}
+
+
+# ---------------------------------------------------------------------------
+# Persistence via snapshot_path
+# ---------------------------------------------------------------------------
+
+
+async def test_snapshot_persists_across_instances(tmp_path):
+    path = tmp_path / "memory.json"
+
+    store = InMemoryKeyValueStore(snapshot_path=path)
+    await store.set("salary", "80k/year")
+    await store.set("goal", "buy a house")
+
+    reloaded = InMemoryKeyValueStore(snapshot_path=path)
+    assert await reloaded.get("salary") == "80k/year"
+    assert await reloaded.items() == {"salary": "80k/year", "goal": "buy a house"}
+
+
+async def test_snapshot_reflects_delete_and_clear(tmp_path):
+    path = tmp_path / "memory.json"
+
+    store = InMemoryKeyValueStore(snapshot_path=path)
+    await store.set("a", "1")
+    await store.set("b", "2")
+    await store.delete("a")
+    assert await InMemoryKeyValueStore(snapshot_path=path).items() == {"b": "2"}
+
+    await store.clear()
+    assert await InMemoryKeyValueStore(snapshot_path=path).items() == {}
+
+
+async def test_no_snapshot_means_ephemeral():
+    store = InMemoryKeyValueStore()
+    await store.set("a", "1")
+    # A fresh instance shares nothing.
+    assert await InMemoryKeyValueStore().items() == {}
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_sets_all_land():
+    store = InMemoryKeyValueStore()
+    await asyncio.gather(*(store.set(f"k{i}", str(i)) for i in range(50)))
+    items = await store.items()
+    assert len(items) == 50
+    assert items["k7"] == "7"

--- a/packages/railtracks/tests/unit_tests/retrieval/stores/test_key_value_store.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/stores/test_key_value_store.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest
 from railtracks.retrieval.stores.key_value import (
     InMemoryKeyValueStore,
     KeyValueStore,


### PR DESCRIPTION
## Summary

Adds a prebuilt key-value memory toolset for agents — the memory analog of `ToDoToolSet`. Introduces a reusable, stdlib-only async key-value store under `railtracks.retrieval.stores.key_value` (`KeyValueStore` protocol + `InMemoryKeyValueStore`, with optional JSON `snapshot_path` persistence), kept deliberately separate from the vector `Store` protocol since it's exact-key get/set with no similarity/embeddings. On top of it, `rt.prebuilt.KeyValueMemoryToolSet` exposes six agent tools (`remember`, `recall`, `forget`, `list_keys`, `list_memories`, `search_memories`), an `on_change` callback for outer-system hooks, and a `prompt()` guidance helper. The default store is lazy-imported via a private helper so `import railtracks` stays free of the retrieval stack (numpy/scikit-learn); `[all]` now bundles `[retrieval]` so the standard install and CI exercise the toolset. This is the first (key-value) layer of the persistent memory toolset.

closes #1205

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

**Extended example — a memory-backed tour-guide assistant.** Learns about a traveler once and personalizes every later answer; the persistent store means what it learns survives across runs.

```python
import railtracks as rt
from railtracks.llm import AssistantMessage, UserMessage
from railtracks.prebuilt import KeyValueMemoryToolSet
from railtracks.retrieval.stores.key_value import InMemoryKeyValueStore

# Persistent store — traveler facts survive across runs.
memory = KeyValueMemoryToolSet(
    store=InMemoryKeyValueStore(snapshot_path="memory.json"),
)

# Persona + the toolset's own usage guidance + app-specific key conventions.
SYSTEM_PROMPT = (
    "You are a tour-guide assistant. You help users plan travel, hikes, and "
    "day trips.\n\n"
    + memory.prompt()
    + "\n\nStore durable traveler facts under separate, stable keys — e.g. "
    "home_city, dietary_restrictions, fitness_level, budget, travel_dates, "
    "destinations_of_interest. Recall the relevant keys before recommending "
    "so every answer stays personalized."
)

agent = rt.agent_node(
    name="Tour-Guide",
    system_message=SYSTEM_PROMPT,
    llm=rt.llm.AnthropicLLM("claude-sonnet-4-6"),
    tool_nodes=[*memory.tool_set()],
)


@rt.function_node
async def conversation():
    history = []
    for user_text in [
        "I'm vegetarian, based in Vancouver, and I love hiking.",
        "Suggest a weekend trip for me.",  # answered from memory, no re-asking
    ]:
        history.append(UserMessage(user_text))
        response = await rt.call(agent, history)
        history.append(AssistantMessage(response.content))
        print(f"User: {user_text}\nAssistant: {response.content}\n")

    # snapshot_path means these facts are also on disk for the next run.
    print("Stored memory:", await memory.store.items())


rt.Flow("Tour-Guide-Chat", entry_point=conversation).invoke()
