### PR TITLE
1139 feature migrate guardrails

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Coroutine,
@@ -26,6 +27,10 @@ from railtracks.built_nodes.llm_helpers import (
     llm_observe,
     llm_prepare_called_as_tool_factory,
 )
+from railtracks.guardrails.llm.guardrail_gates import (
+    guardrail_input_gate,
+    guardrail_output_gate,
+)
 from railtracks.llm import (
     Parameter,
     SystemMessage,
@@ -42,6 +47,9 @@ from railtracks.validation.node_creation.validation import (
     _check_duplicate_param_names,
     _check_tool_params_and_details,
 )
+
+if TYPE_CHECKING:
+    from railtracks.guardrails.core import Guard
 
 
 def classmethod_preserving_function_meta(func):
@@ -121,11 +129,13 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareChain[[UserInput], StringResponse] | None = None,
+        middleware: MiddlewareChain[[UserInput], StringResponse] | list | None = None,
         model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
+        | list
         | None = None,
+        guardrails: Guard | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StringResponse]: ...
 
@@ -143,11 +153,14 @@ class NodeBuilder(Generic[_P, _T]):
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
         middleware: MiddlewareChain[[UserInput], StructuredResponse[_TStructured]]
+        | list
         | None = None,
         model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
+        | list
         | None = None,
+        guardrails: Guard | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], StructuredResponse[_TStructured]]: ...
 
@@ -163,11 +176,13 @@ class NodeBuilder(Generic[_P, _T]):
         connected_nodes: Iterable[Type[Node]] | None = None,
         tool_details: str | None = None,
         tool_params: list[Parameter] | None = None,
-        middleware: MiddlewareChain[[UserInput], _R] | None = None,
+        middleware: MiddlewareChain[[UserInput], _R] | list | None = None,
         model_middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
+        | list
         | None = None,
+        guardrails: Guard | None = None,
         context_injection: bool = True,
     ) -> NodeBuilder[[UserInput], _R]:
         instance = cls()
@@ -187,6 +202,15 @@ class NodeBuilder(Generic[_P, _T]):
             model_invoker.register_sys_entry_gate(context_injection_gateway)
 
         model_invoker.register_sys_wrapper(llm_observe)
+
+        # Guardrails: fixed, non-reorderable system gates; input last before the core, output the last word.
+        if guardrails is not None:
+            if guardrails.input:
+                model_invoker.register_sys_entry_gate(
+                    guardrail_input_gate(guardrails), position="after"
+                )
+            if guardrails.output:
+                model_invoker.register_sys_exit_gate(guardrail_output_gate(guardrails))
 
         casted_instance._invoke = llm_invoke_factory(
             model_invoker=model_invoker,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -7,6 +7,7 @@ from railtracks.built_nodes.concrete import (
 )
 from railtracks.built_nodes.concrete.response import StringResponse, StructuredResponse
 from railtracks.built_nodes.llm_helpers import ModelSource
+from railtracks.guardrails.core import Guard
 from railtracks.llm.message import SystemMessage
 from railtracks.llm.tools.parameters._base import Parameter
 from railtracks.middleware import MiddlewareChain
@@ -46,6 +47,7 @@ def _build_dynamic_agent(
     tool_params: list[Parameter] | None,
     middleware: MiddlewareChain | list | None = None,
     model_middleware: MiddlewareChain | list | None = None,
+    guardrails: Guard | None = None,
     context_injection: bool = True,
 ):
     resolved_system = (
@@ -64,6 +66,7 @@ def _build_dynamic_agent(
             tool_params=tool_params,
             middleware=middleware,
             model_middleware=model_middleware,
+            guardrails=guardrails,
             context_injection=context_injection,
         )
     else:
@@ -77,13 +80,14 @@ def _build_dynamic_agent(
             tool_params=tool_params,
             middleware=middleware,
             model_middleware=model_middleware,
+            guardrails=guardrails,
             context_injection=context_injection,
         )
 
     return nb.build()
 
 
-# --- Tool-calling overloads (no guardrails) ---
+# --- agent_node overloads (string vs structured output) ---
 
 
 @overload
@@ -97,6 +101,7 @@ def agent_node(
     manifest: ToolManifest | None = None,
     middleware: MiddlewareChain | list | None = None,
     model_middleware: MiddlewareChain | list | None = None,
+    guardrails: Guard | None = None,
     context_injection: bool = True,
 ) -> type[Node[[UserInput], StringResponse]]: ...
 
@@ -112,6 +117,7 @@ def agent_node(
     manifest: ToolManifest | None = None,
     middleware: MiddlewareChain | list | None = None,
     model_middleware: MiddlewareChain | list | None = None,
+    guardrails: Guard | None = None,
     context_injection: bool = True,
 ) -> type[Node[[UserInput], StructuredResponse[_TBaseModel]]]: ...
 
@@ -126,6 +132,7 @@ def agent_node(
     manifest: ToolManifest | None = None,
     middleware: MiddlewareChain | list | None = None,
     model_middleware: MiddlewareChain | list | None = None,
+    guardrails: Guard | None = None,
     context_injection: bool = True,
 ):
     """
@@ -145,6 +152,9 @@ def agent_node(
         model_middleware (MiddlewareChain | list | None): Middleware applied around each raw model call
             (messages/schema/tools -> Response), inside the tool-calling loop. Accepts a MiddlewareChain or a
             bare list of Wrapper/Gate.
+        guardrails (Guard | None): Input/output LLM guardrails to enforce around the model call. Input rails
+            run as the last check before the model (after context injection and any model_middleware); output
+            rails run on the final reply as the last word. Attached as fixed, non-reorderable system gates.
         context_injection (bool): Whether to inject rt.context variables into prompt templates for this node.
             Defaults to True. Set to False to disable context injection for this specific agent regardless
             of the session-level prompt_injection setting. Can also be controlled at the session level via
@@ -170,6 +180,7 @@ def agent_node(
         tool_params=tool_params,
         middleware=middleware,
         model_middleware=model_middleware,
+        guardrails=guardrails,
         context_injection=context_injection,
     )
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from railtracks.built_nodes.concrete._llm_base import RequestDetails
 from railtracks.built_nodes.concrete.response import StringResponse, StructuredResponse
-from railtracks.exceptions.errors import LLMError
+from railtracks.exceptions.errors import LLMError, NodeInvocationError
 from railtracks.interaction._call import call
 from railtracks.llm.content import ToolCall, ToolResponse
 from railtracks.llm.history import MessageHistory
@@ -84,6 +84,7 @@ class ModelInvoker:
         middleware: MiddlewareChain[
             [MessageHistory, type[BaseModel] | None, list[Tool] | None], Response
         ]
+        | list
         | None = None,
     ):
         self._get_model = model if callable(model) else lambda: model
@@ -198,6 +199,8 @@ def llm_invoke_factory(
                 returned_mess = await model_invoker.invoke(
                     message_history, schema=schema, tools=tools
                 )
+            except NodeInvocationError:
+                raise  # e.g. a guardrail block from a gate; surface as-is, don't mask
             except Exception as e:
                 raise LLMError(
                     reason=f"Exception during model invoke: {repr(e)}",

--- a/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm_helpers.py
@@ -97,9 +97,16 @@ class ModelInvoker:
             [MessageHistory, type[BaseModel] | None, list[Tool] | None],
             tuple[tuple, dict[str, Any]],
         ],
+        *,
+        position: Literal["before", "after"] = "before",
     ) -> None:
-        """Register a system entry gate around the model call (e.g. context injection)."""
-        self._middleware.register_sys_entry_gate(gw)
+        """Register a system entry gate around the model call.
+
+        ``position="before"`` (default) runs before user model-middleware entry gates
+        (e.g. context injection); ``position="after"`` runs after them — the last gate
+        before the model call (e.g. an input guardrail).
+        """
+        self._middleware.register_sys_entry_gate(gw, position=position)
 
     def register_sys_exit_gate(self, gw: Gate[[Response], Response]) -> None:
         """Register a system exit gate around the model call (e.g. logging)."""

--- a/packages/railtracks/src/railtracks/guardrails/llm/guardrail_gates.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/guardrail_gates.py
@@ -1,0 +1,162 @@
+"""Middleware gates that run the guardrails core around the raw model call.
+
+These adapters let ``agent_node(..., guardrails=Guard(...))`` attach guardrails as
+**system gates on the model-level middleware** (`ModelInvoker`), mirroring how context
+injection is wired. They translate between the runner's ``(value, traces, decision)``
+triple and the middleware transform contract (transform-or-raise):
+
+- :func:`guardrail_input_gate` — an **entry gate**. Register with ``position="after"`` so
+  it is the last gate before the model call (sees the fully assembled, injected,
+  user-transformed prompt). Runs the input rails on the message history.
+- :func:`guardrail_output_gate` — an **exit gate** (register as sys-exit, the last word).
+  Runs the output rails on the final assistant reply; intermediate tool-call turns pass
+  through untouched.
+
+The guardrails core (:class:`GuardRunner`, the built-in guards, decisions, traces) is
+reused unchanged — only the seam moves off the old ``LLMGuardrailsMixin``.
+
+Notes / known limitations:
+
+- **Runs every model round-trip, by design.** The model-level seam does not persist a
+  transform back into the agent's tool-calling loop (the loop keeps its own
+  ``message_history`` and the guards return a *new* history), so redaction must be
+  re-applied on every model call to guarantee the model never sees un-redacted input.
+  The built-in guards are idempotent, so this is safe; it is also the correct security
+  posture. A side-effecting *custom* input guard will therefore fire once per round.
+- **Output guards do not see the upstream history.** An exit gate receives only the
+  ``Response``, so ``event.messages`` is empty. Built-in output guards only inspect the
+  assistant message; a custom output guard that needs conversation context is not
+  supported at this seam (would require a model-level wrapper instead).
+"""
+
+from __future__ import annotations
+
+from railtracks.context.central import (
+    get_parent_id,
+    get_run_id,
+    is_context_present,
+)
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.response import Response
+from railtracks.middleware import Gate, gate
+from railtracks.utils.logging import get_rt_logger
+
+from ..core import Guard, GuardrailBlockedError, GuardRunner
+from ..core.decision import GuardrailAction, GuardrailDecision
+from ..core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from ..core.trace import GuardrailTrace
+
+logger = get_rt_logger("guardrails")
+
+
+def _node_metadata() -> tuple[str | None, str | None]:
+    """``(node_uuid, run_id)`` for event observability.
+
+    Returns ``(None, None)`` when no run context is active — the gate logic never
+    depends on this metadata, so it must not raise just to populate it.
+    """
+    if not is_context_present():
+        return None, None
+    return get_parent_id(), get_run_id()
+
+
+def _record_guard_traces(traces: list[GuardrailTrace]) -> None:
+    """The single sink for guardrail traces.
+
+    TODO: Determine the correct home for observability traces. For now, just log them at debug level.
+    """
+    for t in traces:
+        logger.debug("guardrail trace: %s", t)
+
+
+def _is_intermediate_tool_call(response: Response) -> bool:
+    """A model round-trip is *intermediate* (not the final reply) when it requests tools.
+
+    Mirrors ``process_message`` in ``llm_helpers`` (tool calls present => "Tool").
+    """
+    return len(response.message.tool_calls) > 0
+
+
+def _raise_if_blocked(
+    decision: GuardrailDecision | None, traces: list[GuardrailTrace]
+) -> None:
+    """Raise :class:`GuardrailBlockedError` when a rail returned ``BLOCK``."""
+    if decision is not None and decision.action == GuardrailAction.BLOCK:
+        rail_name = traces[-1].rail_name if traces else None
+        raise GuardrailBlockedError(
+            rail_name=rail_name,
+            reason=decision.reason,
+            user_facing_message=decision.user_facing_message,
+            traces=traces,
+            meta=decision.meta,
+        )
+
+
+def guardrail_input_gate(guard: Guard) -> Gate:
+    """Build an entry gate that runs ``guard.input`` on the message history.
+
+    Register on the model middleware with ``position="after"`` so it runs after any user
+    entry gates; the last transform before the model call. On ``BLOCK`` it raises
+    :class:`GuardrailBlockedError`; on ``TRANSFORM`` it forwards the rewritten history;
+    on ``ALLOW`` it passes through unchanged.
+    """
+
+    @gate
+    def _input_gate(messages: MessageHistory, schema=None, tools=None):
+        if not guard.input:
+            return None
+
+        node_uuid, run_id = _node_metadata()
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.INPUT,
+            messages=messages,
+            node_uuid=node_uuid,
+            run_id=run_id,
+        )
+        new_messages, traces, decision = GuardRunner(guard).run_llm_input(event)
+        _record_guard_traces(traces)
+        _raise_if_blocked(decision, traces)
+
+        if new_messages is messages:
+            return None  # ALLOW / check-only — pass through unchanged
+        # Full (args, kwargs) replacement; keep schema + tools (see context injection).
+        return (new_messages, schema, tools), {}
+
+    return _input_gate
+
+
+def guardrail_output_gate(guard: Guard) -> Gate:
+    """Build an exit gate that runs ``guard.output`` on the final model ``Response``.
+
+    Register on the model middleware as a sys exit gate (the last word on the response).
+    Intermediate tool-call turns pass through untouched, so output rails fire only on the
+    final reply. On ``BLOCK`` it raises; on ``TRANSFORM`` it returns a rewritten
+    ``Response``; on ``ALLOW`` it passes through unchanged.
+    """
+
+    @gate
+    def _output_gate(response: Response):
+        if not guard.output:
+            return None
+        if _is_intermediate_tool_call(response):
+            return None
+
+        node_uuid, run_id = _node_metadata()
+        event = LLMGuardrailEvent(
+            phase=LLMGuardrailPhase.OUTPUT,
+            messages=MessageHistory([]),  # exit-gate seam carries no upstream history
+            output_message=response.message,
+            node_uuid=node_uuid,
+            run_id=run_id,
+        )
+        new_message, traces, decision = GuardRunner(guard).run_llm_output(
+            event, response.message
+        )
+        _record_guard_traces(traces)
+        _raise_if_blocked(decision, traces)
+
+        if new_message is response.message:
+            return None  # ALLOW / check-only — keep the original response
+        return Response(message=new_message, message_info=response.message_info)
+
+    return _output_gate

--- a/packages/railtracks/src/railtracks/guardrails/llm/guardrail_gates.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/guardrail_gates.py
@@ -1,32 +1,19 @@
 """Middleware gates that run the guardrails core around the raw model call.
 
 These adapters let ``agent_node(..., guardrails=Guard(...))`` attach guardrails as
-**system gates on the model-level middleware** (`ModelInvoker`), mirroring how context
-injection is wired. They translate between the runner's ``(value, traces, decision)``
+**system gates on the model-level middleware** (`ModelInvoker`).
+They translate between the runner's ``(value, traces, decision)``
 triple and the middleware transform contract (transform-or-raise):
 
-- :func:`guardrail_input_gate` — an **entry gate**. Register with ``position="after"`` so
+- :func:`guardrail_input_gate`: an **entry gate**. Register with ``position="after"`` so
   it is the last gate before the model call (sees the fully assembled, injected,
   user-transformed prompt). Runs the input rails on the message history.
-- :func:`guardrail_output_gate` — an **exit gate** (register as sys-exit, the last word).
+- :func:`guardrail_output_gate`: an **exit gate** (register as sys-exit, the last word).
   Runs the output rails on the final assistant reply; intermediate tool-call turns pass
   through untouched.
 
 The guardrails core (:class:`GuardRunner`, the built-in guards, decisions, traces) is
-reused unchanged — only the seam moves off the old ``LLMGuardrailsMixin``.
-
-Notes / known limitations:
-
-- **Runs every model round-trip, by design.** The model-level seam does not persist a
-  transform back into the agent's tool-calling loop (the loop keeps its own
-  ``message_history`` and the guards return a *new* history), so redaction must be
-  re-applied on every model call to guarantee the model never sees un-redacted input.
-  The built-in guards are idempotent, so this is safe; it is also the correct security
-  posture. A side-effecting *custom* input guard will therefore fire once per round.
-- **Output guards do not see the upstream history.** An exit gate receives only the
-  ``Response``, so ``event.messages`` is empty. Built-in output guards only inspect the
-  assistant message; a custom output guard that needs conversation context is not
-  supported at this seam (would require a model-level wrapper instead).
+reused unchanged; only the seam moves off the old ``LLMGuardrailsMixin``.
 """
 
 from __future__ import annotations

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -25,6 +25,7 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Literal,
     ParamSpec,
     TypeVar,
 )
@@ -247,10 +248,21 @@ class MiddlewareChain(Generic[_P, _R]):
     # ------------------------------------------------------------------
 
     def register_sys_entry_gate(
-        self, gw: Gate[_P, tuple[tuple, dict[str, Any]]]
+        self,
+        gw: Gate[_P, tuple[tuple, dict[str, Any]]],
+        *,
+        position: Literal["before", "after"] = "before",
     ) -> None:
-        """Register a framework entry gate (runs before user entry gates)."""
-        self._entry.add_sys_before(gw)
+        """Register a framework entry gate.
+
+        ``position="before"`` (default) runs it before the user entry gates — the
+        outer boundary, e.g. context injection. ``position="after"`` runs it after
+        the user entry gates, i.e. the last gate before the core (hugs the core).
+        """
+        if position == "before":
+            self._entry.add_sys_before(gw)
+        else:
+            self._entry.add_sys_after(gw)
 
     def register_sys_exit_gate(self, gw: Gate[[_R], _R]) -> None:
         """Register a framework exit gate (runs after user exit gates)."""

--- a/packages/railtracks/src/railtracks/middleware/set.py
+++ b/packages/railtracks/src/railtracks/middleware/set.py
@@ -58,6 +58,15 @@ class _LayeredList(Generic[_T]):
         if item not in self._sys_after:
             self._sys_after.append(item)
 
+    def add_user(self, item: _T) -> None:
+        """Append an item to the user layer.
+
+        Unlike the system layers this does **not** deduplicate — appending the
+        same middleware twice runs it twice, matching the constructor, which
+        keeps duplicates in the list it is given.
+        """
+        self._user.append(item)
+
     def ordered(self) -> list[_T]:
         """Flat execution order: ``sys_before + user + sys_after``."""
         return self._sys_before + self._user + self._sys_after
@@ -83,38 +92,42 @@ class _LayeredList(Generic[_T]):
         )
 
 
+def _coerce_wrapper(item: Any, *, index: int | None = None) -> Wrapper:
+    """Coerce one wrapper slot entry: auto-wraps a raw async function, rejects a :class:`Gate`."""
+    where = f" at index {index}" if index is not None else ""
+    if isinstance(item, Wrapper):
+        return item
+    if isinstance(item, Gate):
+        raise TypeError(
+            f"Wrapper slot{where} got a Gate: {item!r}. "
+            f"Gates belong in entry_gate / exit_gate."
+        )
+    # Raw async function (or anything else) -> Wrapper validates it.
+    return Wrapper(item)
+
+
+def _coerce_gate(item: Any, *, index: int | None = None) -> Gate:
+    """Coerce one gate slot entry: auto-wraps a raw function, rejects a :class:`Wrapper`."""
+    where = f" at index {index}" if index is not None else ""
+    if isinstance(item, Gate):
+        return item
+    if isinstance(item, Wrapper):
+        raise TypeError(
+            f"Gate slot{where} got a Wrapper: {item!r}. "
+            f"Wrappers belong in wrappers / inner_wrappers."
+        )
+    # Raw async function (or anything else) -> Gate validates it.
+    return Gate(item)
+
+
 def _coerce_wrappers(items: Iterable[Any] | None) -> list[Wrapper]:
     """Coerce a wrapper slot: auto-wraps raw async functions, rejects :class:`Gate` objects."""
-    result: list[Wrapper] = []
-    for i, item in enumerate(items or []):
-        if isinstance(item, Wrapper):
-            result.append(item)
-        elif isinstance(item, Gate):
-            raise TypeError(
-                f"Wrapper slot at index {i} got a Gate: {item!r}. "
-                f"Gates belong in entry_gate / exit_gate."
-            )
-        else:
-            # Raw async function (or anything else) -> Wrapper validates it.
-            result.append(Wrapper(item))
-    return result
+    return [_coerce_wrapper(item, index=i) for i, item in enumerate(items or [])]
 
 
 def _coerce_gates(items: Iterable[Any] | None) -> list[Gate]:
     """Coerce a gate slot: auto-wraps raw functions, rejects :class:`Wrapper` objects."""
-    result: list[Gate] = []
-    for i, item in enumerate(items or []):
-        if isinstance(item, Gate):
-            result.append(item)
-        elif isinstance(item, Wrapper):
-            raise TypeError(
-                f"Gate slot at index {i} got a Wrapper: {item!r}. "
-                f"Wrappers belong in wrappers / inner_wrappers."
-            )
-        else:
-            # Raw async function (or anything else) -> Gate validates it.
-            result.append(Gate(item))
-    return result
+    return [_coerce_gate(item, index=i) for i, item in enumerate(items or [])]
 
 
 class MiddlewareChain(Generic[_P, _R]):
@@ -205,6 +218,29 @@ class MiddlewareChain(Generic[_P, _R]):
         new._exit = self._exit.copy_user_only()
         new._inner = self._inner.copy_user_only()
         return new
+
+    # ------------------------------------------------------------------
+    # User-middleware registration (extends the constructor's user layer;
+    # coerced/role-checked like a slot; ordered, not deduplicated)
+    # ------------------------------------------------------------------
+
+    def add_wrapper(self, w: Wrapper[_P, _R] | Callable[..., Any]) -> None:
+        """Append a user outer wrapper (outermost band). Runs around the whole call."""
+        self._outer.add_user(_coerce_wrapper(w))
+
+    def add_entry_gate(
+        self, g: Gate[_P, tuple[tuple, dict[str, Any]]] | Callable[..., Any]
+    ) -> None:
+        """Append a user entry gate. Transforms the input args before the core runs."""
+        self._entry.add_user(_coerce_gate(g))
+
+    def add_exit_gate(self, g: Gate[[_R], _R] | Callable[..., Any]) -> None:
+        """Append a user exit gate. Transforms the return value after the core runs."""
+        self._exit.add_user(_coerce_gate(g))
+
+    def add_inner_wrapper(self, w: Wrapper[_P, _R] | Callable[..., Any]) -> None:
+        """Append a user inner wrapper (innermost band). Runs inside the gates, hugging the core."""
+        self._inner.add_user(_coerce_wrapper(w))
 
     # ------------------------------------------------------------------
     # System-middleware registration (never touches the user layer)

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guardrail_gates.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guardrail_gates.py
@@ -1,0 +1,242 @@
+"""Unit tests for the guardrail middleware gates (guardrail_gates.py).
+
+These replace the LLMGuardrailsMixin seam: input guards -> entry gate, output guards ->
+exit gate, both delegating to GuardRunner. Tests exercise the gates directly via
+apply_entry / apply_exit, and end-to-end through a MiddlewareChain wired the way
+ModelInvoker wires them (input as sys entry position="after", output as sys exit).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from railtracks.guardrails.core import (
+    Guard,
+    GuardrailBlockedError,
+    GuardrailDecision,
+    InputGuard,
+    LLMGuardrailEvent,
+    OutputGuard,
+)
+from railtracks.guardrails.llm.guardrail_gates import (
+    guardrail_input_gate,
+    guardrail_output_gate,
+)
+from railtracks.llm import AssistantMessage, MessageHistory, UserMessage
+from railtracks.llm.content import ToolCall
+from railtracks.llm.response import MessageInfo, Response
+from railtracks.middleware import MiddlewareChain
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+class FnInputGuard(InputGuard):
+    def __init__(self, fn, name: str | None = None):
+        super().__init__(name=name)
+        self._fn = fn
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        return self._fn(event)
+
+
+class FnOutputGuard(OutputGuard):
+    def __init__(self, fn, name: str | None = None):
+        super().__init__(name=name)
+        self._fn = fn
+
+    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        return self._fn(event)
+
+
+def _content_response(text: str = "hi") -> Response:
+    return Response(message=AssistantMessage(text), message_info=MessageInfo(model_name="m"))
+
+
+def _tool_call_response() -> Response:
+    msg = AssistantMessage(content=[ToolCall(identifier="1", name="foo", arguments={})])
+    return Response(message=msg, message_info=MessageInfo(model_name="m"))
+
+
+# --------------------------------------------------------------------------- input gate
+
+
+class TestInputGate:
+    @pytest.mark.asyncio
+    async def test_empty_input_rails_passes_through(self):
+        gate = guardrail_input_gate(Guard(input=[]))
+        args, kwargs = await gate.apply_entry(MessageHistory([UserMessage("x")]), None, None)
+        assert kwargs == {}
+        assert isinstance(args[0], MessageHistory)
+
+    @pytest.mark.asyncio
+    async def test_allow_passes_through_unchanged(self):
+        gate = guardrail_input_gate(
+            Guard(input=[FnInputGuard(lambda _e: GuardrailDecision.allow(reason="ok"))])
+        )
+        mh = MessageHistory([UserMessage("x")])
+        args, kwargs = await gate.apply_entry(mh, None, None)
+        assert args[0] is mh  # unchanged object flows through
+
+    @pytest.mark.asyncio
+    async def test_block_raises(self):
+        gate = guardrail_input_gate(
+            Guard(
+                input=[
+                    FnInputGuard(
+                        lambda _e: GuardrailDecision.block(reason="nope", user_facing_message="u"),
+                        name="blocker",
+                    )
+                ]
+            )
+        )
+        with pytest.raises(GuardrailBlockedError) as exc:
+            await gate.apply_entry(MessageHistory([UserMessage("x")]), None, None)
+        assert exc.value.reason == "nope"
+        assert exc.value.user_facing_message == "u"
+        assert exc.value.rail_name == "blocker"
+        assert exc.value.traces and exc.value.traces[-1].action == "block"
+
+    @pytest.mark.asyncio
+    async def test_transform_forwards_new_messages_and_keeps_schema_tools(self):
+        new_hist = MessageHistory([UserMessage("redacted")])
+        gate = guardrail_input_gate(
+            Guard(
+                input=[
+                    FnInputGuard(
+                        lambda _e: GuardrailDecision.transform_messages(
+                            messages=new_hist, reason="edit"
+                        )
+                    )
+                ]
+            )
+        )
+        schema, tools = object(), ["t"]
+        args, kwargs = await gate.apply_entry(MessageHistory([UserMessage("x")]), schema, tools)
+        # full (messages, schema, tools) replacement — schema/tools preserved
+        assert args == (new_hist, schema, tools)
+        assert kwargs == {}
+
+
+# --------------------------------------------------------------------------- output gate
+
+
+class TestOutputGate:
+    @pytest.mark.asyncio
+    async def test_empty_output_rails_passes_through(self):
+        gate = guardrail_output_gate(Guard(output=[]))
+        resp = _content_response()
+        assert await gate.apply_exit(resp) is resp
+
+    @pytest.mark.asyncio
+    async def test_intermediate_tool_call_passes_through_untouched(self):
+        # A blocking output guard must NOT fire on an intermediate tool-call turn.
+        gate = guardrail_output_gate(
+            Guard(output=[FnOutputGuard(lambda _e: GuardrailDecision.block(reason="should not run"))])
+        )
+        resp = _tool_call_response()
+        assert await gate.apply_exit(resp) is resp  # unchanged, no raise
+
+    @pytest.mark.asyncio
+    async def test_terminal_block_raises(self):
+        gate = guardrail_output_gate(
+            Guard(output=[FnOutputGuard(lambda _e: GuardrailDecision.block(reason="bad output"))])
+        )
+        with pytest.raises(GuardrailBlockedError) as exc:
+            await gate.apply_exit(_content_response("evil"))
+        assert exc.value.traces[-1].phase == "llm_output"
+
+    @pytest.mark.asyncio
+    async def test_terminal_transform_preserves_message_info(self):
+        new_msg = AssistantMessage("sanitized")
+        gate = guardrail_output_gate(
+            Guard(
+                output=[
+                    FnOutputGuard(
+                        lambda _e: GuardrailDecision.transform_output(
+                            output_message=new_msg, reason="fix"
+                        )
+                    )
+                ]
+            )
+        )
+        info = MessageInfo(input_tokens=3, output_tokens=5, model_name="m")
+        resp = Response(message=AssistantMessage("raw"), message_info=info)
+        out = await gate.apply_exit(resp)
+        assert isinstance(out, Response)
+        assert out.message is new_msg
+        assert out.message_info is info
+
+    @pytest.mark.asyncio
+    async def test_terminal_allow_passes_through(self):
+        gate = guardrail_output_gate(
+            Guard(output=[FnOutputGuard(lambda _e: GuardrailDecision.allow(reason="ok"))])
+        )
+        resp = _content_response()
+        assert await gate.apply_exit(resp) is resp
+
+
+# --------------------------------------------------------------------------- wired like ModelInvoker
+
+
+def _pii_input_guard():
+    from railtracks.guardrails.llm import PIIRedactInputGuard
+
+    return PIIRedactInputGuard()
+
+
+class TestWiredIntoMiddlewareChain:
+    """Wire the gates the way NodeBuilder.llm wires them onto ModelInvoker and run."""
+
+    def _chain(self, guard: Guard) -> MiddlewareChain:
+        mc = MiddlewareChain()
+        if guard.input:
+            mc.register_sys_entry_gate(guardrail_input_gate(guard), position="after")
+        if guard.output:
+            mc.register_sys_exit_gate(guardrail_output_gate(guard))
+        return mc
+
+    @pytest.mark.asyncio
+    async def test_input_redaction_reaches_core(self):
+        seen = {}
+
+        async def core(messages, schema, tools):
+            seen["messages"] = messages
+            return _content_response("done")
+
+        mc = self._chain(Guard(input=[_pii_input_guard()]))
+        original = MessageHistory([UserMessage("email me at alice@example.com")])
+        await mc.run(core, original, None, None)
+
+        # The core saw redacted content; the caller's original is untouched.
+        assert "[EMAIL_ADDRESS]" in seen["messages"][0].content
+        assert "alice@example.com" in original[0].content
+
+    @pytest.mark.asyncio
+    async def test_input_gate_runs_every_round_no_latch(self):
+        # No latch: redaction is re-applied on every model call, so a second round
+        # (same original history) still reaches the core redacted.
+        calls = []
+
+        async def core(messages, schema, tools):
+            calls.append(messages[0].content)
+            return _content_response()
+
+        mc = self._chain(Guard(input=[_pii_input_guard()]))
+        original = MessageHistory([UserMessage("ssn 123-45-6789")])
+        await mc.run(core, original, None, None)
+        await mc.run(core, original, None, None)
+
+        assert len(calls) == 2
+        assert all("[US_SSN]" in c for c in calls)  # redacted every round
+
+    @pytest.mark.asyncio
+    async def test_output_block_propagates_through_run(self):
+        async def core(messages, schema, tools):
+            return _content_response("leak")
+
+        mc = self._chain(
+            Guard(output=[FnOutputGuard(lambda _e: GuardrailDecision.block(reason="blocked"))])
+        )
+        with pytest.raises(GuardrailBlockedError):
+            await mc.run(core, MessageHistory([UserMessage("q")]), None, None)

--- a/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middleware/test_middleware.py
@@ -9,7 +9,7 @@ MiddlewareChain — ordered bands: wrappers -> entry_gate
 """
 
 import pytest
-from railtracks.middleware import Gate, MiddlewareChain, gate, wrapper
+from railtracks.middleware import Gate, MiddlewareChain, Wrapper, gate, wrapper
 from railtracks.middleware.set import _LayeredList
 
 # ---------------------------------------------------------------------------
@@ -305,6 +305,94 @@ class TestMiddlewareChainSysRegistration:
         ms = MiddlewareChain(exit_gate=[user_g])
         ms.register_sys_exit_gate(sys_g)
         assert ms._exit.ordered() == [user_g, sys_g]
+
+    def test_sys_entry_position_before_is_default(self):
+        user_g = _noop_gate()
+        sys_g = _noop_gate()
+        ms = MiddlewareChain(entry_gate=[user_g])
+        ms.register_sys_entry_gate(sys_g)  # default position="before"
+        assert ms._entry.ordered() == [sys_g, user_g]
+
+    def test_sys_entry_position_after_runs_last(self):
+        user_g = _noop_gate()
+        sys_g = _noop_gate()
+        ms = MiddlewareChain(entry_gate=[user_g])
+        ms.register_sys_entry_gate(sys_g, position="after")
+        assert ms._entry.ordered() == [user_g, sys_g]
+
+    def test_sys_entry_before_and_after_bracket_user(self):
+        user_g = _noop_gate()
+        before_g = _noop_gate()
+        after_g = _noop_gate()
+        ms = MiddlewareChain(entry_gate=[user_g])
+        ms.register_sys_entry_gate(before_g, position="before")
+        ms.register_sys_entry_gate(after_g, position="after")
+        assert ms._entry.ordered() == [before_g, user_g, after_g]
+
+    @pytest.mark.asyncio
+    async def test_sys_entry_after_runs_between_user_and_core(self):
+        # Guardrail placement: a sys entry gate registered position="after" must
+        # run after the user entry gate and immediately before the core.
+        order = []
+
+        def make(tag):
+            @gate
+            async def g(*a, **k):
+                order.append(tag)
+                return a, k
+
+            return g
+
+        ms = MiddlewareChain(entry_gate=[make("user")])
+        ms.register_sys_entry_gate(make("sys-before"), position="before")
+        ms.register_sys_entry_gate(make("sys-after"), position="after")
+
+        async def core():
+            order.append("core")
+
+        await ms.run(core)
+        assert order == ["sys-before", "user", "sys-after", "core"]
+
+
+class TestMiddlewareChainUserRegistration:
+    def test_add_appends_to_user_layer(self):
+        w, ig, xg, iw = _noop_wrapper(), _noop_gate(), _noop_gate(), _noop_wrapper()
+        ms = MiddlewareChain()
+        ms.add_wrapper(w)
+        ms.add_entry_gate(ig)
+        ms.add_exit_gate(xg)
+        ms.add_inner_wrapper(iw)
+        assert ms.wrappers == [w]
+        assert ms.entry_gate == [ig]
+        assert ms.exit_gate == [xg]
+        assert ms.inner_wrappers == [iw]
+
+    def test_add_preserves_order_and_keeps_duplicates(self):
+        a, b = _noop_gate(), _noop_gate()
+        ms = MiddlewareChain(entry_gate=[a])
+        ms.add_entry_gate(b)
+        ms.add_entry_gate(a)  # user layer is not deduplicated
+        assert ms.entry_gate == [a, b, a]
+
+    def test_add_coerces_raw_function(self):
+        async def raw_w(call, *a, **k):
+            return await call(*a, **k)
+
+        async def raw_g(*a, **k):
+            return a, k
+
+        ms = MiddlewareChain()
+        ms.add_wrapper(raw_w)
+        ms.add_entry_gate(raw_g)
+        assert isinstance(ms.wrappers[0], Wrapper)
+        assert isinstance(ms.entry_gate[0], Gate)
+
+    def test_add_rejects_wrong_band_type(self):
+        ms = MiddlewareChain()
+        with pytest.raises(TypeError):
+            ms.add_wrapper(_noop_gate())  # gate in a wrapper band
+        with pytest.raises(TypeError):
+            ms.add_entry_gate(_noop_wrapper())  # wrapper in a gate band
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wires guardrails into the new middleware architecture so `agent_node(guardrails=Guard(...))` works again after the NodeBuilder unification. Guardrails are expressed as **middleware gates on the model call** rather than the old `Guarded*` subclasses/mixin: input rails become an entry gate that runs as the *last* check before the model (after context injection and any user middleware), and output rails become an exit gate that has the *last word* on the response.

The existing guardrails core (`GuardRunner`, `Guard`, `GuardrailDecision`, built-in rails) is reused verbatim. Covers tasks 1–4 of the issue; observability (traces), orphaned-module removal, and the full test/doc sweep are intentionally left for follow-up PRs to keep this one reviewable.

closes #1229

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

**What changed**
- New `guardrails/llm/guardrail_gates.py`: `guardrail_input_gate` / `guardrail_output_gate` adapt a `Guard` into middleware gates, delegating to `GuardRunner` and translating its `(value, traces, decision)` result into the gate contract (transform → forward, BLOCK → raise `GuardrailBlockedError`, ALLOW → pass through). Output rails only fire on the final reply.
- `MiddlewareChain.register_sys_entry_gate` gained a `position="before"|"after"` arg so the input guard can run as the innermost entry gate (hugging the model call); also added user-layer `add_wrapper`/`add_entry_gate`/`add_exit_gate`/`add_inner_wrapper`.
- `NodeBuilder.llm` / `agent_node` accept `guardrails=` and register the gates on the `ModelInvoker` as fixed, non-reorderable system gates (mirrors context injection).
- Fix: `llm_invoke` re-raises `NodeInvocationError` before its generic `except → LLMError`, so a `GuardrailBlockedError` raised from a gate surfaces as-is instead of being masked as an `LLMError`.

**Not in this PR (follow-ups):** guardrail-trace observability (routed through a single `_record_guard_traces` seam, currently a debug-log placeholder), removal of the orphaned `Guarded*` classes + `LLMGuardrailsMixin`, and the full test/doc update (incl. rewriting the legacy `..._uses_guarded_base` integration tests).

**Example** :

```python
import railtracks as rt
from railtracks.guardrails import Guard, GuardrailDecision, InputGuard, LLMGuardrailEvent


class BlockPasswords(InputGuard):
    """Block any request that mentions a password before it reaches the model."""

    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
        text = " ".join(m.content for m in event.messages if isinstance(m.content, str))
        if "password" in text.lower():
            return GuardrailDecision.block(reason="passwords are not allowed")
        return GuardrailDecision.allow(reason="ok")


agent = rt.agent_node(
    name="assistant",
    llm=rt.llm.OpenAILLM("gpt-4o-mini"),
    guardrails=Guard(input=[BlockPasswords()]),
)

flow = rt.Flow(name="demo", entry_point=agent)

print(flow.invoke("What's the weather like?"))  # passes → normal reply
try: 
    flow.invoke("What is the admin password?")  # raises GuardrailBlockedError before the model call
except Exception as e:
    print(repr(e))
```