### PR TITLE
Typing Middleware

### DIFF
--- a/docs/advanced_usage/node_builder.md
+++ b/docs/advanced_usage/node_builder.md
@@ -10,7 +10,7 @@ Every builder method returns a builder; call `.build()` to get the node class.
 !!! note "Middleware lives in the middleware guide"
     `NodeBuilder.llm()` and `NodeBuilder.function()` take the same `middleware` /
     `model_middleware` parameters as the public helpers. See
-    [Middleware: Wrappers & Gateways](../documentation/advanced/middleware/usage.md) for
+    [Middleware: Wrappers & Gates](../documentation/advanced/middleware/usage.md) for
     the full model — this page only shows where they attach.
 
 ---
@@ -69,7 +69,7 @@ Sync functions are not supported directly — wrap them with `asyncio.to_thread`
 
 Both builders accept `middleware` (around the node boundary, `wrapped_invoke`). LLM nodes
 additionally accept `model_middleware` (around each raw model call, inside the
-tool-calling loop). Each takes a `MiddlewareSet` or a bare list:
+tool-calling loop). Each takes a `MiddlewareChain` or a bare list:
 
 ```python
 --8<-- "docs/scripts/node_builder.py:middleware"

--- a/docs/documentation/advanced/middleware/internals.md
+++ b/docs/documentation/advanced/middleware/internals.md
@@ -9,14 +9,14 @@ so it can't drift from the implementation.
 
 Everything lives in `railtracks/middleware/`:
 
-- `primitives.py` — the `Wrapper` and `Gateway` classes, their `@wrapper` / `@gateway`
-  decorators, the `gateway.args(...)` helper, and the `_GatewayArgs` tag.
-- `set.py` — `MiddlewareSet` (the container + the `run` execution engine), the internal
+- `primitives.py` — the `Wrapper` and `Gate` classes, their `@wrapper` / `@gate`
+  decorators, the `gate.args(...)` helper, and the `_GateArgs` tag.
+- `set.py` — `MiddlewareChain` (the container + the `run` execution engine), the internal
   `_LayeredList`, and the coercion/validation helpers.
-- `__init__.py` — re-exports (`Wrapper`, `wrapper`, `Gateway`, `gateway`, `MiddlewareSet`).
+- `__init__.py` — re-exports (`Wrapper`, `wrapper`, `Gate`, `gate`, `MiddlewareChain`).
 
-There is **one engine** (`MiddlewareSet.run`) used at every attach site, so wrappers and
-gateways behave identically whether they wrap a function node, an agent, a tool, or a raw
+There is **one engine** (`MiddlewareChain.run`) used at every attach site, so wrappers and
+gates behave identically whether they wrap a function node, an agent, a tool, or a raw
 model call.
 
 ## The three-layer list
@@ -32,44 +32,44 @@ Each band is a `_LayeredList`, holding three ordered layers:
 - `sys_after` — framework middleware that runs *after* user middleware.
 
 `ordered()` flattens them to `sys_before + user + sys_after`. The public iteration
-interface (`__iter__`, `__len__`, the `MiddlewareSet` properties) exposes the **user**
+interface (`__iter__`, `__len__`, the `MiddlewareChain` properties) exposes the **user**
 layer only, so registering system middleware is invisible to user-facing views. This is
 how the framework injects behaviour (see [context injection](#context-injection)) without
 ever touching the user's list.
 
-## `MiddlewareSet`
+## `MiddlewareChain`
 
 Four bands, each a `_LayeredList`: `self._outer` and `self._inner` hold `Wrapper`s,
-`self._entry` and `self._exit` hold `Gateway`s. The public band names are `wrappers`,
-`gateway_entry`, `gateway_exit`, and `inner_wrappers`.
+`self._entry` and `self._exit` hold `Gate`s. The public band names are `wrappers`,
+`entry_gate`, `exit_gate`, and `inner_wrappers`.
 
 ### Construction & coercion
 
-- The constructor coerces each slot: a raw async function (or, for gateways, a sync
-  function) is auto-wrapped into a `Wrapper` / `Gateway`; an already-built primitive of the
+- The constructor coerces each slot: a raw async function (or, for gates, a sync
+  function) is auto-wrapped into a `Wrapper` / `Gate`; an already-built primitive of the
   *wrong* type for the slot raises `TypeError`. This is why the decorator is optional in
   explicit slots but the cross-type mistake is still caught.
-- `MiddlewareSet.coerce(value)` normalises user input: `None` → empty set; a `MiddlewareSet`
-  → a fresh copy; a list/tuple → `Wrapper`s to `wrappers`, `Gateway`s to `gateway_entry` (a
-  bare list can't express exit gateways or inner wrappers, and raw functions are ambiguous
+- `MiddlewareChain.coerce(value)` normalises user input: `None` → empty set; a `MiddlewareChain`
+  → a fresh copy; a list/tuple → `Wrapper`s to `wrappers`, `Gate`s to `entry_gate` (a
+  bare list can't express exit gates or inner wrappers, and raw functions are ambiguous
   there, so the decorator is required).
 - `_fresh_copy()` / `copy_user_only()` produce a copy carrying only the **user** layers,
-  with system layers reset — so a `MiddlewareSet` reused across nodes gives each site its
+  with system layers reset — so a `MiddlewareChain` reused across nodes gives each site its
   own independent system layers and the caller's object is never mutated.
 
 ### The execution engine
 
-`MiddlewareSet.run(core, args, kwargs)` (in `set.py`) composes the onion and awaits it:
+`MiddlewareChain.run(core, args, kwargs)` (in `set.py`) composes the onion and awaits it:
 
 1. Wrap `core` with the **inner** wrappers, applied in **reversed** `ordered()` order so the
    first inner wrapper ends up closest to the core.
-2. Build a `gated` callable that runs every **entry** gateway (`apply_entry`), calls the
-   inner stack, then runs every **exit** gateway (`apply_exit`).
+2. Build a `gated` callable that runs every **entry** gate (`apply_entry`), calls the
+   inner stack, then runs every **exit** gate (`apply_exit`).
 3. Wrap `gated` with the **outer** wrappers, again reversed so the first one ends up
    outermost.
 
 Wrappers are reversed at composition so the first wrapper in each list is the outermost of
-its layer; entry/exit gateways are **separate lists** driven inside `gated`. The resulting
+its layer; entry/exit gates are **separate lists** driven inside `gated`. The resulting
 order is `wrappers → entry → inner → core → exit (unwind) → wrappers (unwind)`.
 
 ## Primitives
@@ -83,43 +83,43 @@ awaiting it. A sync function cannot `await`, so it is rejected at construction t
 is typed with a `ParamSpec`, so composing a wrapper preserves the wrapped callable's
 signature.
 
-### `Gateway`
+### `Gate`
 
-`Gateway.__init__` only requires a callable and records `self._is_async`. `_invoke` bridges
-sync/async: an async gateway is awaited, a sync gateway is run **inline** (not in a thread)
-deliberately, so a sync gateway's `rt.context` writes stay on the current context.
+`Gate.__init__` only requires a callable and records `self._is_async`. `_invoke` bridges
+sync/async: an async gate is awaited, a sync gate is run **inline** (not in a thread)
+deliberately, so a sync gate's `rt.context` writes stay on the current context.
 
 `apply_entry` implements the return contract, in this order: `None` → pass through;
-`_GatewayArgs` → its `(args, kwargs)`; a `(tuple, dict)` 2-tuple → full form; a `tuple` →
+`_GateArgs` → its `(args, kwargs)`; a `(tuple, dict)` 2-tuple → full form; a `tuple` →
 positional-only; a `dict` → keyword-only; anything else → `TypeError`. `apply_exit` returns
-the new result, or the original when the gateway returns `None`.
+the new result, or the original when the gate returns `None`.
 
-`gateway.args(*a, **k)` returns a `_GatewayArgs` tag carrying both; it is the only
+`gate.args(*a, **k)` returns a `_GateArgs` tag carrying both; it is the only
 unambiguous way to state positional **and** keyword args at once, and the escape hatch for
 the rare "single positional arg that looks like `(tuple, dict)`" case.
 
-`Gateway.__call__` is a thin pass-through to `self._fn` — it preserves decorator
-transparency (a `@gateway`-decorated name stays usable as a plain function) and makes
-generic gateways easy to unit-test or reuse. It deliberately does **not** go through
+`Gate.__call__` is a thin pass-through to `self._fn` — it preserves decorator
+transparency (a `@gate`-decorated name stays usable as a plain function) and makes
+generic gates easy to unit-test or reuse. It deliberately does **not** go through
 `apply_entry` / `apply_exit`, so it returns the raw function result (a coroutine for an
-async gateway).
+async gate).
 
 ## Attach-site integration
 
 ### Node middleware
 
-The base `Node` carries a class-level `frozen_middleware: MiddlewareSet` default. Each
+The base `Node` carries a class-level `frozen_middleware: MiddlewareChain` default. Each
 instance takes a fresh copy in `__init__` (`self.middleware = self.frozen_middleware
 ._fresh_copy()`), and `wrapped_invoke` runs `invoke` through it
 (`self.middleware.run(self.invoke, args, kwargs)`). `wrapped_invoke` is what the executor
 calls, so **every** node type goes through its node-level middleware exactly once per call.
 `NodeBuilder` sets `frozen_middleware` from the `middleware=` argument via
-`MiddlewareSet.coerce`.
+`MiddlewareChain.coerce`.
 
 ### Model middleware
 
 `model_middleware` is owned by `ModelInvoker` (in `llm_helpers.py`), which runs the *raw*
-model call (`model.chat` / `structured` / `chat_with_tools`) through its `MiddlewareSet`.
+model call (`model.chat` / `structured` / `chat_with_tools`) through its `MiddlewareChain`.
 `ModelInvoker.invoke` is called inside the agent's tool-calling loop, so model middleware
 runs **once per model round-trip** — a different cardinality and a different core signature
 (`(messages, schema, tools) → Response`) than node middleware. Function nodes have no
@@ -132,19 +132,19 @@ at invocation time (from config or `rt.context`) rather than binding one at buil
 ### Context injection
 
 The one framework middleware wired today: when an LLM node is built with
-`context_injection=True`, `NodeBuilder` registers `context_injection_gateway` as a
-**system entry gateway** on the model-level set
-(`model_invoker.register_sys_gateway_entry(context_injection_gateway)`). It lands in the
-model band's `sys_before` layer, runs before any user entry gateway on every model call,
+`context_injection=True`, `NodeBuilder` registers `context_injection_gate` as a
+**system entry gate** on the model-level set
+(`model_invoker.register_sys_entry_gate(context_injection_gate)`). It lands in the
+model band's `sys_before` layer, runs before any user entry gate on every model call,
 fills `{placeholder}` slots from `rt.context`, and is invisible to the public
-`gateway_entry` view.
+`entry_gate` view.
 
 ## System-registration hooks
 
-`MiddlewareSet` exposes four idempotent hooks for framework code (never the user layer):
+`MiddlewareChain` exposes four idempotent hooks for framework code (never the user layer):
 
-- `register_sys_gateway_entry(gw)` → entry `sys_before`
-- `register_sys_gateway_exit(gw)` → exit `sys_after`
+- `register_sys_entry_gate(gw)` → entry `sys_before`
+- `register_sys_exit_gate(gw)` → exit `sys_after`
 - `register_sys_outer_wrapper(w)` → outer `sys_before`
 - `register_sys_inner_wrapper(w)` → inner `sys_after`
 
@@ -156,16 +156,16 @@ middleware (tracing, cost accounting, etc.).
 - **Wrappers are async-only.** They must `await` the inner call on the event loop; running a
   sync wrapper off-loop (e.g. in a thread) would lose the run's context, so it is rejected
   rather than silently bridged.
-- **Sync gateways run inline.** A gateway never awaits the inner call, so a sync gateway is a
+- **Sync gates run inline.** A gate never awaits the inner call, so a sync gate is a
   cheap inline transform — and inline keeps `rt.context` writes on the live context.
 - **No single-value shorthand for entry returns.** Every accepted entry return is a
   structured container, so a returned `dict` is unambiguously keyword args and is never
   silently unpacked as one positional arg.
-- **Direction-less gateways.** The same `Gateway` object works in entry or exit slots; the
+- **Direction-less gates.** The same `Gate` object works in entry or exit slots; the
   slot picks `apply_entry` vs `apply_exit`. This keeps the primitive small and avoids two
   near-identical decorators.
 - **User lists are never mutated.** Construction copies the user layer; system middleware
-  lives in separate layers; reuse takes a fresh copy. A `MiddlewareSet` is safe to share
+  lives in separate layers; reuse takes a fresh copy. A `MiddlewareChain` is safe to share
   across many nodes.
 
 See the [Usage Guide](usage.md) for the user-facing API.

--- a/docs/documentation/advanced/middleware/usage.md
+++ b/docs/documentation/advanced/middleware/usage.md
@@ -1,4 +1,4 @@
-# Middleware: Wrappers & Gateways
+# Middleware: Wrappers & Gates
 
 Middleware adds behaviour *around* a node's execution — retries, logging, input/output
 transforms, redaction, guardrails — without changing the node's own logic. Every entry
@@ -7,9 +7,9 @@ primitives, so one mental model covers them all:
 
 - **`Wrapper`** — *execution control*: receives the inner call and decides whether / how /
   how many times to run it.
-- **`Gateway`** — *data transform*: reshapes the input before the call, or the output after it.
+- **`Gate`** — *data transform*: reshapes the input before the call, or the output after it.
 
-Group them with `MiddlewareSet` and attach them via the `middleware` parameter (and, for
+Group them with `MiddlewareChain` and attach them via the `middleware` parameter (and, for
 agents, `model_middleware`).
 
 !!! tip "See also"
@@ -37,20 +37,20 @@ A wrapper can **short-circuit** by simply not calling `call`:
 
 !!! warning "Wrappers must be `async`"
     A wrapper has to `await` the inner call, which a plain `def` cannot do. A sync function
-    passed to `@rt.wrapper` raises `TypeError`. (Gateways, below, may be sync.)
+    passed to `@rt.wrapper` raises `TypeError`. (Gates, below, may be sync.)
 
 ---
 
-## `Gateway` — data transforms
+## `Gate` — data transforms
 
-A gateway is authored with `@rt.gateway` and may be **`async` or a plain `def`** (a sync
-gateway runs inline). It carries **no direction** — *where you place it* decides its role:
-`gateway_entry` transforms the **input** before the call; `gateway_exit` transforms the
+A gate is authored with `@rt.gate` and may be **`async` or a plain `def`** (a sync
+gate runs inline). It carries **no direction** — *where you place it* decides its role:
+`entry_gate` transforms the **input** before the call; `exit_gate` transforms the
 **output** after it.
 
-### Entry gateways
+### Entry gates
 
-An entry gateway receives the call's `(*args, **kwargs)` and returns the *new* arguments:
+An entry gate receives the call's `(*args, **kwargs)` and returns the *new* arguments:
 
 | Return | Meaning |
 |---|---|
@@ -58,85 +58,85 @@ An entry gateway receives the call's `(*args, **kwargs)` and returns the *new* a
 | a `tuple` | the new **positional** args, e.g. `return (text,)` |
 | a `dict` | the new **keyword** args, e.g. `return {"city": city}` |
 | a `(tuple, dict)` pair | both positional and keyword args |
-| `rt.gateway.args(*a, **k)` | both, stated explicitly |
+| `rt.gate.args(*a, **k)` | both, stated explicitly |
 
 ```python
---8<-- "docs/scripts/middleware.py:gateway_entry"
+--8<-- "docs/scripts/middleware.py:entry_gate"
 ```
 
 !!! danger "A bare value raises `TypeError`"
     There is **no single-value shorthand**, so a returned `dict` is never silently unpacked
     as one positional arg. Wrap a single positional value explicitly: `return (x,)` or
-    `return rt.gateway.args(x)`. A 2-tuple of `(tuple, dict)` is read as the full
-    `(args, kwargs)` form — use `rt.gateway.args(...)` if you genuinely need two positional
+    `return rt.gate.args(x)`. A 2-tuple of `(tuple, dict)` is read as the full
+    `(args, kwargs)` form — use `rt.gate.args(...)` if you genuinely need two positional
     args shaped that way.
 
-### Exit gateways
+### Exit gates
 
-An exit gateway receives the single `result` and returns the new one. Returning `None`
+An exit gate receives the single `result` and returns the new one. Returning `None`
 keeps the original unchanged.
 
 ```python
---8<-- "docs/scripts/middleware.py:gateway_exit"
+--8<-- "docs/scripts/middleware.py:exit_gate"
 ```
 
-### Check-only gateways = guardrails
+### Check-only gates = guardrails
 
-A gateway doesn't have to transform. An entry gateway can **validate and raise** to block
+A gate doesn't have to transform. An entry gate can **validate and raise** to block
 the call, returning nothing when the input is fine — that is exactly a guardrail:
 
 ```python
---8<-- "docs/scripts/middleware.py:gateway_guardrail"
+--8<-- "docs/scripts/middleware.py:gate_guardrail"
 ```
 
 For ready-made guardrails (PII redaction, length/content checks) see
 [Guardrails](../guardrails/overview.md).
 
-### Calling a gateway directly
+### Calling a gate directly
 
-A `Gateway` is **directly callable**, passing straight through to the function you wrote —
-handy when the gateway is a generic helper you also want to call normally:
+A `Gate` is **directly callable**, passing straight through to the function you wrote —
+handy when the gate is a generic helper you also want to call normally:
 
 ```python
---8<-- "docs/scripts/middleware.py:gateway_direct_call"
+--8<-- "docs/scripts/middleware.py:gate_direct_call"
 ```
 
 !!! warning "Direct call is the *raw* function, not the slot behaviour"
-    Calling `gateway(...)` runs the underlying function as-is; it does **not** apply the
-    entry/exit interpretation. Use `gateway.apply_entry(...)` / `gateway.apply_exit(...)`
-    to see what the engine does. If the gateway is `async`, calling it returns a
+    Calling `gate(...)` runs the underlying function as-is; it does **not** apply the
+    entry/exit interpretation. Use `gate.apply_entry(...)` / `gate.apply_exit(...)`
+    to see what the engine does. If the gate is `async`, calling it returns a
     **coroutine** you must `await`.
 
 ---
 
-## Grouping with `MiddlewareSet`
+## Grouping with `MiddlewareChain`
 
-A `MiddlewareSet` is the ordered bundle attached to one site. It has four bands:
+A `MiddlewareChain` is the ordered bundle attached to one site. It has four bands:
 
 ```python
---8<-- "docs/scripts/middleware.py:middlewareset_bands"
+--8<-- "docs/scripts/middleware.py:middlewarechain_bands"
 ```
 
-They compose as two wrapper layers sandwiching a gateway band:
+They compose as two wrapper layers sandwiching a gate band:
 
 ```
 wrappers
-└── gateway_entry              (transform input)
+└── entry_gate              (transform input)
     └── inner_wrappers
         └── core               (node / function / model call)
     └── (unwind inner_wrappers)
-└── gateway_exit               (transform output)
+└── exit_gate               (transform output)
 └── (unwind wrappers)
 ```
 
-A single call flows `wrappers-in → entry gateways → inner-in → CORE → inner-out → exit
-gateways → wrappers-out`. Wrappers nest; gateways bracket the core from the middle.
+A single call flows `wrappers-in → entry gates → inner-in → CORE → inner-out → exit
+gates → wrappers-out`. Wrappers nest; gates bracket the core from the middle.
 
 ### Bare lists
 
-Anywhere a `MiddlewareSet` is accepted you can pass a **bare list** instead. It is coerced:
-`Wrapper` items go to `wrappers`, `Gateway` items go to `gateway_entry` (use the explicit
-constructor for exit gateways or inner wrappers).
+Anywhere a `MiddlewareChain` is accepted you can pass a **bare list** instead. It is coerced:
+`Wrapper` items go to `wrappers`, `Gate` items go to `entry_gate` (use the explicit
+constructor for exit gates or inner wrappers).
 
 ```python
 --8<-- "docs/scripts/middleware.py:bare_list"
@@ -144,15 +144,15 @@ constructor for exit gateways or inner wrappers).
 
 ### The decorator is optional in explicit slots
 
-Inside an explicit `MiddlewareSet` slot the role is already known, so the `@rt.wrapper` /
-`@rt.gateway` decorator is **optional** — a raw function works:
+Inside an explicit `MiddlewareChain` slot the role is already known, so the `@rt.wrapper` /
+`@rt.gate` decorator is **optional** — a raw function works:
 
 ```python
 --8<-- "docs/scripts/middleware.py:raw_in_slots"
 ```
 
-The decorator is only *required* for a bare list, where wrapper-vs-gateway would otherwise
-be ambiguous. Putting a `Gateway` in a wrapper slot (or vice-versa) raises a clear
+The decorator is only *required* for a bare list, where wrapper-vs-gate would otherwise
+be ambiguous. Putting a `Gate` in a wrapper slot (or vice-versa) raises a clear
 `TypeError`.
 
 ---
@@ -161,7 +161,7 @@ be ambiguous. Putting a `Gateway` in a wrapper slot (or vice-versa) raises a cle
 
 ### Function nodes
 
-`rt.function_node` takes a `middleware` parameter — a `MiddlewareSet` or a bare list —
+`rt.function_node` takes a `middleware` parameter — a `MiddlewareChain` or a bare list —
 applied at the node boundary (its call args → its output):
 
 ```python
@@ -226,11 +226,11 @@ Scrub secrets out of the user input, restore them in the answer, and retry the w
 
 - **`@rt.wrapper`** — async only; `(call, *args, **kwargs)`; `await call(...)`; retry / time
   / fall back / short-circuit.
-- **`@rt.gateway`** — async or sync; direction set by slot. Entry returns `None` / `tuple` /
-  `dict` / `(tuple, dict)` / `rt.gateway.args(*a, **k)` (a bare value raises). Exit returns
+- **`@rt.gate`** — async or sync; direction set by slot. Entry returns `None` / `tuple` /
+  `dict` / `(tuple, dict)` / `rt.gate.args(*a, **k)` (a bare value raises). Exit returns
   the new result, or `None` to keep the original; raise to act as a guardrail.
-- **`rt.MiddlewareSet(wrappers, gateway_entry, gateway_exit, inner_wrappers)`** — or a bare
-  list (wrappers → `wrappers`, gateways → `gateway_entry`). Decorator optional in slots.
+- **`rt.MiddlewareChain(wrappers, entry_gate, exit_gate, inner_wrappers)`** — or a bare
+  list (wrappers → `wrappers`, gates → `entry_gate`). Decorator optional in slots.
 - **Attach** with `middleware` (every node) and, for agents, `model_middleware` (each raw
   model call). `llm` also accepts a no-arg model factory.
 - Your list is never mutated; framework middleware (e.g. context injection) lives in

--- a/docs/scripts/middleware.py
+++ b/docs/scripts/middleware.py
@@ -48,72 +48,72 @@ async def cached(call, *args, **kwargs):
 # --8<-- [end: wrapper_cached]
 
 
-# --8<-- [start: gateway_entry]
-@rt.gateway
+# --8<-- [start: entry_gate]
+@rt.gate
 async def normalize(text: str):
     return (text.strip().lower(),)  # tuple -> positional args only
 
 
-@rt.gateway
+@rt.gate
 async def route(city: str):
     return {"city": city, "units": "metric"}  # dict -> keyword args only
 
 
-@rt.gateway
+@rt.gate
 async def reorder(a, b):
-    return rt.gateway.args(b, a, flag=True)  # both -> ((b, a), {"flag": True})
-# --8<-- [end: gateway_entry]
+    return rt.gate.args(b, a, flag=True)  # both -> ((b, a), {"flag": True})
+# --8<-- [end: entry_gate]
 
 
-# --8<-- [start: gateway_exit]
-@rt.gateway
+# --8<-- [start: exit_gate]
+@rt.gate
 async def add_banner(result: str):
     return f">>> {result} <<<"
 
 
-@rt.gateway
+@rt.gate
 async def audit(result):
     print(f"produced {result!r}")  # returns None -> result unchanged
-# --8<-- [end: gateway_exit]
+# --8<-- [end: exit_gate]
 
 
-# --8<-- [start: gateway_guardrail]
-@rt.gateway
+# --8<-- [start: gate_guardrail]
+@rt.gate
 async def no_secrets(text: str):
     if "password" in text.lower():
         raise ValueError("blocked: input mentions a secret")
     # returns None -> the call proceeds unchanged
-# --8<-- [end: gateway_guardrail]
+# --8<-- [end: gate_guardrail]
 
 
-# --8<-- [start: gateway_direct_call]
-@rt.gateway
+# --8<-- [start: gate_direct_call]
+@rt.gate
 def tag(x):
     return f"[{x}]"
 
 
 tag("hi")  # -> '[hi]'  (raw function result)
-# --8<-- [end: gateway_direct_call]
+# --8<-- [end: gate_direct_call]
 
 
-# --8<-- [start: middlewareset_bands]
-ms = rt.MiddlewareSet(
+# --8<-- [start: middlewarechain_bands]
+ms = rt.MiddlewareChain(
     wrappers=[retry],  # outermost: wrap the whole call
-    gateway_entry=[normalize],  # transform input (before the core)
-    gateway_exit=[add_banner],  # transform output (after the core)
+    entry_gate=[normalize],  # transform input (before the core)
+    exit_gate=[add_banner],  # transform output (after the core)
     inner_wrappers=[cached],  # innermost: hug the core, inside the gateways
 )
-# --8<-- [end: middlewareset_bands]
+# --8<-- [end: middlewarechain_bands]
 
 
 # --8<-- [start: bare_list]
-# retry -> wrappers, no_secrets -> gateway_entry
+# retry -> wrappers, no_secrets -> entry_gate
 middleware = [retry, no_secrets]
 # --8<-- [end: bare_list]
 
 
 # --8<-- [start: raw_in_slots]
-async def add_marker(text):  # raw async function, no @rt.gateway
+async def add_marker(text):  # raw async function, no @rt.gate
     return (f"[{text}]",)
 
 
@@ -121,7 +121,7 @@ def shout(result):  # raw *sync* function (gateways may be sync)
     return result.upper()
 
 
-raw_ms = rt.MiddlewareSet(gateway_entry=[add_marker], gateway_exit=[shout])
+raw_ms = rt.MiddlewareChain(entry_gate=[add_marker], exit_gate=[shout])
 # --8<-- [end: raw_in_slots]
 
 
@@ -129,7 +129,7 @@ raw_ms = rt.MiddlewareSet(gateway_entry=[add_marker], gateway_exit=[shout])
 echo = rt.function_node(
     lambda text: f"echo: {text}",
     name="echo",
-    middleware=rt.MiddlewareSet(gateway_entry=[normalize], gateway_exit=[add_banner]),
+    middleware=rt.MiddlewareChain(entry_gate=[normalize], exit_gate=[add_banner]),
 )
 # --8<-- [end: attach_function_node]
 
@@ -147,7 +147,7 @@ assistant = rt.agent_node(
     llm=rt.llm.OpenAILLM("gpt-4o-mini"),
     system_message="Answer in one sentence.",
     middleware=[no_secrets],  # node boundary: once per agent call
-    model_middleware=rt.MiddlewareSet(gateway_entry=[normalize]),  # each model call
+    model_middleware=rt.MiddlewareChain(entry_gate=[normalize]),  # each model call
 )
 # --8<-- [end: attach_agent]
 
@@ -180,14 +180,14 @@ async def retry_run(call, *args, **kwargs):
                 raise
 
 
-@rt.gateway
+@rt.gate
 async def hide_secrets(text: str):
     found = re.findall(r"\b[A-Za-z0-9]{10,}\b", text)
     rt.context.put("secrets", found)
     return (re.sub(r"\b[A-Za-z0-9]{10,}\b", "[SECRET]", text),)  # tuple -> positional
 
 
-@rt.gateway
+@rt.gate
 async def restore_secrets(result):
     text = result.content if hasattr(result, "content") else result
     for s in rt.context.get("secrets") or []:
@@ -198,10 +198,10 @@ async def restore_secrets(result):
 secret_agent = rt.agent_node(
     llm=rt.llm.OpenAILLM("gpt-4o"),
     system_message="Echo [SECRET] tokens back verbatim.",
-    middleware=rt.MiddlewareSet(
+    middleware=rt.MiddlewareChain(
         wrappers=[retry_run],
-        gateway_entry=[hide_secrets],
-        gateway_exit=[restore_secrets],
+        entry_gate=[hide_secrets],
+        exit_gate=[restore_secrets],
     ),
 )
 # --8<-- [end: end_to_end]

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -47,9 +47,9 @@ __all__ = [
     "enable_logging",
     "Wrapper",
     "wrapper",
-    "Gateway",
-    "gateway",
-    "MiddlewareSet",
+    "Gate",
+    "gate",
+    "MiddlewareChain",
 ]
 
 from railtracks.built_nodes.concrete.rag import RagConfig
@@ -71,7 +71,7 @@ from . import (
 from ._session import ExecutionInfo, Session, session
 from .context.central import session_id, set_config
 from .interaction import broadcast, call, call_batch
-from .middleware import Gateway, MiddlewareSet, Wrapper, gateway, wrapper
+from .middleware import Gate, MiddlewareChain, Wrapper, gate, wrapper
 from .nodes.manifest import ToolManifest
 from .orchestration.flow import Flow
 from .rt_mcp import MCPHttpParams, MCPStdioParams, connect_mcp, create_mcp_server

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -96,6 +96,9 @@ def safe_create_node(
     return type(class_name + "Node", (Node,), class_dict)
 
 
+
+
+
 class NodeBuilder(Generic[_P, _T]):
     def __init__(self) -> None:
         self._class_name: str | None = None
@@ -226,7 +229,7 @@ class NodeBuilder(Generic[_P, _T]):
         class_name: str | None = None,
         name: str | None = None,
         *,
-        middleware: MiddlewareSet | list | None = None,
+        middleware: MiddlewareSet[_P2, _T2] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | Type[BaseModel] | dict[str, Any] | None = None,
         tool_info: Tool | None = None,

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -96,9 +96,6 @@ def safe_create_node(
     return type(class_name + "Node", (Node,), class_dict)
 
 
-
-
-
 class NodeBuilder(Generic[_P, _T]):
     def __init__(self) -> None:
         self._class_name: str | None = None
@@ -126,7 +123,10 @@ class NodeBuilder(Generic[_P, _T]):
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
         middleware: MiddlewareSet[[UserInput], StringResponse] | None = None,
-        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] | None = None,
+        model_middleware: MiddlewareSet[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ]
+        | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StringResponse]: ...
 
@@ -143,8 +143,12 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet[[UserInput], StructuredResponse[_TStructured]] | None = None,
-        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]  | None = None,
+        middleware: MiddlewareSet[[UserInput], StructuredResponse[_TStructured]]
+        | None = None,
+        model_middleware: MiddlewareSet[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ]
+        | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StructuredResponse[_TStructured]]: ...
 
@@ -161,7 +165,10 @@ class NodeBuilder(Generic[_P, _T]):
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
         middleware: MiddlewareSet[[UserInput], _R] | None = None,
-        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]  | None = None,
+        model_middleware: MiddlewareSet[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ]
+        | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], _R]:
         instance = cls()
@@ -179,7 +186,7 @@ class NodeBuilder(Generic[_P, _T]):
         # context_injection=False, or flow/session-wide via prompt_injection=False.
         if context_injection:
             model_invoker.register_sys_gateway_entry(context_injection_gateway)
-        
+
         model_invoker.register_sys_wrapper(llm_observe)
 
         casted_instance._invoke = llm_invoke_factory(

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -35,7 +35,7 @@ from railtracks.llm.history import MessageHistory
 from railtracks.llm.message import Message
 from railtracks.llm.response import Response
 from railtracks.llm.type_mapping import TypeMapper
-from railtracks.middleware import MiddlewareSet
+from railtracks.middleware import MiddlewareChain
 from railtracks.nodes.nodes import Node
 from railtracks.prompts.prompt import context_injection_gateway
 from railtracks.validation.node_creation.validation import (
@@ -107,7 +107,7 @@ class NodeBuilder(Generic[_P, _T]):
         self._tool_info: Callable[[], Tool] | None = None
         self._prepare_arguments: Callable[..., dict[str, Any]] | None = None
 
-        self._frozen_middleware: MiddlewareSet = MiddlewareSet()
+        self._frozen_middleware: MiddlewareChain = MiddlewareChain()
 
     @overload
     @classmethod
@@ -122,8 +122,8 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet[[UserInput], StringResponse] | None = None,
-        model_middleware: MiddlewareSet[
+        middleware: MiddlewareChain[[UserInput], StringResponse] | None = None,
+        model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
         | None = None,
@@ -143,9 +143,9 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet[[UserInput], StructuredResponse[_TStructured]]
+        middleware: MiddlewareChain[[UserInput], StructuredResponse[_TStructured]]
         | None = None,
-        model_middleware: MiddlewareSet[
+        model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
         | None = None,
@@ -164,8 +164,8 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet[[UserInput], _R] | None = None,
-        model_middleware: MiddlewareSet[
+        middleware: MiddlewareChain[[UserInput], _R] | None = None,
+        model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
         | None = None,
@@ -185,7 +185,7 @@ class NodeBuilder(Generic[_P, _T]):
         # higher-level wrapper created the node. Disable per-node with
         # context_injection=False, or flow/session-wide via prompt_injection=False.
         if context_injection:
-            model_invoker.register_sys_gateway_entry(context_injection_gateway)
+            model_invoker.register_sys_entry_gate(context_injection_gateway)
 
         model_invoker.register_sys_wrapper(llm_observe)
 
@@ -208,7 +208,7 @@ class NodeBuilder(Generic[_P, _T]):
                 )
             }
 
-        casted_instance._frozen_middleware = MiddlewareSet.coerce(middleware)
+        casted_instance._frozen_middleware = MiddlewareChain.coerce(middleware)
 
         return casted_instance
 
@@ -236,7 +236,7 @@ class NodeBuilder(Generic[_P, _T]):
         class_name: str | None = None,
         name: str | None = None,
         *,
-        middleware: MiddlewareSet[_P2, _T2] | None = None,
+        middleware: MiddlewareChain[_P2, _T2] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | Type[BaseModel] | dict[str, Any] | None = None,
         tool_info: Tool | None = None,
@@ -260,7 +260,7 @@ class NodeBuilder(Generic[_P, _T]):
 
         casted_instance._prepare_arguments = tm.convert_kwargs_to_appropriate_types
 
-        casted_instance._frozen_middleware = MiddlewareSet.coerce(middleware)
+        casted_instance._frozen_middleware = MiddlewareChain.coerce(middleware)
 
         return casted_instance
 

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -52,7 +52,6 @@ def classmethod_preserving_function_meta(func):
     return classmethod(wrapper)
 
 
-_TNode = TypeVar("_TNode", bound=Node)
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 _P2 = ParamSpec("_P2")

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -282,16 +282,16 @@ class NodeBuilder(Generic[_P, _T]):
     def construct_optional(self) -> dict[str, Any]:
         return {
             "tool_info": self._construct_tool_info(),
-            "prepare_tool": self._construct_prepared_arguments(),
+            "prepare_args": self._construct_prepared_arguments(),
             "frozen_middleware": self._frozen_middleware,
         }
 
-    def _construct_prepared_arguments(self, **kwargs):
+    def _construct_prepared_arguments(self):
         if self._prepare_arguments is None:
             return None
 
         return classmethod_preserving_function_meta(
-            lambda **kwargs: unpack(self._prepare_arguments)(kwargs)
+            lambda **kwargs: unpack(self._prepare_arguments)(**kwargs)
         )
 
     def _construct_tool_info(self):

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -23,6 +23,7 @@ from railtracks.built_nodes.llm_helpers import (
     ModelInvoker,
     ModelSource,
     llm_invoke_factory,
+    llm_observe,
     llm_prepare_called_as_tool_factory,
 )
 from railtracks.llm import (
@@ -32,6 +33,7 @@ from railtracks.llm import (
 )
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.message import Message
+from railtracks.llm.response import Response
 from railtracks.llm.type_mapping import TypeMapper
 from railtracks.middleware import MiddlewareSet
 from railtracks.nodes.nodes import Node
@@ -55,6 +57,7 @@ _P = ParamSpec("_P")
 _T = TypeVar("_T")
 _P2 = ParamSpec("_P2")
 _T2 = TypeVar("_T2")
+_R = TypeVar("_R", bound=StringResponse | StructuredResponse)
 _TStructured = TypeVar("_TStructured", bound=BaseModel)
 
 UserInput = Union[str, MessageHistory, list[Message]]
@@ -119,8 +122,8 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet | list | None = None,
-        model_middleware: MiddlewareSet | list | None = None,
+        middleware: MiddlewareSet[[UserInput], StringResponse] | None = None,
+        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StringResponse]: ...
 
@@ -137,8 +140,8 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet | list | None = None,
-        model_middleware: MiddlewareSet | list | None = None,
+        middleware: MiddlewareSet[[UserInput], StructuredResponse[_TStructured]] | None = None,
+        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]  | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StructuredResponse[_TStructured]]: ...
 
@@ -154,10 +157,10 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareSet | list | None = None,
-        model_middleware: MiddlewareSet | list | None = None,
+        middleware: MiddlewareSet[[UserInput], _R] | None = None,
+        model_middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]  | None = None,
         context_injection: bool = True,
-    ) -> NodeBuilder[[UserInput], StructuredResponse[_TStructured] | StringResponse]:
+    ) -> NodeBuilder[[UserInput], _R]:
         instance = cls()
         casted_instance = cast(NodeBuilder, instance)
         casted_instance._class_name = class_name or name
@@ -173,6 +176,8 @@ class NodeBuilder(Generic[_P, _T]):
         # context_injection=False, or flow/session-wide via prompt_injection=False.
         if context_injection:
             model_invoker.register_sys_gateway_entry(context_injection_gateway)
+        
+        model_invoker.register_sys_wrapper(llm_observe)
 
         casted_instance._invoke = llm_invoke_factory(
             model_invoker=model_invoker,
@@ -251,7 +256,8 @@ class NodeBuilder(Generic[_P, _T]):
 
     def construct_required(self) -> dict[str, Any]:
         async def invoke(_self, *args, **kwargs) -> _T:
-            return await unpack(self._invoke)(*args, **kwargs)
+            method = unpack(self._invoke)
+            return await method(*args, **kwargs)
 
         return {
             "invoke": invoke,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -9,7 +9,7 @@ from railtracks.built_nodes.concrete.response import StringResponse, StructuredR
 from railtracks.built_nodes.llm_helpers import ModelSource
 from railtracks.llm.message import SystemMessage
 from railtracks.llm.tools.parameters._base import Parameter
-from railtracks.middleware import MiddlewareSet
+from railtracks.middleware import MiddlewareChain
 from railtracks.nodes.manifest import ToolManifest
 from railtracks.nodes.nodes import Node
 from railtracks.nodes.utils import extract_node_from_function
@@ -44,8 +44,8 @@ def _build_dynamic_agent(
     system_message: SystemMessage | str | None,
     tool_details: str | None,
     tool_params: list[Parameter] | None,
-    middleware: MiddlewareSet | list | None = None,
-    model_middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareChain | list | None = None,
+    model_middleware: MiddlewareChain | list | None = None,
     context_injection: bool = True,
 ):
     resolved_system = (
@@ -95,8 +95,8 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
-    model_middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareChain | list | None = None,
+    model_middleware: MiddlewareChain | list | None = None,
     context_injection: bool = True,
 ) -> type[Node[[UserInput], StringResponse]]: ...
 
@@ -110,8 +110,8 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
-    model_middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareChain | list | None = None,
+    model_middleware: MiddlewareChain | list | None = None,
     context_injection: bool = True,
 ) -> type[Node[[UserInput], StructuredResponse[_TBaseModel]]]: ...
 
@@ -124,8 +124,8 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
-    model_middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareChain | list | None = None,
+    model_middleware: MiddlewareChain | list | None = None,
     context_injection: bool = True,
 ):
     """
@@ -140,11 +140,11 @@ def agent_node(
             at invocation time, e.g. from config or rt.context).
         system_message (SystemMessage | str | None): System message for the agent.
         manifest (ToolManifest | None): If you want to use this as a tool in other agents you can pass in a ToolManifest.
-        middleware (MiddlewareSet | list | None): Middleware applied around the agent's node boundary
-            (user_input -> Response). Accepts a MiddlewareSet or a bare list of Wrapper/Gateway.
-        model_middleware (MiddlewareSet | list | None): Middleware applied around each raw model call
-            (messages/schema/tools -> Response), inside the tool-calling loop. Accepts a MiddlewareSet or a
-            bare list of Wrapper/Gateway.
+        middleware (MiddlewareChain | list | None): Middleware applied around the agent's node boundary
+            (user_input -> Response). Accepts a MiddlewareChain or a bare list of Wrapper/Gate.
+        model_middleware (MiddlewareChain | list | None): Middleware applied around each raw model call
+            (messages/schema/tools -> Response), inside the tool-calling loop. Accepts a MiddlewareChain or a
+            bare list of Wrapper/Gate.
         context_injection (bool): Whether to inject rt.context variables into prompt templates for this node.
             Defaults to True. Set to False to disable context injection for this specific agent regardless
             of the session-level prompt_injection setting. Can also be controlled at the session level via

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
@@ -178,6 +178,7 @@ def _single_function_node(
         async def wrapped_function(*args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
             return await asyncio.to_thread(func, *args, **kwargs)
 
+        functools.update_wrapper(wrapped_function, func)  # type: ignore[arg-type]
         unwrapped_func = wrapped_function
     else:
         unwrapped_func = func

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
@@ -20,7 +20,7 @@ from typing import (
 from railtracks.built_nodes._node_builder import NodeBuilder
 from railtracks.built_nodes.concrete.function_base import RTFunction
 from railtracks.exceptions import NodeCreationError
-from railtracks.middleware import MiddlewareSet
+from railtracks.middleware import MiddlewareChain
 from railtracks.nodes.manifest import ToolManifest
 from railtracks.nodes.nodes import Node
 from railtracks.validation.node_creation.validation import (
@@ -49,7 +49,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet[_P, _TOutput] | None = None,
+    middleware: MiddlewareChain[_P, _TOutput] | None = None,
 ) -> CallableAsyncRTFunction[_P, _TOutput]: ...
 
 
@@ -60,7 +60,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet[_P, _TOutput] | None = None,
+    middleware: MiddlewareChain[_P, _TOutput] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput]:
     pass
 
@@ -72,7 +72,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet[_P, _TOutput] | None = None,
+    middleware: MiddlewareChain[_P, _TOutput] | None = None,
 ) -> List[RTFunction[..., Any]]:
     pass
 
@@ -84,7 +84,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | None = None,
+    middleware: MiddlewareChain | None = None,
 ) -> Callable[
     [Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]], RTFunction[_P, _TOutput]
 ]:
@@ -121,7 +121,7 @@ def _single_function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet[_P, _TOutput] | None = None,
+    middleware: MiddlewareChain[_P, _TOutput] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput] | CallableAsyncRTFunction[_P, _TOutput]:
     """
     Creates a new Node type from a function that can be used in `rt.call()`.
@@ -213,7 +213,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet[_P, _TOutput] | None = None,
+    middleware: MiddlewareChain[_P, _TOutput] | None = None,
 ) -> (
     Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]
     | List[Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]]
@@ -248,8 +248,8 @@ def function_node(
             parametrized-decorator form, which returns a decorator that takes the function.
         name (str, optional): Human-readable name for the node/tool.
         manifest (ToolManifest, optional): The details you would like to override the tool with.
-        middleware (MiddlewareSet | list | None): Middleware applied around the node boundary.
-            Accepts a MiddlewareSet or a bare list of Wrapper/Gateway (check-only gateways act as guardrails).
+        middleware (MiddlewareChain | list | None): Middleware applied around the node boundary.
+            Accepts a MiddlewareChain or a bare list of Wrapper/Gate (check-only gateways act as guardrails).
     """
 
     # No function yet -> parametrized-decorator form: bind the options and return

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
@@ -77,7 +77,6 @@ def function_node(
     pass
 
 
-
 @overload
 def function_node(
     func: None = None,
@@ -86,7 +85,9 @@ def function_node(
     name: str | None = None,
     manifest: ToolManifest | None = None,
     middleware: MiddlewareSet | None = None,
-) -> Callable[[Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]], RTFunction[_P, _TOutput]]:
+) -> Callable[
+    [Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]], RTFunction[_P, _TOutput]
+]:
     pass
 
 
@@ -253,21 +254,18 @@ def function_node(
     # No function yet -> parametrized-decorator form: bind the options and return
     # a decorator that finishes the job once the function is supplied.
     if func is None:
+
         def _decorator(
             f: Callable[_P, Coroutine[None, None, _TOutput] | _TOutput],
         ) -> Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]:
-            return function_node(
-                f, name=name, manifest=manifest, middleware=middleware
-            )
+            return function_node(f, name=name, manifest=manifest, middleware=middleware)
 
         return _decorator
 
     # handle the case where a list of functions is provided
     if isinstance(func, list):
         return [
-            function_node(
-                f, name=name, manifest=manifest, middleware=middleware
-            )
+            function_node(f, name=name, manifest=manifest, middleware=middleware)
             for f in func
         ]
     else:

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/function.py
@@ -49,7 +49,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareSet[_P, _TOutput] | None = None,
 ) -> CallableAsyncRTFunction[_P, _TOutput]: ...
 
 
@@ -60,7 +60,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareSet[_P, _TOutput] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput]:
     pass
 
@@ -72,9 +72,10 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareSet[_P, _TOutput] | None = None,
 ) -> List[RTFunction[..., Any]]:
     pass
+
 
 
 @overload
@@ -84,8 +85,8 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
-) -> Callable[[Callable[_P, _TOutput]], RTFunction[_P, _TOutput]]:
+    middleware: MiddlewareSet | None = None,
+) -> Callable[[Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]], RTFunction[_P, _TOutput]]:
     pass
 
 
@@ -119,7 +120,7 @@ def _single_function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareSet[_P, _TOutput] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput] | CallableAsyncRTFunction[_P, _TOutput]:
     """
     Creates a new Node type from a function that can be used in `rt.call()`.
@@ -210,7 +211,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: MiddlewareSet | list | None = None,
+    middleware: MiddlewareSet[_P, _TOutput] | None = None,
 ) -> (
     Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]
     | List[Callable[_P, Coroutine[None, None, _TOutput] | _TOutput]]

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -437,30 +437,25 @@ def prepare_string_response(
 
 
 @wrapper
-def llm_observe(
+async def llm_observe(
     call: Callable[
         [MessageHistory, type[BaseModel] | None, list[Tool] | None], Awaitable[Response]
     ],
-):
-    async def wrapper(
-        message_history: MessageHistory,
-        schema: type[BaseModel] | None,
-        tools: list[Tool] | None,
-    ):
-        prev_message_history = deepcopy(message_history)
-        response: Response = await call(message_history, schema, tools)
-        _ = RequestDetails(
-            message_input=prev_message_history,
-            output=response.message,
-            model_name=response.message_info.model_name,
-            model_provider=None,  # TODO: implement parsing logic here
-            input_tokens=response.message_info.input_tokens,
-            output_tokens=response.message_info.output_tokens,
-            total_cost=response.message_info.total_cost,
-            system_fingerprint=response.message_info.system_fingerprint,
-            latency=response.message_info.latency,
-        )
-
-        return response
-
-    return wrapper
+    message_history: MessageHistory,
+    schema: type[BaseModel] | None,
+    tools: list[Tool] | None,
+) -> Response:
+    prev_message_history = deepcopy(message_history)
+    response: Response = await call(message_history, schema, tools)
+    _ = RequestDetails(
+        message_input=prev_message_history,
+        output=response.message,
+        model_name=response.message_info.model_name,
+        model_provider=None,  # TODO: implement parsing logic here
+        input_tokens=response.message_info.input_tokens,
+        output_tokens=response.message_info.output_tokens,
+        total_cost=response.message_info.total_cost,
+        system_fingerprint=response.message_info.system_fingerprint,
+        latency=response.message_info.latency,
+    )
+    return response

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -29,7 +29,7 @@ from railtracks.llm.model import ModelBase
 from railtracks.llm.response import Response
 from railtracks.llm.tools.parameters._base import Parameter
 from railtracks.llm.tools.tool import Tool
-from railtracks.middleware import Gateway, MiddlewareSet
+from railtracks.middleware import Gate, MiddlewareChain
 from railtracks.middleware.primitives import Wrapper, wrapper
 from railtracks.nodes.nodes import Node
 from railtracks.validation.node_invocation.validation import check_message_history
@@ -58,7 +58,7 @@ class StructuredLLMInvoke(Protocol[_TStructured]):
 
 class ModelInvoker:
     """
-    Coordinates a single LLM model call through a :class:`MiddlewareSet`.
+    Coordinates a single LLM model call through a :class:`MiddlewareChain`.
 
     The middleware operates around the *raw* model call, once per model
     round-trip (i.e. inside the tool-calling loop). The core callable takes
@@ -72,8 +72,8 @@ class ModelInvoker:
         └── exit gateways    (transform the Response)
         └── (unwind)
 
-    Accepts a :class:`MiddlewareSet` or a bare list of ``Wrapper`` / ``Gateway``
-    (see :meth:`MiddlewareSet.coerce`). The caller's input is never mutated — a
+    Accepts a :class:`MiddlewareChain` or a bare list of ``Wrapper`` / ``Gate``
+    (see :meth:`MiddlewareChain.coerce`). The caller's input is never mutated — a
     fresh copy is taken so system gateways (e.g. context injection) stay
     independent per node.
     """
@@ -81,29 +81,29 @@ class ModelInvoker:
     def __init__(
         self,
         model: ModelSource,
-        middleware: MiddlewareSet[
+        middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
         | None = None,
     ):
         self._get_model = model if callable(model) else lambda: model
-        self._middleware: MiddlewareSet[
+        self._middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
-        ] = MiddlewareSet.coerce(middleware)
+        ] = MiddlewareChain.coerce(middleware)
 
-    def register_sys_gateway_entry(
+    def register_sys_entry_gate(
         self,
-        gw: Gateway[
+        gw: Gate[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None],
             tuple[tuple, dict[str, Any]],
         ],
     ) -> None:
-        """Register a system entry gateway around the model call (e.g. context injection)."""
-        self._middleware.register_sys_gateway_entry(gw)
+        """Register a system entry gate around the model call (e.g. context injection)."""
+        self._middleware.register_sys_entry_gate(gw)
 
-    def register_sys_gateway_exit(self, gw: Gateway[[Response], Response]) -> None:
-        """Register a system exit gateway around the model call (e.g. logging)."""
-        self._middleware.register_sys_gateway_exit(gw)
+    def register_sys_exit_gate(self, gw: Gate[[Response], Response]) -> None:
+        """Register a system exit gate around the model call (e.g. logging)."""
+        self._middleware.register_sys_exit_gate(gw)
 
     def register_sys_wrapper(
         self,

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -30,7 +30,7 @@ from railtracks.llm.response import Response
 from railtracks.llm.tools.parameters._base import Parameter
 from railtracks.llm.tools.tool import Tool
 from railtracks.middleware import Gateway, MiddlewareSet
-from railtracks.middleware.primitives import Wrapper, gateway, wrapper
+from railtracks.middleware.primitives import Wrapper, wrapper
 from railtracks.nodes.nodes import Node
 from railtracks.validation.node_invocation.validation import check_message_history
 
@@ -84,12 +84,23 @@ class ModelInvoker:
     def __init__(
         self,
         model: ModelSource,
-        middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] | None = None,
+        middleware: MiddlewareSet[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ]
+        | None = None,
     ):
         self._get_model = model if callable(model) else lambda: model
-        self._middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] = MiddlewareSet.coerce(middleware)
+        self._middleware: MiddlewareSet[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ] = MiddlewareSet.coerce(middleware)
 
-    def register_sys_gateway_entry(self, gw: Gateway[[MessageHistory, type[BaseModel] | None, list[Tool] | None], tuple[tuple, dict[str, Any]]]) -> None:
+    def register_sys_gateway_entry(
+        self,
+        gw: Gateway[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None],
+            tuple[tuple, dict[str, Any]],
+        ],
+    ) -> None:
         """Register a system entry gateway around the model call (e.g. context injection)."""
         self._middleware.register_sys_gateway_entry(gw)
 
@@ -97,7 +108,12 @@ class ModelInvoker:
         """Register a system exit gateway around the model call (e.g. logging)."""
         self._middleware.register_sys_gateway_exit(gw)
 
-    def register_sys_wrapper(self, w: Wrapper[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]) -> None:
+    def register_sys_wrapper(
+        self,
+        w: Wrapper[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
+        ],
+    ) -> None:
         """Register a system wrapper around the model call (e.g. logging)."""
         self._middleware.register_sys_outer_wrapper(w)
 
@@ -132,7 +148,7 @@ class ModelInvoker:
 @overload
 def llm_invoke_factory(
     model_invoker: ModelInvoker,
-    system_message: SystemMessage | None,\
+    system_message: SystemMessage | None,
     *,
     tool_nodes: list[type[Node]] | None = None,
     schema: None = None,
@@ -148,6 +164,7 @@ def llm_invoke_factory(
     schema: type[_TStructured],
 ) -> StructuredLLMInvoke[_TStructured]: ...
 
+
 class LLMCallProtocol(Protocol):
     async def __call__(
         self,
@@ -156,6 +173,7 @@ class LLMCallProtocol(Protocol):
         schema: type[BaseModel] | None = None,
         tools: list[Tool] | None = None,
     ) -> Response: ...
+
 
 def llm_invoke_factory(
     model_invoker: ModelInvoker,
@@ -421,16 +439,20 @@ def prepare_string_response(
     return StringResponse(content=content, message_history=message_history)
 
 
-
-
 @wrapper
 def llm_observe(
-    call: Callable[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Awaitable[Response]],
+    call: Callable[
+        [MessageHistory, type[BaseModel] | None, list[Tool] | None], Awaitable[Response]
+    ],
 ):
-    async def wrapper(message_history: MessageHistory, schema: type[BaseModel] | None, tools: list[Tool] | None):
+    async def wrapper(
+        message_history: MessageHistory,
+        schema: type[BaseModel] | None,
+        tools: list[Tool] | None,
+    ):
         prev_message_history = deepcopy(message_history)
-        response: Response = await call(message_history, schema, tools)       
-        rd = RequestDetails(
+        response: Response = await call(message_history, schema, tools)
+        _ = RequestDetails(
             message_input=prev_message_history,
             output=response.message,
             model_name=response.message_info.model_name,
@@ -442,13 +464,6 @@ def llm_observe(
             latency=response.message_info.latency,
         )
 
-
         return response
 
     return wrapper
-        
-        
-
-
-   
-

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -1,8 +1,9 @@
 import asyncio
 from copy import deepcopy
 from typing import (
+    Any,
+    Awaitable,
     Callable,
-    Generic,
     Literal,
     Protocol,
     TypeVar,
@@ -11,6 +12,7 @@ from typing import (
 
 from pydantic import BaseModel
 
+from railtracks.built_nodes.concrete._llm_base import RequestDetails
 from railtracks.built_nodes.concrete.response import StringResponse, StructuredResponse
 from railtracks.exceptions.errors import LLMError
 from railtracks.interaction._call import call
@@ -28,6 +30,7 @@ from railtracks.llm.response import Response
 from railtracks.llm.tools.parameters._base import Parameter
 from railtracks.llm.tools.tool import Tool
 from railtracks.middleware import Gateway, MiddlewareSet
+from railtracks.middleware.primitives import Wrapper, gateway, wrapper
 from railtracks.nodes.nodes import Node
 from railtracks.validation.node_invocation.validation import check_message_history
 
@@ -53,7 +56,10 @@ class StructuredLLMInvoke(Protocol[_TStructured]):
     ) -> StructuredResponse[_TStructured]: ...
 
 
-class ModelInvoker(Generic[_TStructured]):
+_TStructured = TypeVar("_TStructured", bound=BaseModel)
+
+
+class ModelInvoker:
     """
     Coordinates a single LLM model call through a :class:`MiddlewareSet`.
 
@@ -78,14 +84,22 @@ class ModelInvoker(Generic[_TStructured]):
     def __init__(
         self,
         model: ModelSource,
-        middleware: "MiddlewareSet | list | None" = None,
+        middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] | None = None,
     ):
         self._get_model = model if callable(model) else lambda: model
-        self._middleware = MiddlewareSet.coerce(middleware)
+        self._middleware: MiddlewareSet[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response] = MiddlewareSet.coerce(middleware)
 
-    def register_sys_gateway_entry(self, gw: Gateway) -> None:
+    def register_sys_gateway_entry(self, gw: Gateway[[MessageHistory, type[BaseModel] | None, list[Tool] | None], tuple[tuple, dict[str, Any]]]) -> None:
         """Register a system entry gateway around the model call (e.g. context injection)."""
         self._middleware.register_sys_gateway_entry(gw)
+
+    def register_sys_gateway_exit(self, gw: Gateway[[Response], Response]) -> None:
+        """Register a system exit gateway around the model call (e.g. logging)."""
+        self._middleware.register_sys_gateway_exit(gw)
+
+    def register_sys_wrapper(self, w: Wrapper[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Response]) -> None:
+        """Register a system wrapper around the model call (e.g. logging)."""
+        self._middleware.register_sys_outer_wrapper(w)
 
     async def invoke(
         self,
@@ -93,14 +107,14 @@ class ModelInvoker(Generic[_TStructured]):
         *,
         schema: type[BaseModel] | None = None,
         tools: list[Tool] | None = None,
-    ):
+    ) -> Response:
         model = self._get_model()
 
         async def _core_llm_call(
             messages: MessageHistory,
             schema: type[BaseModel] | None,
             tools: list[Tool] | None,
-        ):
+        ) -> Response:
             if tools is not None and len(tools) > 0:
                 return await asyncio.to_thread(
                     model.chat_with_tools, messages, tools=tools
@@ -112,13 +126,14 @@ class ModelInvoker(Generic[_TStructured]):
             else:
                 return await asyncio.to_thread(model.chat, messages)
 
-        return await self._middleware.run(_core_llm_call, (messages, schema, tools), {})
+        return await self._middleware.run(_core_llm_call, messages, schema, tools)
 
 
 @overload
 def llm_invoke_factory(
     model_invoker: ModelInvoker,
-    system_message: SystemMessage | None,
+    system_message: SystemMessage | None,\
+    *,
     tool_nodes: list[type[Node]] | None = None,
     schema: None = None,
 ) -> StringLLMInvoke: ...
@@ -126,16 +141,18 @@ def llm_invoke_factory(
 
 @overload
 def llm_invoke_factory(
-    model_invoker: ModelInvoker[_TStructured],
+    model_invoker: ModelInvoker,
     system_message: SystemMessage | None,
+    *,
     tool_nodes: list[type[Node]] | None = None,
-    schema: type[_TStructured] = ...,
+    schema: type[_TStructured],
 ) -> StructuredLLMInvoke[_TStructured]: ...
 
 
 def llm_invoke_factory(
-    model_invoker: ModelInvoker[_TStructured],
+    model_invoker: ModelInvoker,
     system_message: SystemMessage | None,
+    *,
     tool_nodes: list[type[Node]] | None = None,
     schema: type[_TStructured] | None = None,
 ):
@@ -394,3 +411,37 @@ def prepare_string_response(
     )
 
     return StringResponse(content=content, message_history=message_history)
+
+
+
+
+@wrapper
+def llm_observe(
+    call: Callable[[MessageHistory, type[BaseModel] | None, list[Tool] | None], Awaitable[Response]],
+):
+    async def wrapper(message_history: MessageHistory, schema: type[BaseModel] | None, tools: list[Tool] | None):
+        prev_message_history = deepcopy(message_history)
+        response: Response = await call(message_history, schema, tools)
+        rd = RequestDetails(
+            message_input=prev_message_history,
+            output=response.message,
+            model_name=response.message_info.model_name,
+            model_provider=None,  # TODO: implement parsing logic here
+            input_tokens=response.message_info.input_tokens,
+            output_tokens=response.message_info.output_tokens,
+            total_cost=response.message_info.total_cost,
+            system_fingerprint=response.message_info.system_fingerprint,
+            latency=response.message_info.latency,
+        )
+
+        print(rd)
+
+        return response
+
+    return wrapper
+        
+        
+
+
+   
+

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -148,6 +148,14 @@ def llm_invoke_factory(
     schema: type[_TStructured],
 ) -> StructuredLLMInvoke[_TStructured]: ...
 
+class LLMCallProtocol(Protocol):
+    async def __call__(
+        self,
+        messages: MessageHistory,
+        *,
+        schema: type[BaseModel] | None = None,
+        tools: list[Tool] | None = None,
+    ) -> Response: ...
 
 def llm_invoke_factory(
     model_invoker: ModelInvoker,
@@ -421,7 +429,7 @@ def llm_observe(
 ):
     async def wrapper(message_history: MessageHistory, schema: type[BaseModel] | None, tools: list[Tool] | None):
         prev_message_history = deepcopy(message_history)
-        response: Response = await call(message_history, schema, tools)
+        response: Response = await call(message_history, schema, tools)       
         rd = RequestDetails(
             message_input=prev_message_history,
             output=response.message,

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -442,7 +442,6 @@ def llm_observe(
             latency=response.message_info.latency,
         )
 
-        print(rd)
 
         return response
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -56,9 +56,6 @@ class StructuredLLMInvoke(Protocol[_TStructured]):
     ) -> StructuredResponse[_TStructured]: ...
 
 
-_TStructured = TypeVar("_TStructured", bound=BaseModel)
-
-
 class ModelInvoker:
     """
     Coordinates a single LLM model call through a :class:`MiddlewareSet`.

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -82,7 +82,6 @@ async def call(
 
     if hasattr(node_, "node_type"):
         # local import to prevent circular import issues (note it is a purely type checking import)
-        print(f"Extracting node from function {node_}")
         from railtracks.built_nodes.concrete import RTFunction
 
         assert isinstance(node_, RTFunction)

--- a/packages/railtracks/src/railtracks/llm/type_mapping.py
+++ b/packages/railtracks/src/railtracks/llm/type_mapping.py
@@ -21,7 +21,7 @@ class TypeMapper:
                 "Please use a custom function."
             )
 
-    def convert_kwargs_to_appropriate_types(self, kwargs) -> Dict[str, Any]:
+    def convert_kwargs_to_appropriate_types(self, **kwargs) -> Dict[str, Any]:
         """Convert kwargs to appropriate types based on function signature."""
         converted_kwargs = {}
 

--- a/packages/railtracks/src/railtracks/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/middleware/__init__.py
@@ -15,27 +15,27 @@ call):
                   pass
           raise RuntimeError("All retries exhausted")
 
-- :class:`Gateway` — direction-neutral data transform. Place it in
-  ``gateway_entry`` to transform inputs before the core runs, or in
-  ``gateway_exit`` to transform the output afterwards.
+- :class:`Gate` — direction-neutral data transform. Place it in
+  ``entry_gate`` to transform inputs before the core runs, or in
+  ``exit_gate`` to transform the output afterwards.
 
-:class:`MiddlewareSet` bundles them into an ordered execution chain::
+:class:`MiddlewareChain` bundles them into an ordered execution chain::
 
-    wrappers → gateway_entry → inner_wrappers → core → gateway_exit → (unwind)
+    wrappers → entry_gate → inner_wrappers → core → exit_gate → (unwind)
 """
 
 from railtracks.middleware.primitives import (
-    Gateway,
+    Gate,
     Wrapper,
-    gateway,
+    gate,
     wrapper,
 )
-from railtracks.middleware.set import MiddlewareSet
+from railtracks.middleware.set import MiddlewareChain
 
 __all__ = [
     "Wrapper",
     "wrapper",
-    "Gateway",
-    "gateway",
-    "MiddlewareSet",
+    "Gate",
+    "gate",
+    "MiddlewareChain",
 ]

--- a/packages/railtracks/src/railtracks/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/middleware/__init__.py
@@ -1,5 +1,28 @@
-"""Unified middleware: two primitives (`Wrapper`, `Gateway`) attachable to every
-entry point, plus the `MiddlewareSet` container that orders and runs them."""
+"""Unified middleware for every Railtracks entry point.
+
+Two primitives, each attachable to any callable (function node, agent, model
+call):
+
+- :class:`Wrapper` — execution control (retry, fallback, timing,
+  short-circuit).  Written as a call-style async function::
+
+      @wrapper
+      async def retry(call, *args, **kwargs):
+          for _ in range(3):
+              try:
+                  return await call(*args, **kwargs)
+              except Exception:
+                  pass
+          raise RuntimeError("All retries exhausted")
+
+- :class:`Gateway` — direction-neutral data transform. Place it in
+  ``gateway_entry`` to transform inputs before the core runs, or in
+  ``gateway_exit`` to transform the output afterwards.
+
+:class:`MiddlewareSet` bundles them into an ordered execution chain::
+
+    wrappers → gateway_entry → inner_wrappers → core → gateway_exit → (unwind)
+"""
 
 from railtracks.middleware.primitives import (
     Gateway,

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -231,7 +231,7 @@ class Gateway(Generic[_P, _R]):
         return self._fn(*args, **kwargs)
 
     @property
-    def fn(self) -> Callable[_P, Awaitable[_R]]:
+    def fn(self) -> Callable[_P, Awaitable[_R] | _R]:
         return self._fn
 
     def __repr__(self) -> str:

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -64,19 +64,14 @@ from typing import (
     Awaitable,
     Callable,
     Coroutine,
+    Generic,
     ParamSpec,
     TypeVar,
+    overload,
 )
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
-
-# A wrapper-author function: (inner_call, *args, **kwargs) -> result. Must be async —
-# a wrapper has to ``await`` the inner call, which a sync function cannot do.
-WrapperFn = Callable[..., Coroutine[Any, Any, Any]]
-# A gateway-author function: entry -> (*args, **kwargs) -> (args, kwargs);
-#                            exit  -> (result) -> result. May be async or plain sync.
-GatewayFn = Callable[..., Any]
 
 
 def _require_callable(fn: Callable, role: str) -> None:
@@ -111,7 +106,7 @@ class _GatewayArgs:
         return f"gateway.args({inner})"
 
 
-class Wrapper:
+class Wrapper(Generic[_P, _R]):
     """Execution-control middleware.
 
     Built from a call-style async function ``fn(call, *args, **kwargs)`` where
@@ -124,10 +119,8 @@ class Wrapper:
     loss of the run's context is not acceptable).
     """
 
-    def __init__(self, fn: WrapperFn) -> None:
-        _require_async(fn, "Wrapper function")
+    def __init__(self, fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]) -> None:
         self._fn = fn
-        functools.update_wrapper(self, fn, updated=())
 
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
         """Compose this wrapper onto ``inner``, returning a new callable.
@@ -136,21 +129,17 @@ class Wrapper:
         wrapping does not erase the signature of the function being wrapped.
         """
 
-        @functools.wraps(self._fn)
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            return await self._fn(inner, *args, **kwargs)
+            return await self._fn(inner)(*args, **kwargs)
 
         return wrapped
-
-    @property
-    def fn(self) -> WrapperFn:
-        return self._fn
 
     def __repr__(self) -> str:
         return f"Wrapper({getattr(self._fn, '__name__', self._fn)!r})"
 
 
-class Gateway:
+
+class Gateway(Generic[_P, _R]):
     """Direction-less data-transform middleware.
 
     Build one with :func:`gateway`; its direction is decided by the slot it is
@@ -166,23 +155,24 @@ class Gateway:
             return clean(result)
     """
 
-    def __init__(self, fn: GatewayFn) -> None:
+    def __init__(self, fn: Callable[_P, Awaitable[_R] | _R]) -> None:
         _require_callable(fn, "Gateway function")
         self._fn = fn
-        self._is_async = inspect.iscoroutinefunction(fn)
-        functools.update_wrapper(self, fn, updated=())
 
-    async def _invoke(self, *args: Any, **kwargs: Any) -> Any:
+    async def _invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         """Call the underlying function, awaiting it if it is async.
 
         A sync gateway is a quick data transform, so it is run inline (not in a
         thread) — that keeps any ``rt.context`` writes on the current context.
         """
-        if self._is_async:
-            return await self._fn(*args, **kwargs)
-        return self._fn(*args, **kwargs)
+        if inspect.iscoroutinefunction(self._fn):
+            result: _R = await self._fn(*args, **kwargs)
+        else:
+            result: _R = self._fn(*args, **kwargs)
+        
+        return result
 
-    async def apply_entry(self, *args: Any, **kwargs: Any) -> tuple[tuple, dict]:
+    async def apply_entry(self, *args: _P.args, **kwargs: _P.kwargs) -> tuple[tuple, dict]:
         """Run as an entry gateway. Returns the new ``(args, kwargs)``.
 
         The return value is interpreted as:
@@ -220,7 +210,7 @@ class Gateway:
             f"got {result!r}. Wrap a single positional value as (x,) or gateway.args(x)."
         )
 
-    async def apply_exit(self, result: Any) -> Any:
+    async def apply_exit(self, result: _R) -> _R:
         """Run as an exit gateway. Returns the (possibly transformed) result.
 
         A check-only gateway may ``return`` nothing (``None``); the original result is
@@ -229,7 +219,7 @@ class Gateway:
         transformed = await self._invoke(result)
         return result if transformed is None else transformed
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs):
         """Invoke the underlying function directly (a raw pass-through).
 
         Handy for reusing a generic gateway — e.g. a logger or validator — as an
@@ -241,14 +231,14 @@ class Gateway:
         return self._fn(*args, **kwargs)
 
     @property
-    def fn(self) -> Callable:
+    def fn(self) -> Callable[_P, Awaitable[_R]]:
         return self._fn
 
     def __repr__(self) -> str:
         return f"Gateway({getattr(self._fn, '__name__', self._fn)!r})"
 
 
-def wrapper(fn: WrapperFn) -> Wrapper:
+def wrapper(fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]) -> Wrapper[_P, _R]:
     """Decorator: turn a call-style async function into a :class:`Wrapper`."""
     return Wrapper(fn)
 
@@ -265,8 +255,13 @@ def _gateway_args(*args: Any, **kwargs: Any) -> _GatewayArgs:
     """
     return _GatewayArgs(args, kwargs)
 
+@overload
+def gateway(fn: Callable[_P, Awaitable[_R]]) -> Gateway[_P, _R]: ...
 
-def gateway(fn: GatewayFn) -> Gateway:
+@overload
+def gateway(fn: Callable[_P, _R]) -> Gateway[_P, _R]: ...
+
+def gateway(fn: Callable[_P, Awaitable[_R] | _R]) -> Gateway:
     """Decorator: turn a function into a (direction-less) :class:`Gateway`.
 
     ``fn`` may be ``async`` or plain ``def`` (a sync gateway is run inline).

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -128,9 +128,9 @@ class Wrapper(Generic[_P, _R]):
         The returned callable carries ``inner``'s parameter and return types, so
         wrapping does not erase the signature of the function being wrapped.
         """
-
+        decorated = self._fn(inner)
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            return await self._fn(inner)(*args, **kwargs)
+            return await decorated(*args, **kwargs)
 
         return wrapped
 

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -2,17 +2,17 @@
 
 - :class:`Wrapper` — execution control: receives the inner callable and decides
   whether/how/how-many-times to invoke it (retry, fallback, short-circuit, timing).
-- :class:`Gateway` — direction-neutral data transform: slot placement decides
-  when it runs. ``gateway_entry`` transforms input; ``gateway_exit`` transforms
-  output. Check-only gateways validate and raise, or return ``None`` to pass through.
+- :class:`Gate` — direction-neutral data transform: slot placement decides
+  when it runs. ``entry_gate`` transforms input; ``exit_gate`` transforms
+  output. Check-only gates validate and raise, or return ``None`` to pass through.
 
-``@wrapper`` / ``@gateway`` are optional in named
-:class:`~railtracks.middleware.MiddlewareSet` slots (the slot implies the role
+``@wrapper`` / ``@gate`` are optional in named
+:class:`~railtracks.middleware.MiddlewareChain` slots (the slot implies the role
 and auto-coerces raw functions); required in bare lists where the role is ambiguous.
 
-Entry gateway return conventions:
+Entry gate return conventions:
 ``None`` → pass-through · ``tuple`` → new args · ``dict`` → new kwargs ·
-``(tuple, dict)`` → full replacement · :func:`gateway.args` → explicit form.
+``(tuple, dict)`` → full replacement · :func:`gate.args` → explicit form.
 Any other bare value raises ``TypeError``.
 """
 
@@ -47,8 +47,8 @@ def _require_async(fn: Callable, role: str) -> None:
         )
 
 
-class _GatewayArgs:
-    """Unambiguous ``(args, kwargs)`` container returned by :func:`gateway.args`."""
+class _GateArgs:
+    """Unambiguous ``(args, kwargs)`` container returned by :func:`gate.args`."""
 
     __slots__ = ("args", "kwargs")
 
@@ -61,7 +61,7 @@ class _GatewayArgs:
             [repr(a) for a in self.args]
             + [f"{k}={v!r}" for k, v in self.kwargs.items()]
         )
-        return f"gateway.args({inner})"
+        return f"gate.args({inner})"
 
 
 class Wrapper(Generic[_P, _R]):
@@ -102,30 +102,30 @@ class Wrapper(Generic[_P, _R]):
         return f"Wrapper({getattr(self._fn, '__name__', self._fn)!r})"
 
 
-class Gateway(Generic[_P, _R]):
+class Gate(Generic[_P, _R]):
     """Direction-neutral data-transform middleware.
 
-    Slot placement decides direction: ``gateway_entry`` transforms input,
-    ``gateway_exit`` transforms output. The same object can serve either::
+    Slot placement decides direction: ``entry_gate`` transforms input,
+    ``exit_gate`` transforms output. The same object can serve either::
 
-        @gateway
+        @gate
         async def scrub(*args, **kwargs):  # entry: clean the inputs
             return (clean(args), kwargs)
 
 
-        @gateway
+        @gate
         async def redact(result):  # exit: clean the output
             return clean(result)
     """
 
     def __init__(self, fn: Callable[_P, Awaitable[_R] | _R]) -> None:
-        _require_callable(fn, "Gateway function")
+        _require_callable(fn, "Gate function")
         self._fn = fn
 
     async def _invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         """Call the underlying function, awaiting it if async.
 
-        Sync gateways run inline (not in a thread) to preserve ``rt.context``
+        Sync gates run inline (not in a thread) to preserve ``rt.context``
         writes on the current context.
         """
         if inspect.iscoroutinefunction(self._fn):
@@ -138,7 +138,7 @@ class Gateway(Generic[_P, _R]):
     async def apply_entry(
         self, *args: _P.args, **kwargs: _P.kwargs
     ) -> tuple[tuple, dict]:
-        """Run as an entry gateway; returns the new ``(args, kwargs)``.
+        """Run as an entry gate; returns the new ``(args, kwargs)``.
 
         Return-value conventions:
 
@@ -146,15 +146,15 @@ class Gateway(Generic[_P, _R]):
         - ``tuple``                     — new positional args: ``(the_tuple, {})``.
         - ``dict``                      — new keyword args: ``((), the_dict)``.
         - ``(tuple, dict)`` 2-tuple     — full ``(args, kwargs)`` replacement.
-        - :func:`gateway.args(*a, **k)` — same, stated explicitly.
+        - :func:`gate.args(*a, **k)`    — same, stated explicitly.
 
         Any other bare value raises ``TypeError``. Wrap a lone positional as
-        ``(x,)`` or ``gateway.args(x)``.
+        ``(x,)`` or ``gate.args(x)``.
         """
         result = await self._invoke(*args, **kwargs)
         if result is None:
             return args, kwargs
-        if isinstance(result, _GatewayArgs):
+        if isinstance(result, _GateArgs):
             return result.args, result.kwargs
         # (args_tuple, kwargs_dict) -> full form. Check before the plain-tuple case.
         if (
@@ -169,13 +169,13 @@ class Gateway(Generic[_P, _R]):
         if isinstance(result, dict):
             return (), result  # keyword args only
         raise TypeError(
-            f"Entry gateway {self._fn!r} must return None, a tuple (positional args), "
-            f"a dict (keyword args), a (tuple, dict) pair, or gateway.args(...); "
-            f"got {result!r}. Wrap a single positional value as (x,) or gateway.args(x)."
+            f"Entry gate {self._fn!r} must return None, a tuple (positional args), "
+            f"a dict (keyword args), a (tuple, dict) pair, or gate.args(...); "
+            f"got {result!r}. Wrap a single positional value as (x,) or gate.args(x)."
         )
 
     async def apply_exit(self, result: _R) -> _R:
-        """Run as an exit gateway; returns the transformed result. ``None`` keeps the original."""
+        """Run as an exit gate; returns the transformed result. ``None`` keeps the original."""
         transformed = await self._invoke(result)
         return result if transformed is None else transformed
 
@@ -192,7 +192,7 @@ class Gateway(Generic[_P, _R]):
         return self._fn
 
     def __repr__(self) -> str:
-        return f"Gateway({getattr(self._fn, '__name__', self._fn)!r})"
+        return f"Gate({getattr(self._fn, '__name__', self._fn)!r})"
 
 
 @overload
@@ -217,43 +217,43 @@ def wrapper(fn: Callable) -> Wrapper:
     return Wrapper(fn)
 
 
-def _gateway_args(*args: Any, **kwargs: Any) -> _GatewayArgs:
-    """Return an explicit ``(args, kwargs)`` pair for an entry gateway.
+def _gate_args(*args: Any, **kwargs: Any) -> _GateArgs:
+    """Return an explicit ``(args, kwargs)`` pair for an entry gate.
 
     Use when you need both positional and keyword args — a bare ``tuple`` is
     positional-only and a bare ``dict`` is keyword-only::
 
-        @rt.gateway
+        @rt.gate
         async def reorder(a, b):
-            return rt.gateway.args(b, a, flag=True)  # -> ((b, a), {"flag": True})
+            return rt.gate.args(b, a, flag=True)  # -> ((b, a), {"flag": True})
     """
-    return _GatewayArgs(args, kwargs)
+    return _GateArgs(args, kwargs)
 
 
 @overload
-def gateway(fn: Callable[_P, Awaitable[_R]]) -> Gateway[_P, _R]: ...
+def gate(fn: Callable[_P, Awaitable[_R]]) -> Gate[_P, _R]: ...
 
 
 @overload
-def gateway(fn: Callable[_P, _R]) -> Gateway[_P, _R]: ...
+def gate(fn: Callable[_P, _R]) -> Gate[_P, _R]: ...
 
 
 @overload
-def gateway(fn: Callable[..., Any]) -> Gateway[Any, Any]: ...
+def gate(fn: Callable[..., Any]) -> Gate[Any, Any]: ...
 
 
-def gateway(fn: Callable) -> Gateway:
-    """Decorator: turn a function into a direction-neutral :class:`Gateway`.
+def gate(fn: Callable) -> Gate:
+    """Decorator: turn a function into a direction-neutral :class:`Gate`.
 
-    ``fn`` may be ``async`` or plain ``def`` (sync gateways run inline).
-    Explicitly-typed functions resolve to ``Gateway[_P, _R]``; ``*args, **kwargs``
-    functions resolve to ``Gateway[Any, Any]`` — assignable to any typed slot.
+    ``fn`` may be ``async`` or plain ``def`` (sync gates run inline).
+    Explicitly-typed functions resolve to ``Gate[_P, _R]``; ``*args, **kwargs``
+    functions resolve to ``Gate[Any, Any]`` — assignable to any typed slot.
 
-    See :meth:`Gateway.apply_entry` for return-value conventions; use
-    :func:`gateway.args` to specify both positional and keyword args explicitly.
+    See :meth:`Gate.apply_entry` for return-value conventions; use
+    :func:`gate.args` to specify both positional and keyword args explicitly.
     """
-    return Gateway(fn)
+    return Gate(fn)
 
 
-# Expose the explicit-args helper as `gateway.args(...)`.
-gateway.args = _gateway_args
+# Expose the explicit-args helper as `gate.args(...)`.
+gate.args = _gate_args

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -1,64 +1,19 @@
-"""Unified middleware primitives shared by every entry point in the system.
+"""Unified middleware primitives for every Railtracks entry point.
 
-Two primitives wrap *any* callable (a function node, an agent, a tool, or the
-raw LLM model call):
+- :class:`Wrapper` — execution control: receives the inner callable and decides
+  whether/how/how-many-times to invoke it (retry, fallback, short-circuit, timing).
+- :class:`Gateway` — direction-neutral data transform: slot placement decides
+  when it runs. ``gateway_entry`` transforms input; ``gateway_exit`` transforms
+  output. Check-only gateways validate and raise, or return ``None`` to pass through.
 
-- :class:`Wrapper` — execution control. Receives the inner callable and the call
-  arguments and decides whether / how / how many times to invoke it (retries,
-  fallbacks, short-circuiting, timing, ...).
-- :class:`Gateway` — a one-directional data transform at a boundary. An ``entry``
-  gateway transforms the input *before* the callable runs; an ``exit`` gateway
-  transforms the output *after*. A gateway may also be check-only — validate and
-  raise (a guardrail) or return its input unchanged.
+``@wrapper`` / ``@gateway`` are optional in named
+:class:`~railtracks.middleware.MiddlewareSet` slots (the slot implies the role
+and auto-coerces raw functions); required in bare lists where the role is ambiguous.
 
-Both can be authored with decorators, but the decorator is **optional** when the
-function goes into an explicit :class:`~railtracks.middleware.MiddlewareSet` slot
-(``wrappers`` / ``inner_wrappers`` for wrappers, ``gateway_entry`` /
-``gateway_exit`` for gateways): the slot implies the role, so a raw async
-function is auto-wrapped. The decorator then serves mainly as a checker / marker,
-and is only *required* for a bare list, where the role is otherwise ambiguous::
-
-    @wrapper
-    async def retry(call, *args, **kwargs):
-        for _ in range(3):
-            try:
-                return await call(*args, **kwargs)
-            except Exception:
-                pass
-        raise RuntimeError("All retries exhausted")
-
-
-    # entry gateway: placed in `gateway_entry`, transforms input
-    @gateway
-    async def scrub(*args, **kwargs):
-        return scrub_args(args), kwargs  # MUST return (args, kwargs)
-
-
-    # exit gateway: placed in `gateway_exit`, transforms output
-    @gateway
-    async def redact(result):
-        return redact_response(result)
-
-The ``@wrapper`` / ``@gateway`` decorators are **optional** when the function
-sits in a typed slot of a :class:`~railtracks.middleware.MiddlewareSet`
-(``wrappers`` / ``inner_wrappers`` / ``gateway_entry`` / ``gateway_exit``):
-the slot implies the role, so a raw function is auto-coerced. The decorator is
-only *required* in a bare list where the role would otherwise be ambiguous.
-
-A ``Gateway`` carries **no** direction — *where you place it* (the
-``gateway_entry`` list vs the ``gateway_exit`` list of a
-:class:`~railtracks.middleware.MiddlewareSet`) decides when it runs. Write the
-function with the signature that matches the slot:
-
-- in ``gateway_entry``: ``(*args, **kwargs) -> ...`` where the return is interpreted as:
-    * ``None``                      — check-only; the call passes through unchanged
-    * a ``dict``                    — the new keyword args (no positional args)
-    * a ``tuple``                   — the new positional args (no keyword args)
-    * a ``(tuple, dict)`` 2-tuple   — the new ``(args, kwargs)`` in full
-    * ``gateway.args(*a, **k)``     — the same, stated explicitly
-  Any other (bare) value raises ``TypeError`` — wrap it (``(x,)`` for a positional
-  arg, ``gateway.args(x)`` to be explicit) so the arity is never ambiguous.
-- in ``gateway_exit``:  ``(result) -> result`` (``None`` keeps the original result)
+Entry gateway return conventions:
+``None`` → pass-through · ``tuple`` → new args · ``dict`` → new kwargs ·
+``(tuple, dict)`` → full replacement · :func:`gateway.args` → explicit form.
+Any other bare value raises ``TypeError``.
 """
 
 from __future__ import annotations
@@ -93,9 +48,7 @@ def _require_async(fn: Callable, role: str) -> None:
 
 
 class _GatewayArgs:
-    """Tagged container returned by :func:`gateway.args` to state an entry gateway's
-    new ``(args, kwargs)`` unambiguously — including multiple positional args and/or
-    keyword args, which a bare return value cannot express."""
+    """Unambiguous ``(args, kwargs)`` container returned by :func:`gateway.args`."""
 
     __slots__ = ("args", "kwargs")
 
@@ -112,13 +65,10 @@ class _GatewayArgs:
 
 
 class Wrapper(Generic[_P, _R]):
-    """Execution-control middleware.
+    """Execution-control middleware: wraps a callable to control how it is invoked.
 
-    Built from an ``async`` function ``fn(call, *args, **kwargs)`` where
-    ``call`` is the inner (already-wrapped) callable and ``*args``/``**kwargs``
-    are the arguments for the current invocation. The function is responsible
-    for invoking ``call`` — it may skip it, retry it, or wrap it in error
-    handling::
+    Built from an async call-style function ``fn(call, *args, **kwargs)`` where
+    ``call`` is the next callable in the chain::
 
         @wrapper
         async def retry(call, *args, **kwargs):
@@ -129,8 +79,7 @@ class Wrapper(Generic[_P, _R]):
                     pass
             raise RuntimeError("All retries exhausted")
 
-    ``fn`` must be ``async``: it has to ``await`` the inner ``call``.
-    Passing a plain ``def`` raises ``TypeError`` at construction time.
+    ``fn`` must be ``async``; passing a plain ``def`` raises ``TypeError``.
     """
 
     def __init__(
@@ -141,11 +90,7 @@ class Wrapper(Generic[_P, _R]):
         self._fn = fn
 
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
-        """Compose this wrapper onto ``inner``, returning a new callable.
-
-        The returned callable carries ``inner``'s parameter and return types, so
-        wrapping does not erase the signature of the function being wrapped.
-        """
+        """Compose this wrapper onto ``inner``, returning a new callable with the same signature."""
         fn = self._fn
 
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
@@ -158,18 +103,17 @@ class Wrapper(Generic[_P, _R]):
 
 
 class Gateway(Generic[_P, _R]):
-    """Direction-less data-transform middleware.
+    """Direction-neutral data-transform middleware.
 
-    Build one with :func:`gateway`; its direction is decided by the slot it is
-    placed in (``gateway_entry`` vs ``gateway_exit``)::
+    Slot placement decides direction: ``gateway_entry`` transforms input,
+    ``gateway_exit`` transforms output. The same object can serve either::
 
         @gateway
-        async def scrub(*args, **kwargs):  # used as an entry gateway
+        async def scrub(*args, **kwargs):  # entry: clean the inputs
             return (clean(args), kwargs)
 
-
         @gateway
-        async def redact(result):  # used as an exit gateway
+        async def redact(result):          # exit: clean the output
             return clean(result)
     """
 
@@ -178,10 +122,10 @@ class Gateway(Generic[_P, _R]):
         self._fn = fn
 
     async def _invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
-        """Call the underlying function, awaiting it if it is async.
+        """Call the underlying function, awaiting it if async.
 
-        A sync gateway is a quick data transform, so it is run inline (not in a
-        thread) — that keeps any ``rt.context`` writes on the current context.
+        Sync gateways run inline (not in a thread) to preserve ``rt.context``
+        writes on the current context.
         """
         if inspect.iscoroutinefunction(self._fn):
             result: _R = await self._fn(*args, **kwargs)
@@ -193,19 +137,18 @@ class Gateway(Generic[_P, _R]):
     async def apply_entry(
         self, *args: _P.args, **kwargs: _P.kwargs
     ) -> tuple[tuple, dict]:
-        """Run as an entry gateway. Returns the new ``(args, kwargs)``.
+        """Run as an entry gateway; returns the new ``(args, kwargs)``.
 
-        The return value is interpreted as:
+        Return-value conventions:
 
-        - ``None``                       — check-only; pass the call through unchanged.
-        - a ``dict``                     — new keyword args, i.e. ``((), the_dict)``.
-        - a ``tuple``                    — new positional args, i.e. ``(the_tuple, {})``.
-        - a ``(tuple, dict)`` 2-tuple    — the new ``(args, kwargs)`` in full.
-        - :func:`gateway.args(*a, **k)`  — the same, stated explicitly.
+        - ``None``                      — check-only; pass through unchanged.
+        - ``tuple``                     — new positional args: ``(the_tuple, {})``.
+        - ``dict``                      — new keyword args: ``((), the_dict)``.
+        - ``(tuple, dict)`` 2-tuple     — full ``(args, kwargs)`` replacement.
+        - :func:`gateway.args(*a, **k)` — same, stated explicitly.
 
-        Anything else (a bare value) raises ``TypeError``: there is deliberately no
-        single-value shorthand, so a returned ``dict`` is never silently unpacked as a
-        positional arg. Wrap a lone positional value as ``(x,)`` or ``gateway.args(x)``.
+        Any other bare value raises ``TypeError``. Wrap a lone positional as
+        ``(x,)`` or ``gateway.args(x)``.
         """
         result = await self._invoke(*args, **kwargs)
         if result is None:
@@ -231,22 +174,15 @@ class Gateway(Generic[_P, _R]):
         )
 
     async def apply_exit(self, result: _R) -> _R:
-        """Run as an exit gateway. Returns the (possibly transformed) result.
-
-        A check-only gateway may ``return`` nothing (``None``); the original result is
-        then passed through unchanged.
-        """
+        """Run as an exit gateway; returns the transformed result. ``None`` keeps the original."""
         transformed = await self._invoke(result)
         return result if transformed is None else transformed
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs):
-        """Invoke the underlying function directly (a raw pass-through).
+        """Call the underlying function directly, bypassing slot semantics.
 
-        Handy for reusing a generic gateway — e.g. a logger or validator — as an
-        ordinary function. This calls the wrapped function as-is and does **not** apply
-        the slot semantics; use :meth:`apply_entry` / :meth:`apply_exit` for the
-        ``(args, kwargs)`` / result interpretation the engine uses. If the underlying
-        function is ``async`` this returns a coroutine to ``await``.
+        Use :meth:`apply_entry` / :meth:`apply_exit` for the engine's interpretation.
+        Returns a coroutine if the function is ``async``.
         """
         return self._fn(*args, **kwargs)
 
@@ -273,21 +209,18 @@ def wrapper(
 def wrapper(fn: Callable) -> Wrapper:
     """Decorator: turn a call-style async function into a :class:`Wrapper`.
 
-    When the function carries explicit parameter annotations (e.g.
-    ``async def fn(call, x: int, y: int) -> int``), the returned
-    :class:`Wrapper` is parameterised with those types.  When the function
-    uses ``*args, **kwargs`` — the common pattern for generic wrappers like
-    retry or tracing — the second overload fires and returns
-    ``Wrapper[Any, Any]``, which is assignable to any typed wrapper slot.
+    Explicitly-typed functions (named ``call``, ``x``, ``y``, …) resolve to
+    ``Wrapper[_P, _R]``. ``*args, **kwargs`` functions resolve to
+    ``Wrapper[Any, Any]`` via the fallback overload — assignable to any typed slot.
     """
     return Wrapper(fn)
 
 
 def _gateway_args(*args: Any, **kwargs: Any) -> _GatewayArgs:
-    """Build the explicit ``(args, kwargs)`` an entry gateway should produce.
+    """Return an explicit ``(args, kwargs)`` pair for an entry gateway.
 
-    Use it to state both positional and keyword args at once (a returned ``tuple`` is
-    positional-only and a returned ``dict`` is keyword-only)::
+    Use when you need both positional and keyword args — a bare ``tuple`` is
+    positional-only and a bare ``dict`` is keyword-only::
 
         @rt.gateway
         async def reorder(a, b):
@@ -309,18 +242,14 @@ def gateway(fn: Callable[..., Any]) -> Gateway[Any, Any]: ...
 
 
 def gateway(fn: Callable) -> Gateway:
-    """Decorator: turn a function into a (direction-less) :class:`Gateway`.
+    """Decorator: turn a function into a direction-neutral :class:`Gateway`.
 
-    ``fn`` may be ``async`` or plain ``def`` (a sync gateway is run inline).
+    ``fn`` may be ``async`` or plain ``def`` (sync gateways run inline).
+    Explicitly-typed functions resolve to ``Gateway[_P, _R]``; ``*args, **kwargs``
+    functions resolve to ``Gateway[Any, Any]`` — assignable to any typed slot.
 
-    When the function carries explicit parameter annotations the returned
-    :class:`Gateway` is parameterised with those types.  When the function
-    uses ``*args, **kwargs`` the fallback overload fires and returns
-    ``Gateway[Any, Any]``, which is assignable to any typed gateway slot.
-
-    See :meth:`Gateway.apply_entry` for how an entry gateway's return is
-    interpreted; use :func:`gateway.args` to specify multiple positional/keyword
-    args explicitly.
+    See :meth:`Gateway.apply_entry` for return-value conventions; use
+    :func:`gateway.args` to specify both positional and keyword args explicitly.
     """
     return Gateway(fn)
 

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -112,8 +112,9 @@ class Gateway(Generic[_P, _R]):
         async def scrub(*args, **kwargs):  # entry: clean the inputs
             return (clean(args), kwargs)
 
+
         @gateway
-        async def redact(result):          # exit: clean the output
+        async def redact(result):  # exit: clean the output
             return clean(result)
     """
 

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -57,13 +57,11 @@ function with the signature that matches the slot:
 
 from __future__ import annotations
 
-import functools
 import inspect
 from typing import (
     Any,
     Awaitable,
     Callable,
-    Coroutine,
     Generic,
     ParamSpec,
     TypeVar,
@@ -119,7 +117,9 @@ class Wrapper(Generic[_P, _R]):
     loss of the run's context is not acceptable).
     """
 
-    def __init__(self, fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]) -> None:
+    def __init__(
+        self, fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]
+    ) -> None:
         self._fn = fn
 
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
@@ -136,7 +136,6 @@ class Wrapper(Generic[_P, _R]):
 
     def __repr__(self) -> str:
         return f"Wrapper({getattr(self._fn, '__name__', self._fn)!r})"
-
 
 
 class Gateway(Generic[_P, _R]):
@@ -169,10 +168,12 @@ class Gateway(Generic[_P, _R]):
             result: _R = await self._fn(*args, **kwargs)
         else:
             result: _R = self._fn(*args, **kwargs)
-        
+
         return result
 
-    async def apply_entry(self, *args: _P.args, **kwargs: _P.kwargs) -> tuple[tuple, dict]:
+    async def apply_entry(
+        self, *args: _P.args, **kwargs: _P.kwargs
+    ) -> tuple[tuple, dict]:
         """Run as an entry gateway. Returns the new ``(args, kwargs)``.
 
         The return value is interpreted as:
@@ -238,7 +239,9 @@ class Gateway(Generic[_P, _R]):
         return f"Gateway({getattr(self._fn, '__name__', self._fn)!r})"
 
 
-def wrapper(fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]) -> Wrapper[_P, _R]:
+def wrapper(
+    fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]],
+) -> Wrapper[_P, _R]:
     """Decorator: turn a call-style async function into a :class:`Wrapper`."""
     return Wrapper(fn)
 
@@ -255,13 +258,13 @@ def _gateway_args(*args: Any, **kwargs: Any) -> _GatewayArgs:
     """
     return _GatewayArgs(args, kwargs)
 
+
 @overload
 def gateway(fn: Callable[_P, Awaitable[_R]]) -> Gateway[_P, _R]: ...
 
+
 @overload
 def gateway(fn: Callable[_P, _R]) -> Gateway[_P, _R]: ...
-
-
 
 
 def gateway(fn: Callable[_P, Awaitable[_R] | _R]) -> Gateway:

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -261,6 +261,9 @@ def gateway(fn: Callable[_P, Awaitable[_R]]) -> Gateway[_P, _R]: ...
 @overload
 def gateway(fn: Callable[_P, _R]) -> Gateway[_P, _R]: ...
 
+
+
+
 def gateway(fn: Callable[_P, Awaitable[_R] | _R]) -> Gateway:
     """Decorator: turn a function into a (direction-less) :class:`Gateway`.
 

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -129,6 +129,7 @@ class Wrapper(Generic[_P, _R]):
         wrapping does not erase the signature of the function being wrapped.
         """
         decorated = self._fn(inner)
+
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             return await decorated(*args, **kwargs)
 

--- a/packages/railtracks/src/railtracks/middleware/primitives.py
+++ b/packages/railtracks/src/railtracks/middleware/primitives.py
@@ -24,8 +24,8 @@ and is only *required* for a bare list, where the role is otherwise ambiguous::
             try:
                 return await call(*args, **kwargs)
             except Exception:
-                continue
-        raise
+                pass
+        raise RuntimeError("All retries exhausted")
 
 
     # entry gateway: placed in `gateway_entry`, transforms input
@@ -38,6 +38,12 @@ and is only *required* for a bare list, where the role is otherwise ambiguous::
     @gateway
     async def redact(result):
         return redact_response(result)
+
+The ``@wrapper`` / ``@gateway`` decorators are **optional** when the function
+sits in a typed slot of a :class:`~railtracks.middleware.MiddlewareSet`
+(``wrappers`` / ``inner_wrappers`` / ``gateway_entry`` / ``gateway_exit``):
+the slot implies the role, so a raw function is auto-coerced. The decorator is
+only *required* in a bare list where the role would otherwise be ambiguous.
 
 A ``Gateway`` carries **no** direction — *where you place it* (the
 ``gateway_entry`` list vs the ``gateway_exit`` list of a
@@ -62,6 +68,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Concatenate,
     Generic,
     ParamSpec,
     TypeVar,
@@ -107,19 +114,30 @@ class _GatewayArgs:
 class Wrapper(Generic[_P, _R]):
     """Execution-control middleware.
 
-    Built from a call-style async function ``fn(call, *args, **kwargs)`` where
-    ``call`` is the inner (already-wrapped) callable. The function is responsible
+    Built from an ``async`` function ``fn(call, *args, **kwargs)`` where
+    ``call`` is the inner (already-wrapped) callable and ``*args``/``**kwargs``
+    are the arguments for the current invocation. The function is responsible
     for invoking ``call`` — it may skip it, retry it, or wrap it in error
-    handling.
+    handling::
 
-    ``fn`` must be ``async``: a wrapper has to ``await`` the inner ``call``, which a
-    plain ``def`` cannot do without running off the event loop (and the resulting
-    loss of the run's context is not acceptable).
+        @wrapper
+        async def retry(call, *args, **kwargs):
+            for _ in range(3):
+                try:
+                    return await call(*args, **kwargs)
+                except Exception:
+                    pass
+            raise RuntimeError("All retries exhausted")
+
+    ``fn`` must be ``async``: it has to ``await`` the inner ``call``.
+    Passing a plain ``def`` raises ``TypeError`` at construction time.
     """
 
     def __init__(
-        self, fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]]
+        self,
+        fn: Callable[Concatenate[Callable[_P, Awaitable[_R]], _P], Awaitable[_R]],
     ) -> None:
+        _require_async(fn, "Wrapper function")
         self._fn = fn
 
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
@@ -128,10 +146,10 @@ class Wrapper(Generic[_P, _R]):
         The returned callable carries ``inner``'s parameter and return types, so
         wrapping does not erase the signature of the function being wrapped.
         """
-        decorated = self._fn(inner)
+        fn = self._fn
 
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            return await decorated(*args, **kwargs)
+            return await fn(inner, *args, **kwargs)
 
         return wrapped
 
@@ -240,10 +258,28 @@ class Gateway(Generic[_P, _R]):
         return f"Gateway({getattr(self._fn, '__name__', self._fn)!r})"
 
 
+@overload
 def wrapper(
-    fn: Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Awaitable[_R]]],
-) -> Wrapper[_P, _R]:
-    """Decorator: turn a call-style async function into a :class:`Wrapper`."""
+    fn: Callable[Concatenate[Callable[_P, Awaitable[_R]], _P], Awaitable[_R]],
+) -> Wrapper[_P, _R]: ...
+
+
+@overload
+def wrapper(
+    fn: Callable[..., Awaitable[Any]],
+) -> Wrapper[Any, Any]: ...
+
+
+def wrapper(fn: Callable) -> Wrapper:
+    """Decorator: turn a call-style async function into a :class:`Wrapper`.
+
+    When the function carries explicit parameter annotations (e.g.
+    ``async def fn(call, x: int, y: int) -> int``), the returned
+    :class:`Wrapper` is parameterised with those types.  When the function
+    uses ``*args, **kwargs`` — the common pattern for generic wrappers like
+    retry or tracing — the second overload fires and returns
+    ``Wrapper[Any, Any]``, which is assignable to any typed wrapper slot.
+    """
     return Wrapper(fn)
 
 
@@ -268,13 +304,24 @@ def gateway(fn: Callable[_P, Awaitable[_R]]) -> Gateway[_P, _R]: ...
 def gateway(fn: Callable[_P, _R]) -> Gateway[_P, _R]: ...
 
 
-def gateway(fn: Callable[_P, Awaitable[_R] | _R]) -> Gateway:
+@overload
+def gateway(fn: Callable[..., Any]) -> Gateway[Any, Any]: ...
+
+
+def gateway(fn: Callable) -> Gateway:
     """Decorator: turn a function into a (direction-less) :class:`Gateway`.
 
     ``fn`` may be ``async`` or plain ``def`` (a sync gateway is run inline).
 
-    See :meth:`Gateway.apply_entry` for how an entry gateway's return is interpreted;
-    use :func:`gateway.args` to specify multiple positional/keyword args explicitly."""
+    When the function carries explicit parameter annotations the returned
+    :class:`Gateway` is parameterised with those types.  When the function
+    uses ``*args, **kwargs`` the fallback overload fires and returns
+    ``Gateway[Any, Any]``, which is assignable to any typed gateway slot.
+
+    See :meth:`Gateway.apply_entry` for how an entry gateway's return is
+    interpreted; use :func:`gateway.args` to specify multiple positional/keyword
+    args explicitly.
+    """
     return Gateway(fn)
 
 

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -124,10 +124,10 @@ class MiddlewareSet(Generic[_P, _R]):
     order is explicit::
 
         MiddlewareSet(
-            wrappers=[retry],          # outermost: wrap the entire call
-            gateway_entry=[scrub_pii], # transforms input before core runs
-            gateway_exit=[redact],     # transforms output after core returns
-            inner_wrappers=[cache],    # innermost: hugs the core, inside gateways
+            wrappers=[retry],  # outermost: wrap the entire call
+            gateway_entry=[scrub_pii],  # transforms input before core runs
+            gateway_exit=[redact],  # transforms output after core returns
+            inner_wrappers=[cache],  # innermost: hugs the core, inside gateways
         )
 
     Coerce from a bare list via :meth:`coerce` (``Wrapper`` → ``wrappers``,
@@ -137,7 +137,8 @@ class MiddlewareSet(Generic[_P, _R]):
     def __init__(
         self,
         wrappers: Iterable[Wrapper[_P, _R]] | None = None,
-        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]] | None = None,
+        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]]
+        | None = None,
         gateway_exit: Iterable[Gateway[[_R], _R]] | None = None,
         inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -30,7 +30,16 @@ own system middleware independently).
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Generic, Iterable, Iterator, TypeVar, ParamSpec
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    Iterable,
+    Iterator,
+    ParamSpec,
+    TypeVar,
+)
 
 from railtracks.middleware.primitives import Gateway, Wrapper
 
@@ -144,15 +153,20 @@ class MiddlewareSet(Generic[_P, _R]):
     def __init__(
         self,
         wrappers: Iterable[Wrapper[_P, _R]] | None = None,
-        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]] | None = None,
+        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]]
+        | None = None,
         gateway_exit: Iterable[Gateway[[_R], _R]] | None = None,
         inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:
-        self._outer: _LayeredList[Wrapper[_P, _R]] = _LayeredList(_coerce_wrappers(wrappers))
-        self._entry: _LayeredList[Gateway[_P, tuple[tuple, dict[str, Any]]]] = _LayeredList(
-            _coerce_gateways(gateway_entry)
+        self._outer: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
+            _coerce_wrappers(wrappers)
         )
-        self._exit: _LayeredList[Gateway[[_R], _R]] = _LayeredList(_coerce_gateways(gateway_exit))
+        self._entry: _LayeredList[Gateway[_P, tuple[tuple, dict[str, Any]]]] = (
+            _LayeredList(_coerce_gateways(gateway_entry))
+        )
+        self._exit: _LayeredList[Gateway[[_R], _R]] = _LayeredList(
+            _coerce_gateways(gateway_exit)
+        )
         self._inner: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
             _coerce_wrappers(inner_wrappers)
         )
@@ -215,7 +229,9 @@ class MiddlewareSet(Generic[_P, _R]):
     # System-middleware registration (never touches the user layer)
     # ------------------------------------------------------------------
 
-    def register_sys_gateway_entry(self, gw: Gateway[_P, tuple[tuple, dict[str, Any]]]) -> None:
+    def register_sys_gateway_entry(
+        self, gw: Gateway[_P, tuple[tuple, dict[str, Any]]]
+    ) -> None:
         """Register a framework entry gateway (runs before user entry gateways)."""
         self._entry.add_sys_before(gw)
 
@@ -272,7 +288,7 @@ class MiddlewareSet(Generic[_P, _R]):
         async def gated(*a: _P.args, **k: _P.kwargs) -> _R:
             for g in entry:
                 # no typing remedy possible here until python allows the return type to the be a paramspec
-                a, k = await g.apply_entry(*a, **k) # noqa
+                a, k = await g.apply_entry(*a, **k)  # noqa
             result = await inner(*a, **k)
             for g in exit_:
                 result = await g.apply_exit(result)

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -30,11 +30,13 @@ own system middleware independently).
 
 from __future__ import annotations
 
-from typing import Any, Awaitable, Callable, Generic, Iterable, Iterator, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Iterable, Iterator, TypeVar, ParamSpec
 
 from railtracks.middleware.primitives import Gateway, Wrapper
 
 _T = TypeVar("_T")
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 class _LayeredList(Generic[_T]):
@@ -122,7 +124,7 @@ def _coerce_gateways(items: Iterable[Any] | None) -> list[Gateway]:
     return result
 
 
-class MiddlewareSet:
+class MiddlewareSet(Generic[_P, _R]):
     """The ordered middleware attached to a single entry point.
 
     Construct with explicit bands — entry and exit gateways are **separate** lists
@@ -141,17 +143,17 @@ class MiddlewareSet:
 
     def __init__(
         self,
-        wrappers: Iterable[Wrapper] | None = None,
-        gateway_entry: Iterable[Gateway] | None = None,
-        gateway_exit: Iterable[Gateway] | None = None,
-        inner_wrappers: Iterable[Wrapper] | None = None,
+        wrappers: Iterable[Wrapper[_P, _R]] | None = None,
+        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]] | None = None,
+        gateway_exit: Iterable[Gateway[[_R], _R]] | None = None,
+        inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:
-        self._outer: _LayeredList[Wrapper] = _LayeredList(_coerce_wrappers(wrappers))
-        self._entry: _LayeredList[Gateway] = _LayeredList(
+        self._outer: _LayeredList[Wrapper[_P, _R]] = _LayeredList(_coerce_wrappers(wrappers))
+        self._entry: _LayeredList[Gateway[_P, tuple[tuple, dict[str, Any]]]] = _LayeredList(
             _coerce_gateways(gateway_entry)
         )
-        self._exit: _LayeredList[Gateway] = _LayeredList(_coerce_gateways(gateway_exit))
-        self._inner: _LayeredList[Wrapper] = _LayeredList(
+        self._exit: _LayeredList[Gateway[[_R], _R]] = _LayeredList(_coerce_gateways(gateway_exit))
+        self._inner: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
             _coerce_wrappers(inner_wrappers)
         )
 
@@ -213,19 +215,19 @@ class MiddlewareSet:
     # System-middleware registration (never touches the user layer)
     # ------------------------------------------------------------------
 
-    def register_sys_gateway_entry(self, gw: Gateway) -> None:
+    def register_sys_gateway_entry(self, gw: Gateway[_P, tuple[tuple, dict[str, Any]]]) -> None:
         """Register a framework entry gateway (runs before user entry gateways)."""
         self._entry.add_sys_before(gw)
 
-    def register_sys_gateway_exit(self, gw: Gateway) -> None:
+    def register_sys_gateway_exit(self, gw: Gateway[[_R], _R]) -> None:
         """Register a framework exit gateway (runs after user exit gateways)."""
         self._exit.add_sys_after(gw)
 
-    def register_sys_outer_wrapper(self, w: Wrapper) -> None:
+    def register_sys_outer_wrapper(self, w: Wrapper[_P, _R]) -> None:
         """Register a framework wrapper outside all user (outer) wrappers."""
         self._outer.add_sys_before(w)
 
-    def register_sys_inner_wrapper(self, w: Wrapper) -> None:
+    def register_sys_inner_wrapper(self, w: Wrapper[_P, _R]) -> None:
         """Register a framework wrapper inside all user (inner) wrappers."""
         self._inner.add_sys_after(w)
 
@@ -234,19 +236,19 @@ class MiddlewareSet:
     # ------------------------------------------------------------------
 
     @property
-    def wrappers(self) -> list[Wrapper]:
+    def wrappers(self):
         return list(self._outer)
 
     @property
-    def inner_wrappers(self) -> list[Wrapper]:
+    def inner_wrappers(self):
         return list(self._inner)
 
     @property
-    def gateway_entry(self) -> list[Gateway]:
+    def gateway_entry(self):
         return list(self._entry)
 
     @property
-    def gateway_exit(self) -> list[Gateway]:
+    def gateway_exit(self):
         return list(self._exit)
 
     # ------------------------------------------------------------------
@@ -255,13 +257,11 @@ class MiddlewareSet:
 
     async def run(
         self,
-        core: Callable[..., Awaitable[Any]],
-        args: tuple = (),
-        kwargs: dict | None = None,
-    ) -> Any:
+        core: Callable[_P, Awaitable[_R]],
+        *args: _P.args,
+        **kwargs: _P.kwargs,
+    ) -> _R:
         """Run ``core(*args, **kwargs)`` through this middleware set."""
-        kwargs = kwargs or {}
-
         entry = self._entry.ordered()
         exit_ = self._exit.ordered()
 
@@ -269,15 +269,16 @@ class MiddlewareSet:
         for w in reversed(self._inner.ordered()):
             inner = w.wrap(inner)
 
-        async def gated(*a: Any, **k: Any) -> Any:
+        async def gated(*a: _P.args, **k: _P.kwargs) -> _R:
             for g in entry:
-                a, k = await g.apply_entry(*a, **k)
+                # no typing remedy possible here until python allows the return type to the be a paramspec
+                a, k = await g.apply_entry(*a, **k) # noqa
             result = await inner(*a, **k)
             for g in exit_:
                 result = await g.apply_exit(result)
             return result
 
-        outer: Callable[..., Awaitable[Any]] = gated
+        outer = gated
         for w in reversed(self._outer.ordered()):
             outer = w.wrap(outer)
 

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -124,9 +124,9 @@ class MiddlewareChain(Generic[_P, _R]):
     order is explicit::
 
         MiddlewareChain(
-            wrappers=[retry],     # outermost: wrap the entire call
+            wrappers=[retry],  # outermost: wrap the entire call
             entry_gate=[scrub_pii],  # transforms input before core runs
-            exit_gate=[redact],      # transforms output after core returns
+            exit_gate=[redact],  # transforms output after core returns
             inner_wrappers=[cache],  # innermost: hugs the core, inside gates
         )
 
@@ -137,8 +137,7 @@ class MiddlewareChain(Generic[_P, _R]):
     def __init__(
         self,
         wrappers: Iterable[Wrapper[_P, _R]] | None = None,
-        entry_gate: Iterable[Gate[_P, tuple[tuple, dict[str, Any]]]]
-        | None = None,
+        entry_gate: Iterable[Gate[_P, tuple[tuple, dict[str, Any]]]] | None = None,
         exit_gate: Iterable[Gate[[_R], _R]] | None = None,
         inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:
@@ -160,7 +159,9 @@ class MiddlewareChain(Generic[_P, _R]):
     # ------------------------------------------------------------------
 
     @classmethod
-    def coerce(cls, value: "MiddlewareChain | Iterable[Any] | None") -> "MiddlewareChain":
+    def coerce(
+        cls, value: "MiddlewareChain | Iterable[Any] | None"
+    ) -> "MiddlewareChain":
         """Normalise input into a fresh :class:`MiddlewareChain`.
 
         - ``None``             → empty chain.

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -1,14 +1,14 @@
 """The middleware container + execution engine shared by every entry point.
 
-:class:`MiddlewareSet` bundles the middleware for one site and runs a core
+:class:`MiddlewareChain` bundles the middleware for one site and runs a core
 callable through it in band order::
 
     wrappers
-    └── gateway_entry             (transform input args)
+    └── entry_gate             (transform input args)
         └── inner_wrappers
             └── core              (node / func / model call)
         └── (unwind inner_wrappers)
-    └── gateway_exit              (transform output)
+    └── exit_gate              (transform output)
     └── (unwind wrappers)
 
 Each band is a :class:`_LayeredList` with ``sys_before → user → sys_after``
@@ -29,7 +29,7 @@ from typing import (
     TypeVar,
 )
 
-from railtracks.middleware.primitives import Gateway, Wrapper
+from railtracks.middleware.primitives import Gate, Wrapper
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
@@ -84,15 +84,15 @@ class _LayeredList(Generic[_T]):
 
 
 def _coerce_wrappers(items: Iterable[Any] | None) -> list[Wrapper]:
-    """Coerce a wrapper slot: auto-wraps raw async functions, rejects :class:`Gateway` objects."""
+    """Coerce a wrapper slot: auto-wraps raw async functions, rejects :class:`Gate` objects."""
     result: list[Wrapper] = []
     for i, item in enumerate(items or []):
         if isinstance(item, Wrapper):
             result.append(item)
-        elif isinstance(item, Gateway):
+        elif isinstance(item, Gate):
             raise TypeError(
-                f"Wrapper slot at index {i} got a Gateway: {item!r}. "
-                f"Gateways belong in gateway_entry / gateway_exit."
+                f"Wrapper slot at index {i} got a Gate: {item!r}. "
+                f"Gates belong in entry_gate / exit_gate."
             )
         else:
             # Raw async function (or anything else) -> Wrapper validates it.
@@ -100,56 +100,56 @@ def _coerce_wrappers(items: Iterable[Any] | None) -> list[Wrapper]:
     return result
 
 
-def _coerce_gateways(items: Iterable[Any] | None) -> list[Gateway]:
-    """Coerce a gateway slot: auto-wraps raw functions, rejects :class:`Wrapper` objects."""
-    result: list[Gateway] = []
+def _coerce_gates(items: Iterable[Any] | None) -> list[Gate]:
+    """Coerce a gate slot: auto-wraps raw functions, rejects :class:`Wrapper` objects."""
+    result: list[Gate] = []
     for i, item in enumerate(items or []):
-        if isinstance(item, Gateway):
+        if isinstance(item, Gate):
             result.append(item)
         elif isinstance(item, Wrapper):
             raise TypeError(
-                f"Gateway slot at index {i} got a Wrapper: {item!r}. "
+                f"Gate slot at index {i} got a Wrapper: {item!r}. "
                 f"Wrappers belong in wrappers / inner_wrappers."
             )
         else:
-            # Raw async function (or anything else) -> Gateway validates it.
-            result.append(Gateway(item))
+            # Raw async function (or anything else) -> Gate validates it.
+            result.append(Gate(item))
     return result
 
 
-class MiddlewareSet(Generic[_P, _R]):
+class MiddlewareChain(Generic[_P, _R]):
     """Ordered middleware attached to a single entry point.
 
-    Entry and exit gateways are separate constructor arguments so the execution
+    Entry and exit gates are separate constructor arguments so the execution
     order is explicit::
 
-        MiddlewareSet(
-            wrappers=[retry],  # outermost: wrap the entire call
-            gateway_entry=[scrub_pii],  # transforms input before core runs
-            gateway_exit=[redact],  # transforms output after core returns
-            inner_wrappers=[cache],  # innermost: hugs the core, inside gateways
+        MiddlewareChain(
+            wrappers=[retry],     # outermost: wrap the entire call
+            entry_gate=[scrub_pii],  # transforms input before core runs
+            exit_gate=[redact],      # transforms output after core returns
+            inner_wrappers=[cache],  # innermost: hugs the core, inside gates
         )
 
     Coerce from a bare list via :meth:`coerce` (``Wrapper`` → ``wrappers``,
-    ``Gateway`` → ``gateway_entry``).
+    ``Gate`` → ``entry_gate``).
     """
 
     def __init__(
         self,
         wrappers: Iterable[Wrapper[_P, _R]] | None = None,
-        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]]
+        entry_gate: Iterable[Gate[_P, tuple[tuple, dict[str, Any]]]]
         | None = None,
-        gateway_exit: Iterable[Gateway[[_R], _R]] | None = None,
+        exit_gate: Iterable[Gate[[_R], _R]] | None = None,
         inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:
         self._outer: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
             _coerce_wrappers(wrappers)
         )
-        self._entry: _LayeredList[Gateway[Any, Any]] = _LayeredList(
-            _coerce_gateways(gateway_entry)
+        self._entry: _LayeredList[Gate[Any, Any]] = _LayeredList(
+            _coerce_gates(entry_gate)
         )
-        self._exit: _LayeredList[Gateway[Any, Any]] = _LayeredList(
-            _coerce_gateways(gateway_exit)
+        self._exit: _LayeredList[Gate[Any, Any]] = _LayeredList(
+            _coerce_gates(exit_gate)
         )
         self._inner: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
             _coerce_wrappers(inner_wrappers)
@@ -160,45 +160,45 @@ class MiddlewareSet(Generic[_P, _R]):
     # ------------------------------------------------------------------
 
     @classmethod
-    def coerce(cls, value: "MiddlewareSet | Iterable[Any] | None") -> "MiddlewareSet":
-        """Normalise input into a fresh :class:`MiddlewareSet`.
+    def coerce(cls, value: "MiddlewareChain | Iterable[Any] | None") -> "MiddlewareChain":
+        """Normalise input into a fresh :class:`MiddlewareChain`.
 
-        - ``None``          → empty set.
-        - ``MiddlewareSet`` → fresh copy; user layers preserved, sys layers reset.
-        - ``list``          → :class:`Wrapper` items → ``wrappers``,
-          :class:`Gateway` items → ``gateway_entry``.
+        - ``None``             → empty chain.
+        - ``MiddlewareChain``  → fresh copy; user layers preserved, sys layers reset.
+        - ``list``             → :class:`Wrapper` items → ``wrappers``,
+          :class:`Gate` items → ``entry_gate``.
 
-        In a bare list ``@wrapper`` / ``@gateway`` are required — without a
+        In a bare list ``@wrapper`` / ``@gate`` are required — without a
         named slot a raw function's role is ambiguous. Use the explicit
         constructor to pass raw functions. The caller's input is never mutated.
         """
         if value is None:
             return cls()
-        if isinstance(value, MiddlewareSet):
+        if isinstance(value, MiddlewareChain):
             return value._fresh_copy()
         if isinstance(value, (list, tuple)):
             outer: list[Wrapper] = []
-            entry: list[Gateway] = []
+            entry: list[Gate] = []
             for i, item in enumerate(value):
-                if isinstance(item, Gateway):
+                if isinstance(item, Gate):
                     entry.append(item)
                 elif isinstance(item, Wrapper):
                     outer.append(item)
                 else:
                     raise TypeError(
-                        f"Middleware item at index {i} must be a Wrapper or Gateway: "
+                        f"Middleware item at index {i} must be a Wrapper or Gate: "
                         f"{item!r}. In a bare list the role is ambiguous — decorate it "
-                        f"with @wrapper or @gateway, or use the MiddlewareSet(...) "
+                        f"with @wrapper or @gate, or use the MiddlewareChain(...) "
                         f"constructor to place a raw function in an explicit slot."
                     )
-            return cls(wrappers=outer, gateway_entry=entry)
+            return cls(wrappers=outer, entry_gate=entry)
         raise TypeError(
-            f"Expected a MiddlewareSet or a list of Wrapper/Gateway, got {value!r}"
+            f"Expected a MiddlewareChain or a list of Wrapper/Gate, got {value!r}"
         )
 
-    def _fresh_copy(self) -> "MiddlewareSet":
+    def _fresh_copy(self) -> "MiddlewareChain":
         """Copy carrying user layers; system layers reset for independent reuse."""
-        new = MiddlewareSet.__new__(MiddlewareSet)
+        new = MiddlewareChain.__new__(MiddlewareChain)
         new._outer = self._outer.copy_user_only()
         new._entry = self._entry.copy_user_only()
         new._exit = self._exit.copy_user_only()
@@ -209,14 +209,14 @@ class MiddlewareSet(Generic[_P, _R]):
     # System-middleware registration (never touches the user layer)
     # ------------------------------------------------------------------
 
-    def register_sys_gateway_entry(
-        self, gw: Gateway[_P, tuple[tuple, dict[str, Any]]]
+    def register_sys_entry_gate(
+        self, gw: Gate[_P, tuple[tuple, dict[str, Any]]]
     ) -> None:
-        """Register a framework entry gateway (runs before user entry gateways)."""
+        """Register a framework entry gate (runs before user entry gates)."""
         self._entry.add_sys_before(gw)
 
-    def register_sys_gateway_exit(self, gw: Gateway[[_R], _R]) -> None:
-        """Register a framework exit gateway (runs after user exit gateways)."""
+    def register_sys_exit_gate(self, gw: Gate[[_R], _R]) -> None:
+        """Register a framework exit gate (runs after user exit gates)."""
         self._exit.add_sys_after(gw)
 
     def register_sys_outer_wrapper(self, w: Wrapper[_P, _R]) -> None:
@@ -242,13 +242,13 @@ class MiddlewareSet(Generic[_P, _R]):
         return list(self._inner)
 
     @property
-    def gateway_entry(self) -> list[Gateway[Any, Any]]:
-        """User-layer entry gateways (excludes system-registered layers)."""
+    def entry_gate(self) -> list[Gate[Any, Any]]:
+        """User-layer entry gates (excludes system-registered layers)."""
         return list(self._entry)
 
     @property
-    def gateway_exit(self) -> list[Gateway[Any, Any]]:
-        """User-layer exit gateways (excludes system-registered layers)."""
+    def exit_gate(self) -> list[Gate[Any, Any]]:
+        """User-layer exit gates (excludes system-registered layers)."""
         return list(self._exit)
 
     # ------------------------------------------------------------------
@@ -266,11 +266,11 @@ class MiddlewareSet(Generic[_P, _R]):
         Execution order (including system layers within each band):
 
         1. ``wrappers`` sys_before → user → sys_after  (outermost, entered first)
-        2. ``gateway_entry`` — transforms ``(args, kwargs)`` before the core
+        2. ``entry_gate`` — transforms ``(args, kwargs)`` before the core
         3. ``inner_wrappers`` sys_before → user → sys_after
         4. ``core``
         5. ``inner_wrappers`` unwind  (inner → outer)
-        6. ``gateway_exit`` — transforms the return value
+        6. ``exit_gate`` — transforms the return value
         7. ``wrappers`` unwind  (inner → outer, exited last)
         """
         entry = self._entry.ordered()
@@ -297,6 +297,6 @@ class MiddlewareSet(Generic[_P, _R]):
 
     def __repr__(self) -> str:
         return (
-            f"MiddlewareSet(outer={self._outer!r}, "
+            f"MiddlewareChain(outer={self._outer!r}, "
             f"entry={self._entry!r}, exit={self._exit!r}, inner={self._inner!r})"
         )

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -153,18 +153,17 @@ class MiddlewareSet(Generic[_P, _R]):
     def __init__(
         self,
         wrappers: Iterable[Wrapper[_P, _R]] | None = None,
-        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]]
-        | None = None,
+        gateway_entry: Iterable[Gateway[_P, tuple[tuple, dict[str, Any]]]] | None = None,
         gateway_exit: Iterable[Gateway[[_R], _R]] | None = None,
         inner_wrappers: Iterable[Wrapper[_P, _R]] | None = None,
     ) -> None:
         self._outer: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
             _coerce_wrappers(wrappers)
         )
-        self._entry: _LayeredList[Gateway[_P, tuple[tuple, dict[str, Any]]]] = (
-            _LayeredList(_coerce_gateways(gateway_entry))
+        self._entry: _LayeredList[Gateway[Any, Any]] = _LayeredList(
+            _coerce_gateways(gateway_entry)
         )
-        self._exit: _LayeredList[Gateway[[_R], _R]] = _LayeredList(
+        self._exit: _LayeredList[Gateway[Any, Any]] = _LayeredList(
             _coerce_gateways(gateway_exit)
         )
         self._inner: _LayeredList[Wrapper[_P, _R]] = _LayeredList(
@@ -252,19 +251,23 @@ class MiddlewareSet(Generic[_P, _R]):
     # ------------------------------------------------------------------
 
     @property
-    def wrappers(self):
+    def wrappers(self) -> list[Wrapper[_P, _R]]:
+        """User-layer outer wrappers (excludes system-registered layers)."""
         return list(self._outer)
 
     @property
-    def inner_wrappers(self):
+    def inner_wrappers(self) -> list[Wrapper[_P, _R]]:
+        """User-layer inner wrappers (excludes system-registered layers)."""
         return list(self._inner)
 
     @property
-    def gateway_entry(self):
+    def gateway_entry(self) -> list[Gateway[Any, Any]]:
+        """User-layer entry gateways (excludes system-registered layers)."""
         return list(self._entry)
 
     @property
-    def gateway_exit(self):
+    def gateway_exit(self) -> list[Gateway[Any, Any]]:
+        """User-layer exit gateways (excludes system-registered layers)."""
         return list(self._exit)
 
     # ------------------------------------------------------------------
@@ -277,7 +280,18 @@ class MiddlewareSet(Generic[_P, _R]):
         *args: _P.args,
         **kwargs: _P.kwargs,
     ) -> _R:
-        """Run ``core(*args, **kwargs)`` through this middleware set."""
+        """Thread ``core(*args, **kwargs)`` through all middleware in band order.
+
+        Execution order (including system layers within each band):
+
+        1. ``wrappers`` sys_before → user → sys_after  (outermost, entered first)
+        2. ``gateway_entry`` — transforms ``(args, kwargs)`` before the core
+        3. ``inner_wrappers`` sys_before → user → sys_after
+        4. ``core``
+        5. ``inner_wrappers`` unwind  (inner → outer)
+        6. ``gateway_exit`` — transforms the return value
+        7. ``wrappers`` unwind  (inner → outer, exited last)
+        """
         entry = self._entry.ordered()
         exit_ = self._exit.ordered()
 

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -1,31 +1,19 @@
 """The middleware container + execution engine shared by every entry point.
 
-A :class:`MiddlewareSet` bundles the middleware attached to one site and runs a
-core callable through it. The agreed structure has two fixed wrapper layers
-sandwiching a gateway band::
+:class:`MiddlewareSet` bundles the middleware for one site and runs a core
+callable through it in band order::
 
     wrappers
-    └── entry gateways            (transform input)
+    └── gateway_entry             (transform input args)
         └── inner_wrappers
             └── core              (node / func / model call)
         └── (unwind inner_wrappers)
-    └── exit gateways             (transform output)
+    └── gateway_exit              (transform output)
     └── (unwind wrappers)
 
-Each band is an internal :class:`_LayeredList` with three layers so that
-**system-provided** middleware can be registered without ever touching the
-**user-provided** list:
-
-    [sys_before]  →  [user]  →  [sys_after]
-
-- ``sys_before`` — framework middleware that runs before user middleware.
-- ``user``       — exactly what the caller passed; copied in, never mutated.
-- ``sys_after``  — framework middleware that runs after user middleware.
-
-The caller's original list is copied into the user layer, so the object they
-passed is never modified. When a ``MiddlewareSet`` is reused across nodes, each
-site gets a fresh copy whose system layers are reset (every site registers its
-own system middleware independently).
+Each band is a :class:`_LayeredList` with ``sys_before → user → sys_after``
+layers so framework middleware can be injected without touching user lists.
+The caller's list is always copied in — the original is never mutated.
 """
 
 from __future__ import annotations
@@ -51,8 +39,8 @@ _R = TypeVar("_R")
 class _LayeredList(Generic[_T]):
     """Three-layer ordered list: ``sys_before → user → sys_after``.
 
-    The public iteration interface exposes the **user** layer only; the user
-    list is copied on construction and never mutated thereafter.
+    Public iteration (``__iter__``, ``__len__``, ``__getitem__``) exposes the
+    user layer only. The user list is copied on construction and never mutated.
     """
 
     def __init__(self, user: Iterable[_T] | None = None) -> None:
@@ -96,9 +84,7 @@ class _LayeredList(Generic[_T]):
 
 
 def _coerce_wrappers(items: Iterable[Any] | None) -> list[Wrapper]:
-    """Normalise a wrapper slot. The slot already tells us the role, so a raw
-    async function is auto-wrapped — ``@wrapper`` is optional here. An already
-    built :class:`Gateway` in a wrapper slot is the one thing we reject."""
+    """Coerce a wrapper slot: auto-wraps raw async functions, rejects :class:`Gateway` objects."""
     result: list[Wrapper] = []
     for i, item in enumerate(items or []):
         if isinstance(item, Wrapper):
@@ -115,9 +101,7 @@ def _coerce_wrappers(items: Iterable[Any] | None) -> list[Wrapper]:
 
 
 def _coerce_gateways(items: Iterable[Any] | None) -> list[Gateway]:
-    """Normalise a gateway slot. The slot already tells us the role, so a raw
-    async function is auto-wrapped — ``@gateway`` is optional here. An already
-    built :class:`Wrapper` in a gateway slot is the one thing we reject."""
+    """Coerce a gateway slot: auto-wraps raw functions, rejects :class:`Wrapper` objects."""
     result: list[Gateway] = []
     for i, item in enumerate(items or []):
         if isinstance(item, Gateway):
@@ -134,20 +118,20 @@ def _coerce_gateways(items: Iterable[Any] | None) -> list[Gateway]:
 
 
 class MiddlewareSet(Generic[_P, _R]):
-    """The ordered middleware attached to a single entry point.
+    """Ordered middleware attached to a single entry point.
 
-    Construct with explicit bands — entry and exit gateways are **separate** lists
-    so the execution order is obvious at the call site::
+    Entry and exit gateways are separate constructor arguments so the execution
+    order is explicit::
 
         MiddlewareSet(
-            wrappers=[retry],  # outermost: wrap the whole call
-            gateway_entry=[scrub_pii],  # run before the core (input transforms)
-            gateway_exit=[redact],  # run after the core (output transforms)
-            inner_wrappers=[cache],  # innermost: hug the core, inside the gateways
+            wrappers=[retry],          # outermost: wrap the entire call
+            gateway_entry=[scrub_pii], # transforms input before core runs
+            gateway_exit=[redact],     # transforms output after core returns
+            inner_wrappers=[cache],    # innermost: hugs the core, inside gateways
         )
 
-    Or coerce from a bare list via :meth:`coerce` (``Wrapper`` items →
-    ``wrappers``, ``Gateway`` items → ``gateway_entry``).
+    Coerce from a bare list via :meth:`coerce` (``Wrapper`` → ``wrappers``,
+    ``Gateway`` → ``gateway_entry``).
     """
 
     def __init__(
@@ -176,20 +160,16 @@ class MiddlewareSet(Generic[_P, _R]):
 
     @classmethod
     def coerce(cls, value: "MiddlewareSet | Iterable[Any] | None") -> "MiddlewareSet":
-        """Normalise user input into a fresh ``MiddlewareSet``.
+        """Normalise input into a fresh :class:`MiddlewareSet`.
 
-        - ``None``           → empty set
-        - ``MiddlewareSet``  → fresh copy (user layers preserved, sys layers reset)
-        - ``list`` / iterable → ``Wrapper`` items go to ``wrappers``,
-          ``Gateway`` items go to ``gateway_entry`` (the common case; use the
-          explicit constructor for exit gateways)
+        - ``None``          → empty set.
+        - ``MiddlewareSet`` → fresh copy; user layers preserved, sys layers reset.
+        - ``list``          → :class:`Wrapper` items → ``wrappers``,
+          :class:`Gateway` items → ``gateway_entry``.
 
-        A bare list is the one place the ``@wrapper`` / ``@gateway`` decorator is
-        still required: with no slot to imply the role, a raw async function is
-        ambiguous. Use the explicit ``MiddlewareSet(...)`` constructor to pass
-        raw functions.
-
-        The caller's list / ``MiddlewareSet`` is never mutated.
+        In a bare list ``@wrapper`` / ``@gateway`` are required — without a
+        named slot a raw function's role is ambiguous. Use the explicit
+        constructor to pass raw functions. The caller's input is never mutated.
         """
         if value is None:
             return cls()

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -86,7 +86,7 @@ class Node(ABC, Generic[_P, _TOutput]):
 
         # ================= Checks for Creation ================
         # 1. Check if the class methods are all classmethods, else raise an exception
-        class_method_checklist = ["tool_info", "prepare_tool", "name"]
+        class_method_checklist = ["tool_info", "prepare_tool", "prepare_args", "name"]
         for method_name in class_method_checklist:
             if method_name in cls.__dict__ and callable(cls.__dict__[method_name]):
                 method = cls.__dict__[method_name]

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Any, Generic, Literal, ParamSpec, TypeVar
 
 from railtracks.llm.tools.tool import Tool
-from railtracks.middleware import MiddlewareSet
+from railtracks.middleware import MiddlewareChain
 from railtracks.validation.node_creation.validation import (
     check_classmethod,
 )
@@ -98,7 +98,7 @@ class Node(ABC, Generic[_P, _TOutput]):
     # Node-level middleware applied around `invoke` (boundary: the node's call
     # args -> the node's output). Shared class-level default is never mutated;
     # each instance takes a fresh copy in __init__.
-    frozen_middleware: MiddlewareSet = MiddlewareSet()
+    frozen_middleware: MiddlewareChain = MiddlewareChain()
 
     def __init__(
         self,

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -126,7 +126,7 @@ class Node(ABC, Generic[_P, _TOutput]):
         """
         Runs ``invoke`` through the node-level middleware (wrappers + gateways).
         """
-        return await self.middleware.run(self.invoke, args, kwargs)
+        return await self.middleware.run(self.invoke, *args, **kwargs)
 
     def __repr__(self):
         return f"{self.name()} <{hex(id(self))}>"

--- a/packages/railtracks/src/railtracks/prompts/prompt.py
+++ b/packages/railtracks/src/railtracks/prompts/prompt.py
@@ -5,7 +5,7 @@ from railtracks.context.central import get_local_config
 from railtracks.exceptions import ContextError
 from railtracks.llm import MessageHistory
 from railtracks.llm.tools.tool import Tool
-from railtracks.middleware import gateway
+from railtracks.middleware import gate
 from railtracks.utils.prompt_injection import ValueDict, inject_values
 
 
@@ -36,14 +36,14 @@ def inject_context(message_history: MessageHistory):
     return message_history
 
 
-@gateway
+@gate
 async def context_injection_gateway(
     messages: MessageHistory,
     schema: type[BaseModel] | None = None,
     tools: list[Tool] | None = None,
 ):
     """
-    Entry :class:`~railtracks.middleware.Gateway` that injects context variables
+    Entry :class:`~railtracks.middleware.Gate` that injects context variables
     into message prompts before the model call.
 
     Respects the session-level prompt_injection config flag and per-message

--- a/packages/railtracks/src/railtracks/prompts/prompt.py
+++ b/packages/railtracks/src/railtracks/prompts/prompt.py
@@ -1,6 +1,5 @@
-from typing import Any
-
 from pydantic import BaseModel
+
 import railtracks.context as context
 from railtracks.context.central import get_local_config
 from railtracks.exceptions import ContextError
@@ -52,5 +51,3 @@ async def context_injection_gateway(
     """
     inject_context(messages)
     return (messages, schema, tools), {}
-
-

--- a/packages/railtracks/src/railtracks/prompts/prompt.py
+++ b/packages/railtracks/src/railtracks/prompts/prompt.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+from pydantic import BaseModel
 import railtracks.context as context
 from railtracks.context.central import get_local_config
 from railtracks.exceptions import ContextError
 from railtracks.llm import MessageHistory
+from railtracks.llm.tools.tool import Tool
 from railtracks.middleware import gateway
 from railtracks.utils.prompt_injection import ValueDict, inject_values
 
@@ -38,9 +40,9 @@ def inject_context(message_history: MessageHistory):
 @gateway
 async def context_injection_gateway(
     messages: MessageHistory,
-    schema: Any,
-    tools: Any,
-) -> tuple[tuple, dict]:
+    schema: type[BaseModel] | None = None,
+    tools: list[Tool] | None = None,
+):
     """
     Entry :class:`~railtracks.middleware.Gateway` that injects context variables
     into message prompts before the model call.
@@ -50,3 +52,5 @@ async def context_injection_gateway(
     """
     inject_context(messages)
     return (messages, schema, tools), {}
+
+

--- a/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
@@ -105,13 +105,11 @@ class TestFunctionNodeMiddleware:
         attempt = {"count": 0}
 
         @rt.wrapper
-        def retry_once(call):
-            async def _inner(*args, **kwargs):
-                try:
-                    return await call(*args, **kwargs)
-                except ValueError:
-                    return await call(*args, **kwargs)
-            return _inner
+        async def retry_once(call, *args, **kwargs):
+            try:
+                return await call(*args, **kwargs)
+            except ValueError:
+                return await call(*args, **kwargs)
 
         @rt.function_node(middleware=MiddlewareSet(wrappers=[retry_once]))
         async def flaky() -> str:
@@ -130,10 +128,8 @@ class TestFunctionNodeMiddleware:
         """Wrapper can skip the inner call entirely and return its own result."""
 
         @rt.wrapper
-        def block(call):
-            async def _inner(*args, **kwargs):
-                return "blocked"
-            return _inner
+        async def block(call, *args, **kwargs):
+            return "blocked"
 
         @rt.function_node(middleware=MiddlewareSet(wrappers=[block]))
         async def should_not_run() -> str:
@@ -150,13 +146,11 @@ class TestFunctionNodeMiddleware:
         log = []
 
         @rt.wrapper
-        def outer_wrap(call):
-            async def _inner(*args, **kwargs):
-                log.append("outer_before")
-                result = await call(*args, **kwargs)
-                log.append("outer_after")
-                return result
-            return _inner
+        async def outer_wrap(call, *args, **kwargs):
+            log.append("outer_before")
+            result = await call(*args, **kwargs)
+            log.append("outer_after")
+            return result
 
         @rt.gateway
         def entry_gw(x: int):
@@ -164,13 +158,11 @@ class TestFunctionNodeMiddleware:
             return (x,), {}
 
         @rt.wrapper
-        def inner_wrap(call):
-            async def _inner(*args, **kwargs):
-                log.append("inner_before")
-                result = await call(*args, **kwargs)
-                log.append("inner_after")
-                return result
-            return _inner
+        async def inner_wrap(call, *args, **kwargs):
+            log.append("inner_before")
+            result = await call(*args, **kwargs)
+            log.append("inner_after")
+            return result
 
         @rt.gateway
         def exit_gw(result: int):
@@ -209,22 +201,18 @@ class TestFunctionNodeMiddleware:
         log = []
 
         @rt.wrapper
-        def first(call):
-            async def _inner(*args, **kwargs):
-                log.append("first_before")
-                result = await call(*args, **kwargs)
-                log.append("first_after")
-                return result
-            return _inner
+        async def first(call, *args, **kwargs):
+            log.append("first_before")
+            result = await call(*args, **kwargs)
+            log.append("first_after")
+            return result
 
         @rt.wrapper
-        def second(call):
-            async def _inner(*args, **kwargs):
-                log.append("second_before")
-                result = await call(*args, **kwargs)
-                log.append("second_after")
-                return result
-            return _inner
+        async def second(call, *args, **kwargs):
+            log.append("second_before")
+            result = await call(*args, **kwargs)
+            log.append("second_after")
+            return result
 
         @rt.function_node(middleware=MiddlewareSet(wrappers=[first, second]))
         def identity(x: int) -> int:
@@ -389,11 +377,9 @@ class TestAgentNodeMiddleware:
         call_count = {"n": 0}
 
         @rt.wrapper
-        def count_calls(call):
-            async def _inner(*args, **kwargs):
-                call_count["n"] += 1
-                return await call(*args, **kwargs)
-            return _inner
+        async def count_calls(call, *args, **kwargs):
+            call_count["n"] += 1
+            return await call(*args, **kwargs)
 
         agent = rt.agent_node(
             name="CountedAgent",
@@ -472,11 +458,9 @@ class TestModelMiddleware:
         invocations = {"n": 0}
 
         @rt.wrapper
-        def count_model_calls(call):
-            async def _inner(messages, schema, tools):
-                invocations["n"] += 1
-                return await call(messages, schema, tools)
-            return _inner
+        async def count_model_calls(call, *args, **kwargs):
+            invocations["n"] += 1
+            return await call(*args, **kwargs)
 
         agent = rt.agent_node(
             name="CountedModel",
@@ -558,15 +542,13 @@ class TestModelMiddleware:
         attempts = {"n": 0}
 
         @rt.wrapper
-        def retry_llm(call):
-            async def _inner(messages, schema, tools):
-                for _ in range(3):
-                    try:
-                        return await call(messages, schema, tools)
-                    except Exception:
-                        attempts["n"] += 1
-                raise LLMError(reason="exhausted", message_history=messages)
-            return _inner
+        async def retry_llm(call, *args, **kwargs):
+            for _ in range(3):
+                try:
+                    return await call(*args, **kwargs)
+                except Exception:
+                    attempts["n"] += 1
+            raise LLMError(reason="exhausted", message_history=args[0])
 
         # First call raises, second succeeds
         llm = mock_llm(

--- a/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
@@ -2,10 +2,10 @@
 Integration tests for the unified middleware system.
 
 Covers:
-  - Function node: entry/exit gateways, wrappers, ordering, guardrails
+  - Function node: entry/exit gates, wrappers, ordering, guardrails
   - Agent node: node-level middleware (around the user_input → response boundary)
-  - Model middleware: entry/exit gateways and wrappers around each raw model call
-  - MiddlewareSet mechanics: fresh-copy isolation, gateway.args(), coerce()
+  - Model middleware: entry/exit gates and wrappers around each raw model call
+  - MiddlewareChain mechanics: fresh-copy isolation, gate.args(), coerce()
   - Context injection via rt.context prompt templates
   - ModelSource factory form (model resolved fresh per call)
   - Tool calling with prepare_args (end-to-end verify of the prepare_tool→prepare_args fix)
@@ -17,7 +17,7 @@ import pytest
 import railtracks as rt
 from pydantic import BaseModel, Field
 from railtracks.llm import ToolCall
-from railtracks.middleware import MiddlewareSet
+from railtracks.middleware import MiddlewareChain
 
 
 # ---------------------------------------------------------------------------
@@ -29,14 +29,14 @@ class TestFunctionNodeMiddleware:
     """Middleware attached to function node boundaries (user args → return value)."""
 
     @pytest.mark.asyncio
-    async def test_entry_gateway_transforms_args(self):
-        """Entry gateway can rewrite positional args before the function runs."""
+    async def test_entry_gate_transforms_args(self):
+        """Entry gate can rewrite positional args before the function runs."""
 
-        @rt.gateway
+        @rt.gate
         def uppercase_in(text: str):
             return (text.upper(),), {}
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[uppercase_in]))
+        @rt.function_node(middleware=MiddlewareChain(entry_gate=[uppercase_in]))
         def echo(text: str) -> str:
             return text
 
@@ -45,14 +45,14 @@ class TestFunctionNodeMiddleware:
         assert result == "HELLO"
 
     @pytest.mark.asyncio
-    async def test_exit_gateway_transforms_output(self):
-        """Exit gateway can rewrite the return value after the function returns."""
+    async def test_exit_gate_transforms_output(self):
+        """Exit gate can rewrite the return value after the function returns."""
 
-        @rt.gateway
+        @rt.gate
         def double_out(result: int) -> int:
             return result * 2
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[double_out]))
+        @rt.function_node(middleware=MiddlewareChain(exit_gate=[double_out]))
         def add(x: int, y: int) -> int:
             return x + y
 
@@ -61,17 +61,17 @@ class TestFunctionNodeMiddleware:
         assert result == 14  # (3 + 4) * 2
 
     @pytest.mark.asyncio
-    async def test_entry_gateway_check_only_passes_through(self):
-        """A check-only entry gateway (returns None) leaves args unchanged."""
+    async def test_entry_gate_check_only_passes_through(self):
+        """A check-only entry gate (returns None) leaves args unchanged."""
 
         checked = {"called": False}
 
-        @rt.gateway
+        @rt.gate
         def just_check(x: int, y: int):
             checked["called"] = True
             # returning None = check-only; args pass through unchanged
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[just_check]))
+        @rt.function_node(middleware=MiddlewareChain(entry_gate=[just_check]))
         def add(x: int, y: int) -> int:
             return x + y
 
@@ -81,17 +81,17 @@ class TestFunctionNodeMiddleware:
         assert checked["called"]
 
     @pytest.mark.asyncio
-    async def test_entry_gateway_guardrail_raises(self):
-        """Entry gateway acting as a guardrail propagates its exception to the caller."""
+    async def test_entry_gate_guardrail_raises(self):
+        """Entry gate acting as a guardrail propagates its exception to the caller."""
 
-        @rt.gateway
+        @rt.gate
         def no_negatives(x: int, y: int):
             if x < 0 or y < 0:
                 raise ValueError("Negative numbers not allowed")
 
             return (x, y), {}
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[no_negatives]))
+        @rt.function_node(middleware=MiddlewareChain(entry_gate=[no_negatives]))
         def add(x: int, y: int) -> int:
             return x + y
 
@@ -111,7 +111,7 @@ class TestFunctionNodeMiddleware:
             except ValueError:
                 return await call(*args, **kwargs)
 
-        @rt.function_node(middleware=MiddlewareSet(wrappers=[retry_once]))
+        @rt.function_node(middleware=MiddlewareChain(wrappers=[retry_once]))
         async def flaky() -> str:
             attempt["count"] += 1
             if attempt["count"] < 2:
@@ -131,7 +131,7 @@ class TestFunctionNodeMiddleware:
         async def block(call, *args, **kwargs):
             return "blocked"
 
-        @rt.function_node(middleware=MiddlewareSet(wrappers=[block]))
+        @rt.function_node(middleware=MiddlewareChain(wrappers=[block]))
         async def should_not_run() -> str:
             raise AssertionError("core should not be called")
 
@@ -141,7 +141,7 @@ class TestFunctionNodeMiddleware:
 
     @pytest.mark.asyncio
     async def test_full_band_ordering(self):
-        """Wrappers → entry gateways → inner_wrappers → core → exit gateways → outer unwind."""
+        """Wrappers → entry gates → inner_wrappers → core → exit gates → outer unwind."""
 
         log = []
 
@@ -152,7 +152,7 @@ class TestFunctionNodeMiddleware:
             log.append("outer_after")
             return result
 
-        @rt.gateway
+        @rt.gate
         def entry_gw(x: int):
             log.append("entry")
             return (x,), {}
@@ -164,16 +164,16 @@ class TestFunctionNodeMiddleware:
             log.append("inner_after")
             return result
 
-        @rt.gateway
+        @rt.gate
         def exit_gw(result: int):
             log.append("exit")
             return result
 
-        ms = MiddlewareSet(
+        ms = MiddlewareChain(
             wrappers=[outer_wrap],
-            gateway_entry=[entry_gw],
+            entry_gate=[entry_gw],
             inner_wrappers=[inner_wrap],
-            gateway_exit=[exit_gw],
+            exit_gate=[exit_gw],
         )
 
         @rt.function_node(middleware=ms)
@@ -214,7 +214,7 @@ class TestFunctionNodeMiddleware:
             log.append("second_after")
             return result
 
-        @rt.function_node(middleware=MiddlewareSet(wrappers=[first, second]))
+        @rt.function_node(middleware=MiddlewareChain(wrappers=[first, second]))
         def identity(x: int) -> int:
             log.append("core")
             return x
@@ -230,18 +230,18 @@ class TestFunctionNodeMiddleware:
         ]
 
     @pytest.mark.asyncio
-    async def test_multiple_entry_gateways_apply_sequentially(self):
-        """Multiple entry gateways run in list order; each transforms what the previous produced."""
+    async def test_multiple_entry_gates_apply_sequentially(self):
+        """Multiple entry gates run in list order; each transforms what the previous produced."""
 
-        @rt.gateway
+        @rt.gate
         def add_one(x: int):
             return (x + 1,), {}
 
-        @rt.gateway
+        @rt.gate
         def double(x: int):
             return (x * 2,), {}
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[add_one, double]))
+        @rt.function_node(middleware=MiddlewareChain(entry_gate=[add_one, double]))
         def identity(x: int) -> int:
             return x  # receives (x+1)*2
 
@@ -250,18 +250,18 @@ class TestFunctionNodeMiddleware:
         assert result == 8
 
     @pytest.mark.asyncio
-    async def test_multiple_exit_gateways_apply_sequentially(self):
-        """Multiple exit gateways chain: first transforms, second transforms the result."""
+    async def test_multiple_exit_gates_apply_sequentially(self):
+        """Multiple exit gates chain: first transforms, second transforms the result."""
 
-        @rt.gateway
+        @rt.gate
         def add_ten(result: int) -> int:
             return result + 10
 
-        @rt.gateway
+        @rt.gate
         def negate(result: int) -> int:
             return -result
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[add_ten, negate]))
+        @rt.function_node(middleware=MiddlewareChain(exit_gate=[add_ten, negate]))
         def five() -> int:
             return 5  # → +10 = 15 → negate = -15
 
@@ -270,33 +270,33 @@ class TestFunctionNodeMiddleware:
         assert result == -15
 
     @pytest.mark.asyncio
-    async def test_gateway_args_explicit_with_kwargs(self):
-        """gateway.args() lets an entry gateway specify both positional and keyword args."""
+    async def test_gate_args_explicit_with_kwargs(self):
+        """gate.args() lets an entry gate specify both positional and keyword args."""
 
-        @rt.gateway
+        @rt.gate
         def swap_and_flag(a: int, b: int):
-            return rt.gateway.args(b, a, flag=True)
+            return rt.gate.args(b, a, flag=True)
 
         @rt.function_node(
-            middleware=MiddlewareSet(gateway_entry=[swap_and_flag])
+            middleware=MiddlewareChain(entry_gate=[swap_and_flag])
         )
         def compute(a: int, b: int, flag: bool = False) -> str:
             return f"{a}-{b}-{flag}"
 
-        result = await rt.Flow("test_gateway_args", compute).ainvoke(3, 10)  # swap → (10, 3, flag=True)
+        result = await rt.Flow("test_gate_args", compute).ainvoke(3, 10)  # swap → (10, 3, flag=True)
 
         assert result == "10-3-True"
 
     @pytest.mark.asyncio
-    async def test_async_entry_gateway(self):
-        """Entry gateways may be async; they are awaited correctly."""
+    async def test_async_entry_gate(self):
+        """Entry gates may be async; they are awaited correctly."""
 
-        @rt.gateway
+        @rt.gate
         async def async_double_input(x: int):
             await asyncio.sleep(0)
             return (x * 2,), {}
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[async_double_input]))
+        @rt.function_node(middleware=MiddlewareChain(entry_gate=[async_double_input]))
         def identity(x: int) -> int:
             return x
 
@@ -305,15 +305,15 @@ class TestFunctionNodeMiddleware:
         assert result == 10
 
     @pytest.mark.asyncio
-    async def test_async_exit_gateway(self):
-        """Exit gateways may be async; they are awaited correctly."""
+    async def test_async_exit_gate(self):
+        """Exit gates may be async; they are awaited correctly."""
 
-        @rt.gateway
+        @rt.gate
         async def async_double_output(result: int) -> int:
             await asyncio.sleep(0)
             return result * 2
 
-        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[async_double_output]))
+        @rt.function_node(middleware=MiddlewareChain(exit_gate=[async_double_output]))
         def three() -> int:
             return 3
 
@@ -323,15 +323,15 @@ class TestFunctionNodeMiddleware:
 
     @pytest.mark.asyncio
     async def test_middleware_set_coerce_from_bare_list(self):
-        """MiddlewareSet.coerce() routes Gateways→gateway_entry and Wrappers→wrappers."""
+        """MiddlewareChain.coerce() routes Gates→entry_gate and Wrappers→wrappers."""
 
-        # coerce puts Gateways into gateway_entry (not gateway_exit), so the
-        # gateway must have an entry signature: receives the function's input args.
-        @rt.gateway
+        # coerce puts Gates into entry_gate (not exit_gate), so the
+        # gate must have an entry signature: receives the function's input args.
+        @rt.gate
         def double_x(x: int):
             return (x * 2,), {}
 
-        @rt.function_node(middleware=MiddlewareSet.coerce([double_x]))
+        @rt.function_node(middleware=MiddlewareChain.coerce([double_x]))
         def identity(x: int) -> int:
             return x
 
@@ -349,12 +349,12 @@ class TestAgentNodeMiddleware:
     """Middleware at the agent node boundary (user_input → StringResponse/StructuredResponse)."""
 
     @pytest.mark.asyncio
-    async def test_node_level_exit_gateway_fires_after_response(self, mock_llm):
-        """Node-level exit gateway is called after the full agent response is ready."""
+    async def test_node_level_exit_gate_fires_after_response(self, mock_llm):
+        """Node-level exit gate is called after the full agent response is ready."""
 
         side_effects = {"called": False}
 
-        @rt.gateway
+        @rt.gate
         def mark_called(response):
             side_effects["called"] = True
             # None = check-only, pass response through unchanged
@@ -362,7 +362,7 @@ class TestAgentNodeMiddleware:
         agent = rt.agent_node(
             name="ExitGWAgent",
             llm=mock_llm(custom_response="hello"),
-            middleware=MiddlewareSet(gateway_exit=[mark_called]),
+            middleware=MiddlewareChain(exit_gate=[mark_called]),
         )
 
         result = await rt.Flow("ExitGWAgent", agent).ainvoke("hi")
@@ -384,7 +384,7 @@ class TestAgentNodeMiddleware:
         agent = rt.agent_node(
             name="CountedAgent",
             llm=mock_llm(custom_response="done"),
-            middleware=MiddlewareSet(wrappers=[count_calls]),
+            middleware=MiddlewareChain(wrappers=[count_calls]),
         )
 
         await rt.Flow("CountedAgent", agent).ainvoke("run once")
@@ -393,11 +393,11 @@ class TestAgentNodeMiddleware:
 
     @pytest.mark.asyncio
     async def test_node_level_guardrail_blocks_call(self, mock_llm):
-        """Node-level entry gateway raises before the LLM is ever called."""
+        """Node-level entry gate raises before the LLM is ever called."""
 
         llm_called = {"value": False}
 
-        @rt.gateway
+        @rt.gate
         def block_all(user_input):
             raise PermissionError("Access denied")
 
@@ -409,7 +409,7 @@ class TestAgentNodeMiddleware:
         agent = rt.agent_node(
             name="BlockedAgent",
             llm=mock_llm(custom_response="should not appear"),
-            middleware=MiddlewareSet(gateway_entry=[block_all]),
+            middleware=MiddlewareChain(entry_gate=[block_all]),
         )
 
         with pytest.raises(PermissionError, match="Access denied"):
@@ -418,15 +418,15 @@ class TestAgentNodeMiddleware:
         assert not llm_called["value"]
 
     @pytest.mark.asyncio
-    async def test_structured_output_agent_with_exit_gateway(self, mock_llm):
-        """Exit gateway receives the StructuredResponse and can inspect it."""
+    async def test_structured_output_agent_with_exit_gate(self, mock_llm):
+        """Exit gate receives the StructuredResponse and can inspect it."""
 
         class Answer(BaseModel):
             value: int = Field(description="The answer")
 
         captured = {}
 
-        @rt.gateway
+        @rt.gate
         def capture_response(response):
             captured["response"] = response
 
@@ -434,7 +434,7 @@ class TestAgentNodeMiddleware:
             name="StructuredAgent",
             llm=mock_llm(custom_response='{"value": 42}'),
             output_schema=Answer,
-            middleware=MiddlewareSet(gateway_exit=[capture_response]),
+            middleware=MiddlewareChain(exit_gate=[capture_response]),
         )
 
         result = await rt.Flow("StructuredAgent", agent).ainvoke("what is the answer?")
@@ -465,7 +465,7 @@ class TestModelMiddleware:
         agent = rt.agent_node(
             name="CountedModel",
             llm=mock_llm(custom_response="reply"),
-            model_middleware=MiddlewareSet(wrappers=[count_model_calls]),
+            model_middleware=MiddlewareChain(wrappers=[count_model_calls]),
         )
 
         await rt.Flow("CountedModel", agent).ainvoke("hello")
@@ -473,12 +473,12 @@ class TestModelMiddleware:
         assert invocations["n"] == 1
 
     @pytest.mark.asyncio
-    async def test_model_middleware_entry_gateway_can_inspect_messages(self, mock_llm):
-        """Model-level entry gateway sees the full MessageHistory before the model call."""
+    async def test_model_middleware_entry_gate_can_inspect_messages(self, mock_llm):
+        """Model-level entry gate sees the full MessageHistory before the model call."""
 
         seen_roles = []
 
-        @rt.gateway
+        @rt.gate
         async def capture_roles(messages, schema, tools):
             for m in messages:
                 seen_roles.append(m.role)
@@ -488,7 +488,7 @@ class TestModelMiddleware:
             name="RoleCapture",
             llm=mock_llm(custom_response="ok"),
             system_message="You are a helper.",
-            model_middleware=MiddlewareSet(gateway_entry=[capture_roles]),
+            model_middleware=MiddlewareChain(entry_gate=[capture_roles]),
         )
 
         await rt.Flow("RoleCapture", agent).ainvoke("question")
@@ -497,12 +497,12 @@ class TestModelMiddleware:
         assert "user" in seen_roles
 
     @pytest.mark.asyncio
-    async def test_model_middleware_entry_gateway_can_modify_messages(self, mock_llm):
-        """Model-level entry gateway can inject or rewrite messages."""
+    async def test_model_middleware_entry_gate_can_modify_messages(self, mock_llm):
+        """Model-level entry gate can inject or rewrite messages."""
 
         received_content = []
 
-        @rt.gateway
+        @rt.gate
         async def inject_header(messages, schema, tools):
             from railtracks.llm.message import UserMessage
             from railtracks.llm.history import MessageHistory
@@ -511,7 +511,7 @@ class TestModelMiddleware:
             new_messages.insert(0, UserMessage("[INJECTED]"))
             return (new_messages, schema, tools), {}
 
-        @rt.gateway
+        @rt.gate
         async def capture_first_message(messages, schema, tools):
             received_content.append(messages[0].content)
             # check-only after capture
@@ -519,8 +519,8 @@ class TestModelMiddleware:
         agent = rt.agent_node(
             name="InjectionAgent",
             llm=mock_llm(custom_response="ok"),
-            model_middleware=MiddlewareSet(
-                gateway_entry=[inject_header, capture_first_message]
+            model_middleware=MiddlewareChain(
+                entry_gate=[inject_header, capture_first_message]
             ),
         )
 
@@ -559,7 +559,7 @@ class TestModelMiddleware:
         agent = rt.agent_node(
             name="RetryAgent",
             llm=llm,
-            model_middleware=MiddlewareSet(wrappers=[retry_llm]),
+            model_middleware=MiddlewareChain(wrappers=[retry_llm]),
         )
 
         result = await rt.Flow("RetryAgent", agent).ainvoke("try this")
@@ -569,35 +569,35 @@ class TestModelMiddleware:
 
     @pytest.mark.asyncio
     async def test_model_middleware_independent_per_agent_node(self, mock_llm):
-        """Each agent node gets its own copy of model_middleware; sys gateways don't cross-contaminate."""
+        """Each agent node gets its own copy of model_middleware; sys gates don't cross-contaminate."""
 
-        gateway_a_calls = {"n": 0}
-        gateway_b_calls = {"n": 0}
+        gate_a_calls = {"n": 0}
+        gate_b_calls = {"n": 0}
 
-        @rt.gateway
+        @rt.gate
         async def gw_a(messages, schema, tools):
-            gateway_a_calls["n"] += 1
+            gate_a_calls["n"] += 1
 
-        @rt.gateway
+        @rt.gate
         async def gw_b(messages, schema, tools):
-            gateway_b_calls["n"] += 1
+            gate_b_calls["n"] += 1
 
         agent_a = rt.agent_node(
             "AgentA",
             llm=mock_llm(custom_response="a"),
-            model_middleware=MiddlewareSet(gateway_entry=[gw_a]),
+            model_middleware=MiddlewareChain(entry_gate=[gw_a]),
         )
         agent_b = rt.agent_node(
             "AgentB",
             llm=mock_llm(custom_response="b"),
-            model_middleware=MiddlewareSet(gateway_entry=[gw_b]),
+            model_middleware=MiddlewareChain(entry_gate=[gw_b]),
         )
 
         await rt.Flow("AgentA", agent_a).ainvoke("hello")
         await rt.Flow("AgentB", agent_b).ainvoke("hello")
 
-        assert gateway_a_calls["n"] == 1
-        assert gateway_b_calls["n"] == 1
+        assert gate_a_calls["n"] == 1
+        assert gate_b_calls["n"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -614,7 +614,7 @@ class TestContextInjection:
 
         injected_system_content = []
 
-        @rt.gateway
+        @rt.gate
         async def capture_system(messages, schema, tools):
             for m in messages:
                 if m.role == "system":
@@ -624,7 +624,7 @@ class TestContextInjection:
             name="TemplateAgent",
             llm=mock_llm(custom_response="done"),
             system_message="You assist {username}.",
-            model_middleware=MiddlewareSet(gateway_entry=[capture_system]),
+            model_middleware=MiddlewareChain(entry_gate=[capture_system]),
         )
 
         await rt.Flow("TemplateAgent", agent, context={"username": "Alice"}).ainvoke("help me")
@@ -637,7 +637,7 @@ class TestContextInjection:
 
         injected_system_content = []
 
-        @rt.gateway
+        @rt.gate
         async def capture_system(messages, schema, tools):
             for m in messages:
                 if m.role == "system":
@@ -647,7 +647,7 @@ class TestContextInjection:
             name="NoInjectionAgent",
             llm=mock_llm(custom_response="done"),
             system_message="You assist {username}.",
-            model_middleware=MiddlewareSet(gateway_entry=[capture_system]),
+            model_middleware=MiddlewareChain(entry_gate=[capture_system]),
             context_injection=False,
         )
 
@@ -792,11 +792,11 @@ class TestToolCallingWithPrepareArgs:
     ):
         """Middleware on a function node tool fires when the tool is called by an agent."""
 
-        gateway_fired = {"value": False}
+        gate_fired = {"value": False}
 
-        @rt.gateway
+        @rt.gate
         def mark_fired(n: int):
-            gateway_fired["value"] = True
+            gate_fired["value"] = True
 
         def increment(n: int) -> int:
             """Increments a number.
@@ -808,7 +808,7 @@ class TestToolCallingWithPrepareArgs:
             return n + 1
 
         tool = rt.function_node(
-            increment, middleware=MiddlewareSet(gateway_entry=[mark_fired])
+            increment, middleware=MiddlewareChain(entry_gate=[mark_fired])
         )
 
         llm = mock_llm(
@@ -824,22 +824,22 @@ class TestToolCallingWithPrepareArgs:
 
         result = await rt.Flow("ToolWithMiddlewareAgent", agent).ainvoke("increment 9")
 
-        assert gateway_fired["value"]
+        assert gate_fired["value"]
         assert "10" in result.content
 
 
 # ---------------------------------------------------------------------------
-# TestMiddlewareSetIsolation
+# TestMiddlewareChainIsolation
 # ---------------------------------------------------------------------------
 
 
-class TestMiddlewareSetIsolation:
-    """MiddlewareSet fresh-copy semantics: sharing a set across nodes is safe."""
+class TestMiddlewareChainIsolation:
+    """MiddlewareChain fresh-copy semantics: sharing a set across nodes is safe."""
 
     def test_shared_middleware_set_not_mutated(self, mock_llm):
-        """Two nodes built from the same MiddlewareSet get independent copies."""
+        """Two nodes built from the same MiddlewareChain get independent copies."""
 
-        shared = MiddlewareSet()
+        shared = MiddlewareChain()
 
         node_a = rt.agent_node("IsoA", llm=mock_llm(), middleware=shared)
         node_b = rt.agent_node("IsoB", llm=mock_llm(), middleware=shared)
@@ -858,17 +858,17 @@ class TestMiddlewareSetIsolation:
         assert instance_a.middleware is not agent_cls.frozen_middleware
 
     @pytest.mark.asyncio
-    async def test_sys_gateway_registered_once_per_node(self, mock_llm):
-        """System-registered gateways (e.g. context injection) do not accumulate across builds."""
+    async def test_sys_gate_registered_once_per_node(self, mock_llm):
+        """System-registered gates (e.g. context injection) do not accumulate across builds."""
 
         call_count = {"n": 0}
 
-        @rt.gateway
+        @rt.gate
         async def counting_gw(messages, schema, tools):
             call_count["n"] += 1
 
         # Build the same agent multiple times with the same model_middleware
-        ms = MiddlewareSet(gateway_entry=[counting_gw])
+        ms = MiddlewareChain(entry_gate=[counting_gw])
 
         for _ in range(3):
             agent = rt.agent_node(

--- a/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middleware/test_middleware_integration.py
@@ -1,0 +1,900 @@
+"""
+Integration tests for the unified middleware system.
+
+Covers:
+  - Function node: entry/exit gateways, wrappers, ordering, guardrails
+  - Agent node: node-level middleware (around the user_input → response boundary)
+  - Model middleware: entry/exit gateways and wrappers around each raw model call
+  - MiddlewareSet mechanics: fresh-copy isolation, gateway.args(), coerce()
+  - Context injection via rt.context prompt templates
+  - ModelSource factory form (model resolved fresh per call)
+  - Tool calling with prepare_args (end-to-end verify of the prepare_tool→prepare_args fix)
+"""
+
+import asyncio
+
+import pytest
+import railtracks as rt
+from pydantic import BaseModel, Field
+from railtracks.llm import ToolCall
+from railtracks.middleware import MiddlewareSet
+
+
+# ---------------------------------------------------------------------------
+# TestFunctionNodeMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionNodeMiddleware:
+    """Middleware attached to function node boundaries (user args → return value)."""
+
+    @pytest.mark.asyncio
+    async def test_entry_gateway_transforms_args(self):
+        """Entry gateway can rewrite positional args before the function runs."""
+
+        @rt.gateway
+        def uppercase_in(text: str):
+            return (text.upper(),), {}
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[uppercase_in]))
+        def echo(text: str) -> str:
+            return text
+
+        result = await rt.Flow("test_echo", echo).ainvoke("hello")
+
+        assert result == "HELLO"
+
+    @pytest.mark.asyncio
+    async def test_exit_gateway_transforms_output(self):
+        """Exit gateway can rewrite the return value after the function returns."""
+
+        @rt.gateway
+        def double_out(result: int) -> int:
+            return result * 2
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[double_out]))
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await rt.Flow("test_add", add).ainvoke(3, 4)
+
+        assert result == 14  # (3 + 4) * 2
+
+    @pytest.mark.asyncio
+    async def test_entry_gateway_check_only_passes_through(self):
+        """A check-only entry gateway (returns None) leaves args unchanged."""
+
+        checked = {"called": False}
+
+        @rt.gateway
+        def just_check(x: int, y: int):
+            checked["called"] = True
+            # returning None = check-only; args pass through unchanged
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[just_check]))
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        result = await rt.Flow("test_add_check", add).ainvoke(3, 4)
+
+        assert result == 7
+        assert checked["called"]
+
+    @pytest.mark.asyncio
+    async def test_entry_gateway_guardrail_raises(self):
+        """Entry gateway acting as a guardrail propagates its exception to the caller."""
+
+        @rt.gateway
+        def no_negatives(x: int, y: int):
+            if x < 0 or y < 0:
+                raise ValueError("Negative numbers not allowed")
+
+            return (x, y), {}
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[no_negatives]))
+        def add(x: int, y: int) -> int:
+            return x + y
+
+        with pytest.raises(ValueError, match="Negative"):
+            await rt.Flow("test_add_guardrail", add).ainvoke(-1, 5)
+
+    @pytest.mark.asyncio
+    async def test_wrapper_retries_on_failure(self):
+        """Wrapper can catch exceptions and retry the inner call."""
+
+        attempt = {"count": 0}
+
+        @rt.wrapper
+        def retry_once(call):
+            async def _inner(*args, **kwargs):
+                try:
+                    return await call(*args, **kwargs)
+                except ValueError:
+                    return await call(*args, **kwargs)
+            return _inner
+
+        @rt.function_node(middleware=MiddlewareSet(wrappers=[retry_once]))
+        async def flaky() -> str:
+            attempt["count"] += 1
+            if attempt["count"] < 2:
+                raise ValueError("not ready")
+            return "ok"
+
+        result = await rt.Flow("test_flaky", flaky).ainvoke()
+
+        assert result == "ok"
+        assert attempt["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_wrapper_short_circuits(self):
+        """Wrapper can skip the inner call entirely and return its own result."""
+
+        @rt.wrapper
+        def block(call):
+            async def _inner(*args, **kwargs):
+                return "blocked"
+            return _inner
+
+        @rt.function_node(middleware=MiddlewareSet(wrappers=[block]))
+        async def should_not_run() -> str:
+            raise AssertionError("core should not be called")
+
+        result = await rt.Flow("test_block", should_not_run).ainvoke()
+
+        assert result == "blocked"
+
+    @pytest.mark.asyncio
+    async def test_full_band_ordering(self):
+        """Wrappers → entry gateways → inner_wrappers → core → exit gateways → outer unwind."""
+
+        log = []
+
+        @rt.wrapper
+        def outer_wrap(call):
+            async def _inner(*args, **kwargs):
+                log.append("outer_before")
+                result = await call(*args, **kwargs)
+                log.append("outer_after")
+                return result
+            return _inner
+
+        @rt.gateway
+        def entry_gw(x: int):
+            log.append("entry")
+            return (x,), {}
+
+        @rt.wrapper
+        def inner_wrap(call):
+            async def _inner(*args, **kwargs):
+                log.append("inner_before")
+                result = await call(*args, **kwargs)
+                log.append("inner_after")
+                return result
+            return _inner
+
+        @rt.gateway
+        def exit_gw(result: int):
+            log.append("exit")
+            return result
+
+        ms = MiddlewareSet(
+            wrappers=[outer_wrap],
+            gateway_entry=[entry_gw],
+            inner_wrappers=[inner_wrap],
+            gateway_exit=[exit_gw],
+        )
+
+        @rt.function_node(middleware=ms)
+        def core(x: int) -> int:
+            log.append("core")
+            return x + 1
+
+        result = await rt.Flow("test_band_order", core).ainvoke(5)
+
+        assert result == 6
+        assert log == [
+            "outer_before",
+            "entry",
+            "inner_before",
+            "core",
+            "inner_after",
+            "exit",
+            "outer_after",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_wrappers_outer_to_inner_order(self):
+        """First wrapper in the list is outermost; list order = outer-to-inner."""
+
+        log = []
+
+        @rt.wrapper
+        def first(call):
+            async def _inner(*args, **kwargs):
+                log.append("first_before")
+                result = await call(*args, **kwargs)
+                log.append("first_after")
+                return result
+            return _inner
+
+        @rt.wrapper
+        def second(call):
+            async def _inner(*args, **kwargs):
+                log.append("second_before")
+                result = await call(*args, **kwargs)
+                log.append("second_after")
+                return result
+            return _inner
+
+        @rt.function_node(middleware=MiddlewareSet(wrappers=[first, second]))
+        def identity(x: int) -> int:
+            log.append("core")
+            return x
+
+        await rt.Flow("test_wrapper_order", identity).ainvoke(0)
+
+        assert log == [
+            "first_before",
+            "second_before",
+            "core",
+            "second_after",
+            "first_after",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_multiple_entry_gateways_apply_sequentially(self):
+        """Multiple entry gateways run in list order; each transforms what the previous produced."""
+
+        @rt.gateway
+        def add_one(x: int):
+            return (x + 1,), {}
+
+        @rt.gateway
+        def double(x: int):
+            return (x * 2,), {}
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[add_one, double]))
+        def identity(x: int) -> int:
+            return x  # receives (x+1)*2
+
+        result = await rt.Flow("test_entry_gw_chain", identity).ainvoke(3)  # (3+1)*2 = 8
+
+        assert result == 8
+
+    @pytest.mark.asyncio
+    async def test_multiple_exit_gateways_apply_sequentially(self):
+        """Multiple exit gateways chain: first transforms, second transforms the result."""
+
+        @rt.gateway
+        def add_ten(result: int) -> int:
+            return result + 10
+
+        @rt.gateway
+        def negate(result: int) -> int:
+            return -result
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[add_ten, negate]))
+        def five() -> int:
+            return 5  # → +10 = 15 → negate = -15
+
+        result = await rt.Flow("test_exit_gw_chain", five).ainvoke()
+
+        assert result == -15
+
+    @pytest.mark.asyncio
+    async def test_gateway_args_explicit_with_kwargs(self):
+        """gateway.args() lets an entry gateway specify both positional and keyword args."""
+
+        @rt.gateway
+        def swap_and_flag(a: int, b: int):
+            return rt.gateway.args(b, a, flag=True)
+
+        @rt.function_node(
+            middleware=MiddlewareSet(gateway_entry=[swap_and_flag])
+        )
+        def compute(a: int, b: int, flag: bool = False) -> str:
+            return f"{a}-{b}-{flag}"
+
+        result = await rt.Flow("test_gateway_args", compute).ainvoke(3, 10)  # swap → (10, 3, flag=True)
+
+        assert result == "10-3-True"
+
+    @pytest.mark.asyncio
+    async def test_async_entry_gateway(self):
+        """Entry gateways may be async; they are awaited correctly."""
+
+        @rt.gateway
+        async def async_double_input(x: int):
+            await asyncio.sleep(0)
+            return (x * 2,), {}
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_entry=[async_double_input]))
+        def identity(x: int) -> int:
+            return x
+
+        result = await rt.Flow("test_async_entry", identity).ainvoke(5)
+
+        assert result == 10
+
+    @pytest.mark.asyncio
+    async def test_async_exit_gateway(self):
+        """Exit gateways may be async; they are awaited correctly."""
+
+        @rt.gateway
+        async def async_double_output(result: int) -> int:
+            await asyncio.sleep(0)
+            return result * 2
+
+        @rt.function_node(middleware=MiddlewareSet(gateway_exit=[async_double_output]))
+        def three() -> int:
+            return 3
+
+        result = await rt.Flow("test_async_exit", three).ainvoke()
+
+        assert result == 6
+
+    @pytest.mark.asyncio
+    async def test_middleware_set_coerce_from_bare_list(self):
+        """MiddlewareSet.coerce() routes Gateways→gateway_entry and Wrappers→wrappers."""
+
+        # coerce puts Gateways into gateway_entry (not gateway_exit), so the
+        # gateway must have an entry signature: receives the function's input args.
+        @rt.gateway
+        def double_x(x: int):
+            return (x * 2,), {}
+
+        @rt.function_node(middleware=MiddlewareSet.coerce([double_x]))
+        def identity(x: int) -> int:
+            return x
+
+        result = await rt.Flow("test_coerce", identity).ainvoke(7)
+
+        assert result == 14
+
+
+# ---------------------------------------------------------------------------
+# TestAgentNodeMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestAgentNodeMiddleware:
+    """Middleware at the agent node boundary (user_input → StringResponse/StructuredResponse)."""
+
+    @pytest.mark.asyncio
+    async def test_node_level_exit_gateway_fires_after_response(self, mock_llm):
+        """Node-level exit gateway is called after the full agent response is ready."""
+
+        side_effects = {"called": False}
+
+        @rt.gateway
+        def mark_called(response):
+            side_effects["called"] = True
+            # None = check-only, pass response through unchanged
+
+        agent = rt.agent_node(
+            name="ExitGWAgent",
+            llm=mock_llm(custom_response="hello"),
+            middleware=MiddlewareSet(gateway_exit=[mark_called]),
+        )
+
+        result = await rt.Flow("ExitGWAgent", agent).ainvoke("hi")
+
+        assert side_effects["called"]
+        assert "hello" in result.content
+
+    @pytest.mark.asyncio
+    async def test_node_level_wrapper_around_agent(self, mock_llm):
+        """Node-level wrapper wraps the entire agent invocation."""
+
+        call_count = {"n": 0}
+
+        @rt.wrapper
+        def count_calls(call):
+            async def _inner(*args, **kwargs):
+                call_count["n"] += 1
+                return await call(*args, **kwargs)
+            return _inner
+
+        agent = rt.agent_node(
+            name="CountedAgent",
+            llm=mock_llm(custom_response="done"),
+            middleware=MiddlewareSet(wrappers=[count_calls]),
+        )
+
+        await rt.Flow("CountedAgent", agent).ainvoke("run once")
+
+        assert call_count["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_node_level_guardrail_blocks_call(self, mock_llm):
+        """Node-level entry gateway raises before the LLM is ever called."""
+
+        llm_called = {"value": False}
+
+        @rt.gateway
+        def block_all(user_input):
+            raise PermissionError("Access denied")
+
+        class TrackingLLM(type(mock_llm())):
+            def _chat(self, messages, **kwargs):
+                llm_called["value"] = True
+                return super()._chat(messages, **kwargs)
+
+        agent = rt.agent_node(
+            name="BlockedAgent",
+            llm=mock_llm(custom_response="should not appear"),
+            middleware=MiddlewareSet(gateway_entry=[block_all]),
+        )
+
+        with pytest.raises(PermissionError, match="Access denied"):
+            await rt.Flow("BlockedAgent", agent).ainvoke("attempt this")
+
+        assert not llm_called["value"]
+
+    @pytest.mark.asyncio
+    async def test_structured_output_agent_with_exit_gateway(self, mock_llm):
+        """Exit gateway receives the StructuredResponse and can inspect it."""
+
+        class Answer(BaseModel):
+            value: int = Field(description="The answer")
+
+        captured = {}
+
+        @rt.gateway
+        def capture_response(response):
+            captured["response"] = response
+
+        agent = rt.agent_node(
+            name="StructuredAgent",
+            llm=mock_llm(custom_response='{"value": 42}'),
+            output_schema=Answer,
+            middleware=MiddlewareSet(gateway_exit=[capture_response]),
+        )
+
+        result = await rt.Flow("StructuredAgent", agent).ainvoke("what is the answer?")
+
+        assert result.structured.value == 42
+        assert captured["response"] is result
+
+
+# ---------------------------------------------------------------------------
+# TestModelMiddleware
+# ---------------------------------------------------------------------------
+
+
+class TestModelMiddleware:
+    """Middleware around each raw model call (messages/schema/tools → Response)."""
+
+    @pytest.mark.asyncio
+    async def test_model_middleware_wrapper_invoked_per_llm_call(self, mock_llm):
+        """A model_middleware wrapper runs once per raw model invocation."""
+
+        invocations = {"n": 0}
+
+        @rt.wrapper
+        def count_model_calls(call):
+            async def _inner(messages, schema, tools):
+                invocations["n"] += 1
+                return await call(messages, schema, tools)
+            return _inner
+
+        agent = rt.agent_node(
+            name="CountedModel",
+            llm=mock_llm(custom_response="reply"),
+            model_middleware=MiddlewareSet(wrappers=[count_model_calls]),
+        )
+
+        await rt.Flow("CountedModel", agent).ainvoke("hello")
+
+        assert invocations["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_model_middleware_entry_gateway_can_inspect_messages(self, mock_llm):
+        """Model-level entry gateway sees the full MessageHistory before the model call."""
+
+        seen_roles = []
+
+        @rt.gateway
+        async def capture_roles(messages, schema, tools):
+            for m in messages:
+                seen_roles.append(m.role)
+            # None = check-only
+
+        agent = rt.agent_node(
+            name="RoleCapture",
+            llm=mock_llm(custom_response="ok"),
+            system_message="You are a helper.",
+            model_middleware=MiddlewareSet(gateway_entry=[capture_roles]),
+        )
+
+        await rt.Flow("RoleCapture", agent).ainvoke("question")
+
+        assert "system" in seen_roles
+        assert "user" in seen_roles
+
+    @pytest.mark.asyncio
+    async def test_model_middleware_entry_gateway_can_modify_messages(self, mock_llm):
+        """Model-level entry gateway can inject or rewrite messages."""
+
+        received_content = []
+
+        @rt.gateway
+        async def inject_header(messages, schema, tools):
+            from railtracks.llm.message import UserMessage
+            from railtracks.llm.history import MessageHistory
+
+            new_messages = MessageHistory(list(messages))
+            new_messages.insert(0, UserMessage("[INJECTED]"))
+            return (new_messages, schema, tools), {}
+
+        @rt.gateway
+        async def capture_first_message(messages, schema, tools):
+            received_content.append(messages[0].content)
+            # check-only after capture
+
+        agent = rt.agent_node(
+            name="InjectionAgent",
+            llm=mock_llm(custom_response="ok"),
+            model_middleware=MiddlewareSet(
+                gateway_entry=[inject_header, capture_first_message]
+            ),
+        )
+
+        await rt.Flow("InjectionAgent", agent).ainvoke("actual question")
+
+        assert received_content[0] == "[INJECTED]"
+
+    @pytest.mark.asyncio
+    async def test_model_middleware_wrapper_can_retry_on_llm_error(self, mock_llm):
+        """Model-level wrapper can catch model errors and retry.
+
+        model_middleware wraps _core_llm_call directly, so the wrapper sees the
+        raw Exception from the model — LLMError wrapping happens one layer above
+        in llm_invoke_factory after the middleware stack unwinds.
+        """
+
+        from railtracks.exceptions.errors import LLMError
+
+        attempts = {"n": 0}
+
+        @rt.wrapper
+        def retry_llm(call):
+            async def _inner(messages, schema, tools):
+                for _ in range(3):
+                    try:
+                        return await call(messages, schema, tools)
+                    except Exception:
+                        attempts["n"] += 1
+                raise LLMError(reason="exhausted", message_history=messages)
+            return _inner
+
+        # First call raises, second succeeds
+        llm = mock_llm(
+            custom_response="success",
+            errors=[lambda: Exception("transient network error")],
+        )
+
+        agent = rt.agent_node(
+            name="RetryAgent",
+            llm=llm,
+            model_middleware=MiddlewareSet(wrappers=[retry_llm]),
+        )
+
+        result = await rt.Flow("RetryAgent", agent).ainvoke("try this")
+
+        assert "success" in result.content
+        assert attempts["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_model_middleware_independent_per_agent_node(self, mock_llm):
+        """Each agent node gets its own copy of model_middleware; sys gateways don't cross-contaminate."""
+
+        gateway_a_calls = {"n": 0}
+        gateway_b_calls = {"n": 0}
+
+        @rt.gateway
+        async def gw_a(messages, schema, tools):
+            gateway_a_calls["n"] += 1
+
+        @rt.gateway
+        async def gw_b(messages, schema, tools):
+            gateway_b_calls["n"] += 1
+
+        agent_a = rt.agent_node(
+            "AgentA",
+            llm=mock_llm(custom_response="a"),
+            model_middleware=MiddlewareSet(gateway_entry=[gw_a]),
+        )
+        agent_b = rt.agent_node(
+            "AgentB",
+            llm=mock_llm(custom_response="b"),
+            model_middleware=MiddlewareSet(gateway_entry=[gw_b]),
+        )
+
+        await rt.Flow("AgentA", agent_a).ainvoke("hello")
+        await rt.Flow("AgentB", agent_b).ainvoke("hello")
+
+        assert gateway_a_calls["n"] == 1
+        assert gateway_b_calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestContextInjection
+# ---------------------------------------------------------------------------
+
+
+class TestContextInjection:
+    """Context injection: rt.context variables substituted into prompt templates."""
+
+    @pytest.mark.asyncio
+    async def test_context_variable_injected_into_system_message(self, mock_llm):
+        """rt.context values are substituted into {placeholder} template syntax before the LLM call."""
+
+        injected_system_content = []
+
+        @rt.gateway
+        async def capture_system(messages, schema, tools):
+            for m in messages:
+                if m.role == "system":
+                    injected_system_content.append(m.content)
+
+        agent = rt.agent_node(
+            name="TemplateAgent",
+            llm=mock_llm(custom_response="done"),
+            system_message="You assist {username}.",
+            model_middleware=MiddlewareSet(gateway_entry=[capture_system]),
+        )
+
+        await rt.Flow("TemplateAgent", agent, context={"username": "Alice"}).ainvoke("help me")
+
+        assert any("Alice" in c for c in injected_system_content)
+
+    @pytest.mark.asyncio
+    async def test_context_injection_disabled_when_flag_is_false(self, mock_llm):
+        """context_injection=False prevents {placeholder} substitution."""
+
+        injected_system_content = []
+
+        @rt.gateway
+        async def capture_system(messages, schema, tools):
+            for m in messages:
+                if m.role == "system":
+                    injected_system_content.append(m.content)
+
+        agent = rt.agent_node(
+            name="NoInjectionAgent",
+            llm=mock_llm(custom_response="done"),
+            system_message="You assist {username}.",
+            model_middleware=MiddlewareSet(gateway_entry=[capture_system]),
+            context_injection=False,
+        )
+
+        await rt.Flow("NoInjectionAgent", agent, context={"username": "Alice"}).ainvoke("help me")
+
+        assert all("{username}" in c for c in injected_system_content)
+
+
+# ---------------------------------------------------------------------------
+# TestModelSourceFactory
+# ---------------------------------------------------------------------------
+
+
+class TestModelSourceFactory:
+    """ModelSource can be a no-arg callable resolved fresh on every model call."""
+
+    @pytest.mark.asyncio
+    async def test_model_factory_resolved_per_agent_call(self, mock_llm):
+        """A factory ModelSource is called once per agent invocation."""
+
+        factory_calls = {"n": 0}
+
+        def llm_factory():
+            factory_calls["n"] += 1
+            return mock_llm(custom_response=f"response_{factory_calls['n']}")
+
+        agent = rt.agent_node(name="FactoryAgent", llm=llm_factory)
+
+        flow = rt.Flow("FactoryAgent", agent)
+        r1 = await flow.ainvoke("first call")
+        r2 = await flow.ainvoke("second call")
+
+        assert factory_calls["n"] == 2
+        assert "response_1" in r1.content
+        assert "response_2" in r2.content
+
+
+# ---------------------------------------------------------------------------
+# TestToolCallingWithPrepareArgs
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallingWithPrepareArgs:
+    """End-to-end tool calling via the NodeBuilder path (verifies prepare_args fix)."""
+
+    @pytest.mark.asyncio
+    async def test_function_node_tool_called_with_correct_args(self, mock_llm):
+        """Agent dispatches a tool call; the function node receives correctly typed arguments."""
+
+        received = {}
+
+        def double(n: int) -> int:
+            """Doubles a number.
+            Args:
+                n (int): The number to double.
+            Returns:
+                int: The doubled number.
+            """
+            received["n"] = n
+            return n * 2
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(name="double", identifier="call_001", arguments={"n": 5})
+            ]
+        )
+        agent = rt.agent_node(
+            name="DoubleAgent",
+            llm=llm,
+            tool_nodes=[rt.function_node(double)],
+        )
+
+        result = await rt.Flow("DoubleAgent", agent).ainvoke("double 5")
+
+        assert received.get("n") == 5
+        assert "10" in result.content
+
+    @pytest.mark.asyncio
+    async def test_multiple_parallel_tool_calls(self, mock_llm):
+        """Agent dispatching multiple tool calls in one response runs them all."""
+
+        calls_made = []
+
+        def tag(label: str) -> str:
+            """Tags a call.
+            Args:
+                label (str): The tag label.
+            Returns:
+                str: The label.
+            """
+            calls_made.append(label)
+            return label
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(name="tag", identifier="id_a", arguments={"label": "alpha"}),
+                ToolCall(name="tag", identifier="id_b", arguments={"label": "beta"}),
+            ]
+        )
+        agent = rt.agent_node(
+            name="MultiToolAgent",
+            llm=llm,
+            tool_nodes=[rt.function_node(tag)],
+        )
+
+        await rt.Flow("MultiToolAgent", agent).ainvoke("tag alpha and beta")
+
+        assert sorted(calls_made) == ["alpha", "beta"]
+
+    @pytest.mark.asyncio
+    async def test_tool_exception_surfaced_to_llm_as_string(self, mock_llm):
+        """Tool runtime errors become error-string ToolMessages; the LLM loop continues."""
+
+        def always_fails(x: int) -> int:
+            """Always raises.
+            Args:
+                x (int): Input.
+            Returns:
+                int: Never returns.
+            """
+            raise RuntimeError("tool exploded")
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(name="always_fails", identifier="id_err", arguments={"x": 1})
+            ]
+        )
+        agent = rt.agent_node(
+            name="ErrorToolAgent",
+            llm=llm,
+            tool_nodes=[rt.function_node(always_fails)],
+        )
+
+        result = await rt.Flow("ErrorToolAgent", agent).ainvoke("call always_fails")
+
+        # The error is surfaced to the LLM as a tool message string, not raised.
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_function_node_tool_with_middleware_executes_middleware(
+        self, mock_llm
+    ):
+        """Middleware on a function node tool fires when the tool is called by an agent."""
+
+        gateway_fired = {"value": False}
+
+        @rt.gateway
+        def mark_fired(n: int):
+            gateway_fired["value"] = True
+
+        def increment(n: int) -> int:
+            """Increments a number.
+            Args:
+                n (int): The number.
+            Returns:
+                int: n + 1.
+            """
+            return n + 1
+
+        tool = rt.function_node(
+            increment, middleware=MiddlewareSet(gateway_entry=[mark_fired])
+        )
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(name="increment", identifier="id_inc", arguments={"n": 9})
+            ]
+        )
+        agent = rt.agent_node(
+            name="ToolWithMiddlewareAgent",
+            llm=llm,
+            tool_nodes=[tool],
+        )
+
+        result = await rt.Flow("ToolWithMiddlewareAgent", agent).ainvoke("increment 9")
+
+        assert gateway_fired["value"]
+        assert "10" in result.content
+
+
+# ---------------------------------------------------------------------------
+# TestMiddlewareSetIsolation
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareSetIsolation:
+    """MiddlewareSet fresh-copy semantics: sharing a set across nodes is safe."""
+
+    def test_shared_middleware_set_not_mutated(self, mock_llm):
+        """Two nodes built from the same MiddlewareSet get independent copies."""
+
+        shared = MiddlewareSet()
+
+        node_a = rt.agent_node("IsoA", llm=mock_llm(), middleware=shared)
+        node_b = rt.agent_node("IsoB", llm=mock_llm(), middleware=shared)
+
+        assert node_a.frozen_middleware is not node_b.frozen_middleware
+        assert node_a.frozen_middleware is not shared
+
+    def test_node_instance_middleware_independent_from_class(self, mock_llm):
+        """Each Node instance gets a fresh copy of frozen_middleware; mutations don't bleed."""
+
+        agent_cls = rt.agent_node("InstanceIso", llm=mock_llm())
+        instance_a = agent_cls()
+        instance_b = agent_cls()
+
+        assert instance_a.middleware is not instance_b.middleware
+        assert instance_a.middleware is not agent_cls.frozen_middleware
+
+    @pytest.mark.asyncio
+    async def test_sys_gateway_registered_once_per_node(self, mock_llm):
+        """System-registered gateways (e.g. context injection) do not accumulate across builds."""
+
+        call_count = {"n": 0}
+
+        @rt.gateway
+        async def counting_gw(messages, schema, tools):
+            call_count["n"] += 1
+
+        # Build the same agent multiple times with the same model_middleware
+        ms = MiddlewareSet(gateway_entry=[counting_gw])
+
+        for _ in range(3):
+            agent = rt.agent_node(
+                name="AccumTest",
+                llm=mock_llm(custom_response="ok"),
+                model_middleware=ms,
+            )
+            await rt.Flow("AccumTest", agent).ainvoke("hi")
+
+        # counting_gw fires exactly once per call, 3 calls total
+        assert call_count["n"] == 3

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -69,7 +69,7 @@ def test_nodebuilder_llm_with_tool_details_has_tool_info():
     assert tool.name == "TestNode"
 
 
-def test_nodebuilder_llm_with_tool_details_has_prepare_tool():
+def test_nodebuilder_llm_with_tool_details_has_prepare_args():
     params = [Parameter(name="x", description="Input", param_type="integer")]
     node_cls = NodeBuilder.llm(
         "TestNode",
@@ -77,7 +77,7 @@ def test_nodebuilder_llm_with_tool_details_has_prepare_tool():
         tool_details="Does something",
         tool_params=params,
     ).build()
-    assert hasattr(node_cls, "prepare_tool")
+    assert hasattr(node_cls, "prepare_args")
 
 
 def test_nodebuilder_llm_with_system_message_string():

--- a/packages/railtracks/tests/unit_tests/execution/conftest.py
+++ b/packages/railtracks/tests/unit_tests/execution/conftest.py
@@ -13,7 +13,7 @@ def mock_node():
 
 @pytest.fixture
 def mock_task(mock_node):
-    return Task(request_id="req-1", node=mock_node)
+    return Task(request_id="req-1", node=mock_node, arguments=((), {}))
 
 
 @pytest.fixture

--- a/packages/railtracks/tests/unit_tests/llm/test_type_mapping.py
+++ b/packages/railtracks/tests/unit_tests/llm/test_type_mapping.py
@@ -46,7 +46,7 @@ def test_convert_kwargs_to_appropriate_types(type_mapper):
         "e": ["1", "2", "3"],
         "f": ("foo", "2"),
     }
-    converted = type_mapper.convert_kwargs_to_appropriate_types(kwargs)
+    converted = type_mapper.convert_kwargs_to_appropriate_types(**kwargs)
 
     assert converted["a"] == 1
     assert converted["b"] == "text"
@@ -83,7 +83,7 @@ def test_convert_to_pydantic_model_failure():
 def test_convert_value_dict_error():
     tm = TypeMapper(dummy_func_with_dict)
     with pytest.raises(RuntimeError):
-        tm.convert_kwargs_to_appropriate_types({"a": {"key": "value"}})
+        tm.convert_kwargs_to_appropriate_types(a={"key": "value"})
 
 
 def test_builtin_function_raises_runtime_error():

--- a/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
@@ -23,9 +23,9 @@ class TestWrapper:
             wrapper(123)  # type: ignore[arg-type]
 
     def test_wrapper_requires_async(self):
-        # A wrapper must await the inner call, so a sync function is rejected.
+        # A sync function is rejected immediately — wrappers must be async.
         with pytest.raises(TypeError, match="async"):
-            wrapper(lambda call: call)  # type: ignore[arg-type]
+            wrapper(lambda call, *a, **k: call(*a, **k))  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
     async def test_wrapper_wraps_and_calls(self):

--- a/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
@@ -1,15 +1,15 @@
-"""Tests for the unified middleware primitives + MiddlewareSet engine.
+"""Tests for the unified middleware primitives + MiddlewareChain engine.
 
 Wrapper   — execution control (wraps the inner callable)
-Gateway   — direction-less data transform; the slot it is placed in
-            (gateway_entry vs gateway_exit) decides when it runs
-MiddlewareSet — ordered bands: wrappers -> gateway_entry
-                -> inner_wrappers -> core -> gateway_exit
+Gate   — direction-less data transform; the slot it is placed in
+            (entry_gate vs exit_gate) decides when it runs
+MiddlewareChain — ordered bands: wrappers -> entry_gate
+                -> inner_wrappers -> core -> exit_gate
                 (with internal sys/user layers)
 """
 
 import pytest
-from railtracks.middleware import Gateway, MiddlewareSet, gateway, wrapper
+from railtracks.middleware import Gate, MiddlewareChain, gate, wrapper
 from railtracks.middleware.set import _LayeredList
 
 # ---------------------------------------------------------------------------
@@ -52,48 +52,48 @@ class TestWrapper:
         assert await never.wrap(core)() == "blocked"
 
 
-class TestGateway:
-    def test_gateway_requires_callable(self):
+class TestGate:
+    def test_gate_requires_callable(self):
         with pytest.raises(TypeError, match="callable"):
-            Gateway(123)  # type: ignore[arg-type]
+            Gate(123)  # type: ignore[arg-type]
 
     @pytest.mark.asyncio
-    async def test_sync_gateway_is_adapted(self):
-        # A plain `def` gateway is accepted and run inline.
-        @gateway
+    async def test_sync_gate_is_adapted(self):
+        # A plain `def` gate is accepted and run inline.
+        @gate
         def shout(result):
             return result + "!"
 
         assert await shout.apply_exit("hi") == "hi!"
 
     @pytest.mark.asyncio
-    async def test_sync_entry_gateway_is_adapted(self):
-        @gateway
+    async def test_sync_entry_gate_is_adapted(self):
+        @gate
         def strip_in(text):
             return (text.strip(),), {}
 
         assert await strip_in.apply_entry("  hi  ") == (("hi",), {})
 
-    def test_decorator_builds_gateway(self):
-        @gateway
+    def test_decorator_builds_gate(self):
+        @gate
         async def g(*args, **kwargs):
             return args, kwargs
 
-        assert isinstance(g, Gateway)
+        assert isinstance(g, Gate)
 
-    def test_sync_gateway_is_directly_callable(self):
+    def test_sync_gate_is_directly_callable(self):
         # __call__ is a raw passthrough to the underlying function (no slot semantics).
-        @gateway
+        @gate
         def tag(x):
             return f"[{x}]"
 
         assert tag("a") == "[a]"
 
     @pytest.mark.asyncio
-    async def test_async_gateway_call_returns_coroutine(self):
+    async def test_async_gate_call_returns_coroutine(self):
         seen = []
 
-        @gateway
+        @gate
         async def log(x):
             seen.append(x)
             return "raw"
@@ -105,7 +105,7 @@ class TestGateway:
     @pytest.mark.asyncio
     async def test_entry_bare_value_raises(self):
         # No single-value shorthand: a bare value is ambiguous and rejected.
-        @gateway
+        @gate
         async def upper(text):
             return text.upper()
 
@@ -114,7 +114,7 @@ class TestGateway:
 
     @pytest.mark.asyncio
     async def test_entry_tuple_is_positional_args(self):
-        @gateway
+        @gate
         async def pair(*args, **kwargs):
             return (1, 2)  # tuple -> positional args only
 
@@ -122,7 +122,7 @@ class TestGateway:
 
     @pytest.mark.asyncio
     async def test_entry_dict_is_keyword_args(self):
-        @gateway
+        @gate
         async def kw(*args, **kwargs):
             return {"k": 3}  # dict -> keyword args only
 
@@ -130,26 +130,26 @@ class TestGateway:
 
     @pytest.mark.asyncio
     async def test_entry_explicit_args_kwargs_tuple(self):
-        @gateway
+        @gate
         async def reshape(*args, **kwargs):
             return (1, 2), {"k": 3}
 
         assert await reshape.apply_entry("x") == ((1, 2), {"k": 3})
 
     @pytest.mark.asyncio
-    async def test_entry_gateway_args_helper(self):
-        @gateway
+    async def test_entry_gate_args_helper(self):
+        @gate
         async def reorder(a, b):
-            return gateway.args(b, a, flag=True)
+            return gate.args(b, a, flag=True)
 
         assert await reorder.apply_entry(1, 2) == ((2, 1), {"flag": True})
 
     @pytest.mark.asyncio
-    async def test_check_only_entry_gateway_passes_through(self):
+    async def test_check_only_entry_gate_passes_through(self):
         # Returning None == "inspected only, don't change the call".
         seen = []
 
-        @gateway
+        @gate
         async def log(*args, **kwargs):
             seen.append((args, kwargs))
 
@@ -157,8 +157,8 @@ class TestGateway:
         assert seen == [(("hi",), {"n": 1})]
 
     @pytest.mark.asyncio
-    async def test_check_only_exit_gateway_passes_through(self):
-        @gateway
+    async def test_check_only_exit_gate_passes_through(self):
+        @gate
         async def audit(result):
             pass  # returns None -> original result kept
 
@@ -166,16 +166,16 @@ class TestGateway:
 
     @pytest.mark.asyncio
     async def test_exit_transforms_result(self):
-        @gateway
+        @gate
         async def shout(result):
             return result.upper()
 
         assert await shout.apply_exit("hi") == "HI"
 
     @pytest.mark.asyncio
-    async def test_same_gateway_object_can_serve_either_slot(self):
-        # A gateway carries no direction; apply_entry / apply_exit pick behaviour.
-        @gateway
+    async def test_same_gate_object_can_serve_either_slot(self):
+        # A gate carries no direction; apply_entry / apply_exit pick behaviour.
+        @gate
         async def passthrough(*args, **kwargs):
             return args, kwargs
 
@@ -222,12 +222,12 @@ class TestLayeredList:
 
 
 # ---------------------------------------------------------------------------
-# MiddlewareSet construction / coercion
+# MiddlewareChain construction / coercion
 # ---------------------------------------------------------------------------
 
 
-def _noop_gateway():
-    @gateway
+def _noop_gate():
+    @gate
     async def g(*args, **kwargs):
         return args, kwargs
 
@@ -242,103 +242,103 @@ def _noop_wrapper():
     return w
 
 
-class TestMiddlewareSetConstruction:
+class TestMiddlewareChainConstruction:
     def test_empty(self):
-        ms = MiddlewareSet()
+        ms = MiddlewareChain()
         assert ms.wrappers == []
-        assert ms.gateway_entry == []
-        assert ms.gateway_exit == []
+        assert ms.entry_gate == []
+        assert ms.exit_gate == []
         assert ms.inner_wrappers == []
 
     def test_explicit_entry_and_exit(self):
-        g_in, g_out = _noop_gateway(), _noop_gateway()
-        ms = MiddlewareSet(gateway_entry=[g_in], gateway_exit=[g_out])
-        assert ms.gateway_entry == [g_in]
-        assert ms.gateway_exit == [g_out]
+        g_in, g_out = _noop_gate(), _noop_gate()
+        ms = MiddlewareChain(entry_gate=[g_in], exit_gate=[g_out])
+        assert ms.entry_gate == [g_in]
+        assert ms.exit_gate == [g_out]
 
     def test_coerce_none(self):
-        assert isinstance(MiddlewareSet.coerce(None), MiddlewareSet)
+        assert isinstance(MiddlewareChain.coerce(None), MiddlewareChain)
 
     def test_coerce_list_splits_by_type(self):
-        g = _noop_gateway()
+        g = _noop_gate()
         w = _noop_wrapper()
-        ms = MiddlewareSet.coerce([g, w])
-        assert ms.gateway_entry == [g]  # bare-list gateways default to entry
+        ms = MiddlewareChain.coerce([g, w])
+        assert ms.entry_gate == [g]  # bare-list gates default to entry
         assert ms.wrappers == [w]
 
     def test_coerce_rejects_non_middleware(self):
         with pytest.raises(TypeError):
-            MiddlewareSet.coerce([object()])
+            MiddlewareChain.coerce([object()])
 
     def test_constructor_rejects_wrong_band_type(self):
-        g = _noop_gateway()
+        g = _noop_gate()
         with pytest.raises(TypeError, match="Wrapper"):
-            MiddlewareSet(wrappers=[g])  # gateway in a wrapper band
+            MiddlewareChain(wrappers=[g])  # gate in a wrapper band
 
     def test_coerce_middlewareset_is_fresh_copy(self):
-        g = _noop_gateway()
-        ms1 = MiddlewareSet(gateway_entry=[g])
-        ms1.register_sys_gateway_entry(_noop_gateway())
-        ms2 = MiddlewareSet.coerce(ms1)
+        g = _noop_gate()
+        ms1 = MiddlewareChain(entry_gate=[g])
+        ms1.register_sys_entry_gate(_noop_gate())
+        ms2 = MiddlewareChain.coerce(ms1)
         # user layer preserved, sys layer reset
-        assert ms2.gateway_entry == [g]
+        assert ms2.entry_gate == [g]
         assert ms2._entry._sys_before == []
 
     def test_user_list_not_mutated_by_sys_registration(self):
-        user = [_noop_gateway()]
-        ms = MiddlewareSet(gateway_entry=user)
-        ms.register_sys_gateway_entry(_noop_gateway())
+        user = [_noop_gate()]
+        ms = MiddlewareChain(entry_gate=user)
+        ms.register_sys_entry_gate(_noop_gate())
         assert len(user) == 1
 
 
-class TestMiddlewareSetSysRegistration:
+class TestMiddlewareChainSysRegistration:
     def test_sys_entry_runs_before_user_entry(self):
-        user_g = _noop_gateway()
-        ms = MiddlewareSet(gateway_entry=[user_g])
-        sys_g = _noop_gateway()
-        ms.register_sys_gateway_entry(sys_g)
+        user_g = _noop_gate()
+        ms = MiddlewareChain(entry_gate=[user_g])
+        sys_g = _noop_gate()
+        ms.register_sys_entry_gate(sys_g)
         assert ms._entry.ordered() == [sys_g, user_g]
 
     def test_sys_exit_runs_after_user_exit(self):
-        user_g = _noop_gateway()
-        sys_g = _noop_gateway()
-        ms = MiddlewareSet(gateway_exit=[user_g])
-        ms.register_sys_gateway_exit(sys_g)
+        user_g = _noop_gate()
+        sys_g = _noop_gate()
+        ms = MiddlewareChain(exit_gate=[user_g])
+        ms.register_sys_exit_gate(sys_g)
         assert ms._exit.ordered() == [user_g, sys_g]
 
 
 # ---------------------------------------------------------------------------
-# MiddlewareSet.run — the engine
+# MiddlewareChain.run — the engine
 # ---------------------------------------------------------------------------
 
 
 class TestEngineExecution:
     @pytest.mark.asyncio
     async def test_bare_core(self):
-        ms = MiddlewareSet()
+        ms = MiddlewareChain()
 
         async def core(x):
             return x * 2
 
-        assert await ms.run(core, (5,), {}) == 10
+        assert await ms.run(core, 5) == 10
 
     @pytest.mark.asyncio
     async def test_entry_then_exit(self):
-        @gateway
+        @gate
         async def add_one(x):
             return (x + 1,), {}
 
-        @gateway
+        @gate
         async def times_ten(result):
             return result * 10
 
-        ms = MiddlewareSet(gateway_entry=[add_one], gateway_exit=[times_ten])
+        ms = MiddlewareChain(entry_gate=[add_one], exit_gate=[times_ten])
 
         async def core(x):
             return x
 
         # core(5+1)=6 -> *10 = 60
-        assert await ms.run(core, (5,), {}) == 60
+        assert await ms.run(core, 5) == 60
 
     @pytest.mark.asyncio
     async def test_full_onion_order(self):
@@ -351,7 +351,7 @@ class TestEngineExecution:
             trace.append("outer-out")
             return r
 
-        @gateway
+        @gate
         async def entry(*a, **k):
             trace.append("entry")
             return a, k
@@ -363,15 +363,15 @@ class TestEngineExecution:
             trace.append("inner-out")
             return r
 
-        @gateway
+        @gate
         async def exit_(result):
             trace.append("exit")
             return result
 
-        ms = MiddlewareSet(
+        ms = MiddlewareChain(
             wrappers=[outer],
-            gateway_entry=[entry],
-            gateway_exit=[exit_],
+            entry_gate=[entry],
+            exit_gate=[exit_],
             inner_wrappers=[inner],
         )
 
@@ -391,18 +391,18 @@ class TestEngineExecution:
         ]
 
     @pytest.mark.asyncio
-    async def test_multiple_entry_gateways_in_order(self):
+    async def test_multiple_entry_gates_in_order(self):
         order = []
 
         def make(tag):
-            @gateway
+            @gate
             async def g(*a, **k):
                 order.append(tag)
                 return a, k
 
             return g
 
-        ms = MiddlewareSet(gateway_entry=[make("a"), make("b"), make("c")])
+        ms = MiddlewareChain(entry_gate=[make("a"), make("b"), make("c")])
 
         async def core():
             return None

--- a/packages/railtracks/tests/unit_tests/nodes/library/tool_calling_llms/test_structured_tool_call_llm.py
+++ b/packages/railtracks/tests/unit_tests/nodes/library/tool_calling_llms/test_structured_tool_call_llm.py
@@ -106,19 +106,7 @@ async def test_structured_tool_call_llm_return_output_exception(mock_llm, schema
         await node.invoke()
 
 
-def test_structured_llm_easy_usage_wrapper(mock_llm, schema, mock_tool):
-    mh = MessageHistory([SystemMessage("system prompt"), UserMessage("extract value")])
-    node = structured_tool_call_llm(
-        system_message="system prompt",
-        tool_nodes={mock_tool},
-        llm=mock_llm(),
-        output_schema=schema,
-        tool_details="Extracts a value.",
-        tool_params=None,
-        name="Mock Structured ToolCallLLM",
-    )
-    node = node(mh, mock_llm())
-    assert hasattr(node, "structured_resp_node")
+
 
 def test_structured_tool_call_llm_instantiate_with_string(mock_llm, schema, mock_tool):
     """Test that StructuredToolCallLLM can be instantiated with a string input."""


### PR DESCRIPTION
## Summary

I clairfied and fixed up some typing in the middlware module. The only remaining hole is the output types of input gateways. Those remain a `tuple[tuple, dict[str, Any]]`. everything else is typed up nice, please see below examples and play around with it yourself
## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [x] Breaking changes include migration notes

## Notes

Some cool typing stuff

incorrect input types for a input gateway
<img width="1125" height="413" alt="image" src="https://github.com/user-attachments/assets/b4a26254-806c-4393-ad30-005fe42eeecf" />


correct type

<img width="1100" height="411" alt="image" src="https://github.com/user-attachments/assets/d0a582b1-76d7-4cf0-9fff-779640e033fd" />

mixing up inputs and outputs

<img width="1128" height="511" alt="image" src="https://github.com/user-attachments/assets/724b667d-7b2b-431c-a4a6-dc818d38bb1d" />

coereced type in exit gateway
<img width="1123" height="351" alt="image" src="https://github.com/user-attachments/assets/da7ceb83-a2fe-43db-b032-57fae96328c6" />

correct exit gateway
<img width="1181" height="353" alt="image" src="https://github.com/user-attachments/assets/db3e2d3b-a15a-495e-93a0-b957466dfdf6" />

correct typing for wrapper
<img width="1109" height="449" alt="image" src="https://github.com/user-attachments/assets/1e895184-a379-45e5-b2d2-614a313f6651" />


```python


from curses import wrapper
from typing import Awaitable, Callable

import railtracks as rt

@rt.function_node
def hello_world(suffix: str) -> str:
    return f"hello world {suffix}"

@rt.gate
def log_inputs(*args, **kwargs):
    print(f"Gateway received inputs: args={args}, kwargs={kwargs}")
    return 


@rt.gate
def add_gateway(x: int, y: int):
    if x < 0 or y < 0:
        raise ValueError("Error: Negative numbers are not allowed.")
    
    return (x, y), {}

@rt.gate
async def add_gateway_exit(result: int):
    return result * 2

@rt.wrapper
async def half_fail(call: Callable[[int, int], Awaitable[int]], x: int, y: int) -> int:
        import random

        if random.random() < 0.5:
            raise Exception("Random failure occurred.")
        return await call(x, y)


@rt.wrapper
async def retry(call, *args, **kwargs):
    max_retries = 3
    for attempt in range(max_retries):
        try:
            return await call(*args, **kwargs)
        except Exception as e:
            if attempt == max_retries - 1:
                raise e
            else:
                print(f"Attempt {attempt + 1} failed: {e}. Retrying...")
        
    raise Exception("All retry attempts failed.")



@rt.function_node(middleware=rt.MiddlewareChain(wrappers=[retry, half_fail], entry_gate=[add_gateway, log_inputs], exit_gate=[add_gateway_exit]))
async def add(x: int, y: int) -> int:
    return x + y
```

code to play with