### PR TITLE
1206: call-scoped streaming — rt.astream, channels, unified stream_callback

### DIFF
--- a/docs/advanced_usage/config.md
+++ b/docs/advanced_usage/config.md
@@ -20,7 +20,8 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 ### Advanced Settings
 
 - **`context`** (`Dict[str, Any]`): Global context variables for execution
-- **`broadcast_callback`** (`Callable | dict[str, Callable]`): Passive listener (or per-channel dict) for streamed/broadcast items; never enables streaming
+- **`broadcast_callback`** (`Callable | dict[str, Callable]`): Passive listener (or per-channel dict) for one-off `rt.broadcast` events
+- **`stream_callback`** (`Callable | dict[str, Callable]`): Passive listener (or per-channel dict) for `rt.broadcast_stream` chunks (LLM tokens included); never enables streaming
 - **`prompt_injection`** (`bool`): Automatically inject prompts from context variables
 - **`save_state`** (`bool`): Save execution state to the `.railtracks` data directory (see [Data directory resolution](#data-directory-railtracks) below)
 
@@ -30,7 +31,8 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 # Default configuration values
 timeout = 150.0                   # seconds
 end_on_error = False              # continue on errors
-broadcast_callback = None         # no bus listener
+broadcast_callback = None         # no event listener
+stream_callback = None            # no stream-chunk listener
 prompt_injection = True           # enable prompt injection
 save_state = True                 # save execution state
 ```

--- a/docs/advanced_usage/config.md
+++ b/docs/advanced_usage/config.md
@@ -20,7 +20,7 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 ### Advanced Settings
 
 - **`context`** (`Dict[str, Any]`): Global context variables for execution
-- **`broadcast_callback`** (`Callable`): Callback function for broadcast messages
+- **`stream_callback`** (`Callable | dict[str, Callable]`): Callback (or per-channel dict) for streamed/broadcast items; also enables push-mode token streaming
 - **`prompt_injection`** (`bool`): Automatically inject prompts from context variables
 - **`save_state`** (`bool`): Save execution state to the `.railtracks` data directory (see [Data directory resolution](#data-directory-railtracks) below)
 
@@ -30,7 +30,7 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 # Default configuration values
 timeout = 150.0                   # seconds
 end_on_error = False              # continue on errors
-broadcast_callback = None         # no broadcast callback
+stream_callback = None            # no stream/broadcast callback
 prompt_injection = True           # enable prompt injection
 save_state = True                 # save execution state
 ```
@@ -139,7 +139,7 @@ def debug_callback(message: str):
     print(f"Broadcast: {message}")
 
 with rt.session(
-    broadcast_callback=debug_callback,
+    stream_callback=debug_callback,
 ):
     response = await rt.call(
         my_agent,

--- a/docs/advanced_usage/config.md
+++ b/docs/advanced_usage/config.md
@@ -20,7 +20,7 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 ### Advanced Settings
 
 - **`context`** (`Dict[str, Any]`): Global context variables for execution
-- **`stream_callback`** (`Callable | dict[str, Callable]`): Callback (or per-channel dict) for streamed/broadcast items; also enables push-mode token streaming
+- **`broadcast_callback`** (`Callable | dict[str, Callable]`): Passive listener (or per-channel dict) for streamed/broadcast items; never enables streaming
 - **`prompt_injection`** (`bool`): Automatically inject prompts from context variables
 - **`save_state`** (`bool`): Save execution state to the `.railtracks` data directory (see [Data directory resolution](#data-directory-railtracks) below)
 
@@ -30,7 +30,7 @@ Configuration parameters follow a specific precedence order, allowing you to ove
 # Default configuration values
 timeout = 150.0                   # seconds
 end_on_error = False              # continue on errors
-stream_callback = None            # no stream/broadcast callback
+broadcast_callback = None         # no bus listener
 prompt_injection = True           # enable prompt injection
 save_state = True                 # save execution state
 ```
@@ -139,7 +139,7 @@ def debug_callback(message: str):
     print(f"Broadcast: {message}")
 
 with rt.session(
-    stream_callback=debug_callback,
+    broadcast_callback=debug_callback,
 ):
     response = await rt.call(
         my_agent,

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -36,22 +36,25 @@ A `Stream` is also awaitable — `await stream` consumes it to completion and re
 --8<-- "docs/scripts/streaming.py:flow_astream"
 ```
 
-## Push — `stream_callback`
+## Push — `Stream.route()` and `broadcast_callback`
 
-If you prefer callbacks over iteration, attach a `stream_callback` to a `Flow` (scoped to its runs) or set one globally with `rt.set_config` — never construct a `Session` yourself, it is an internal object. Its presence enables streaming for top-level calls, and the framework invokes your callback per chunk while `.invoke()` / `rt.call` still return the complete response:
-
-```python
---8<-- "docs/scripts/streaming.py:stream_callback"
-```
-
-To route chunks from different sources, pass a dict mapping channel names to callbacks (see [Channels](#channels) below). Chunks on channels without a registered callback are dropped:
+**Callbacks never enable streaming — only `astream` does.** For push-style consumption of a streamed call, `route()` the stream: it dispatches each chunk to your handler(s) by channel and returns the final result. Never construct a `Session` yourself — it is an internal object:
 
 ```python
---8<-- "docs/scripts/streaming.py:stream_callback_channels"
+--8<-- "docs/scripts/streaming.py:route"
 ```
 
-!!! Note "One streaming callback"
-    `stream_callback` is the single push-mode consumer: it receives every streamed **and** broadcast item (`rt.broadcast` notes included), routes per channel when given a dict, and its presence enables token streaming for top-level calls. (The former `broadcast_callback` has been merged into it.) The end-of-run `payload_callback` is separate — it fires once with the serialized session payload.
+Separately, a **`broadcast_callback`** (on the `Flow`, or globally via `rt.set_config`) is a *passive* session-wide listener: it receives every streamed/broadcast item of the run — including one-off `rt.broadcast` progress notes and chunks from *any* scope (e.g. nested `astream`s) — but it does not turn streaming on. Prefer the dict form (channel name → callback); a bare callable is the firehose and will also receive token chunks whenever something streams:
+
+```python
+--8<-- "docs/scripts/streaming.py:broadcast_callback"
+```
+
+!!! Note "Which push consumer?"
+    `route()` = **this call's** chunks (per-call isolated, enables the streaming, returns the result). `broadcast_callback` = **everything in the session**, passively (buffered runs included — explicit `rt.broadcast`/`rt.broadcast_stream` items always flow). The end-of-run `payload_callback` is separate — it fires once with the serialized session payload.
+
+!!! Tip "Unused-callback warnings"
+    If a `broadcast_callback` (or any of its channel entries) never fires during a session, a warning is logged at close — distinguishing "nothing was broadcast (did you forget `astream`?)" from "traffic existed on other channels (channel-name typo?)". `route()` logs the same for handler channels that never matched.
 
 ## Custom Nodes — `rt.broadcast_stream`
 
@@ -71,7 +74,7 @@ Every chunk is emitted on a named channel (default: `"default"`). Channels let m
 
 - Producers: `rt.broadcast_stream(gen, channel="draft")`, `rt.broadcast("note", channel="progress")`.
 - Pull consumers: chain `.on_channel("final")` on the stream handle to yield only that channel (by default a stream yields everything in the run).
-- Push consumers: `stream_callback={"draft": fn1, "final": fn2}` routes per channel.
+- Push consumers: `stream.route({"draft": fn1, "final": fn2})` for one call, or a passive `broadcast_callback` dict for the whole session.
 
 ```python
 --8<-- "docs/scripts/streaming.py:custom_channels"
@@ -79,7 +82,7 @@ Every chunk is emitted on a named channel (default: `"default"`). Channels let m
 
 ### Binding a prebuilt agent to a channel — `stream_channel`
 
-Custom nodes pick their channel at each `broadcast_stream` call. Prebuilt agents bind theirs at construction with `agent_node(..., stream_channel="...")` — every token the agent streams (including every round of its tool-calling loop) is emitted on that bus. Combined with a `stream_callback` dict, different agents in one flow route to different consumers:
+Custom nodes pick their channel at each `broadcast_stream` call. Prebuilt agents bind theirs at construction with `agent_node(..., stream_channel="...")` — every token the agent streams (including every round of its tool-calling loop) is emitted on that bus. Combined with a passive `broadcast_callback` dict, different agents in one flow route to different consumers:
 
 ```python
 --8<-- "docs/scripts/streaming.py:agent_stream_channel"
@@ -89,7 +92,7 @@ Note the nested `rt.astream(writer, ...)` inside the pipeline: nested `rt.call`s
 
 ## Consuming a Channel From Inside a Run
 
-`rt.astream` and `stream_callback` both consume at the *top* of a run. To consume a channel **from inside** a run — e.g. an orchestrator node that runs a child concurrently and folds the child's live tokens into its own work — use `rt.context.get_stream(channel)`:
+`rt.astream` (with or without `route()`) and `broadcast_callback` both consume at the *top* of a run. To consume a channel **from inside** a run — e.g. an orchestrator node that runs a child concurrently and folds the child's live tokens into its own work — use `rt.context.get_stream(channel)`:
 
 ```python
 --8<-- "docs/scripts/streaming.py:get_stream"
@@ -134,4 +137,4 @@ This is what the framework uses internally, and what you pass to `rt.broadcast_s
     Token streaming with **tool calling** is currently supported on OpenAI models only. Streamed runs of tool-calling agents on other providers automatically fall back to a buffered model call (a warning is logged) — the final result is unaffected; you just don't get incremental chunks.
 
 !!! Warning "Deprecated: `stream=True` on the model"
-    Constructing a model with `stream=True` (e.g. `OpenAILLM("gpt-4o", stream=True)`) is deprecated. It no longer changes agent behavior — agents built from such models return complete responses. Use `rt.astream(...)` or a `stream_callback` instead.
+    Constructing a model with `stream=True` (e.g. `OpenAILLM("gpt-4o", stream=True)`) is deprecated. It no longer changes agent behavior — agents built from such models return complete responses. Use `rt.astream(...)` (optionally with `.route(...)`) instead.

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -2,43 +2,136 @@
 
 ## What Is Streaming?
 
-Streaming is a way to make your agent feel more responsive. Instead of waiting for the complete response, you can stream intermediate results as they arrive.
+Streaming makes your agent feel responsive: instead of waiting for the complete response, token chunks are delivered as they arrive.
 
+## The One Rule
 
-## Streaming Support
-Railtracks supports streaming responses from your agent. To interact with a stream, just set the appropriate flag when creating your LLM.
+**Streaming is requested at the call, not baked into the agent.** The same agent object serves streaming and non-streaming runs:
 
-```python
---8<-- "docs/scripts/streaming.py:streaming_flag"
-```
+- `rt.call(agent, ...)` runs buffered — no streaming overhead, no chunks.
+- `rt.astream(agent, ...)` streams — the agent's LLM responses are delivered chunk-by-chunk while it runs.
 
-When you call the LLM, it will return a generator that you can iterate through:
+Streaming is also **frame-local**: only the node you invoke streams its LLM responses. Nested `rt.call` children (e.g. agents used as tools) run buffered — you will not see their tokens interleaved with the entry agent's.
 
-```python
---8<-- "docs/scripts/streaming.py:streaming_usage"
-```
+## Pull — `rt.astream`
 
-## Agent Support
-
-Agents in Railtracks also support streamed responses. When creating your agent, you provide an LLM with streaming enabled:
+`rt.astream` returns a `Stream` handle: an async iterator that yields **only** `str` chunks. The final result is available separately via `.result` once the stream is exhausted, so there is never any ambiguity between a chunk and the final value:
 
 ```python
---8<-- "docs/scripts/streaming.py:streaming_with_agents"
+--8<-- "docs/scripts/streaming.py:astream_basic"
 ```
 
-The output of the agent will be a generator containing a sequence of strings, followed by the complete message.
+A `Stream` is also awaitable — `await stream` consumes it to completion and returns the final result:
 
-!!! Example "Usage"
-    ```python    
-    --8<-- "docs/scripts/streaming.py:streaming_agent_usage"
-    ```
-    `
+```python
+--8<-- "docs/scripts/streaming.py:astream_await"
+```
 
-!!! Warning
-    When using streaming, you should fully exhaust the returned object within the session. If you do this outside of the session, the visualizer suite will not work as expected.
+!!! Note "The final result is authoritative"
+    `stream.result` may differ from the concatenation of the streamed chunks — for example when output guardrails gate or correct the buffered response after the raw tokens were streamed. Treat the chunks as live progress and `.result` as the answer.
 
-!!! Warning 
-    Streaming is only supported for tool-calling agents if you are using openai.
+`Flow` supports the same pattern:
 
+```python
+--8<-- "docs/scripts/streaming.py:flow_astream"
+```
 
+## Push — `stream_callback`
 
+If you prefer callbacks over iteration, attach a `stream_callback` to a `Flow` (scoped to its runs) or set one globally with `rt.set_config` — never construct a `Session` yourself, it is an internal object. Its presence enables streaming for top-level calls, and the framework invokes your callback per chunk while `.invoke()` / `rt.call` still return the complete response:
+
+```python
+--8<-- "docs/scripts/streaming.py:stream_callback"
+```
+
+To route chunks from different sources, pass a dict mapping channel names to callbacks (see [Channels](#channels) below). Chunks on channels without a registered callback are dropped:
+
+```python
+--8<-- "docs/scripts/streaming.py:stream_callback_channels"
+```
+
+!!! Note "One streaming callback"
+    `stream_callback` is the single push-mode consumer: it receives every streamed **and** broadcast item (`rt.broadcast` notes included), routes per channel when given a dict, and its presence enables token streaming for top-level calls. (The former `broadcast_callback` has been merged into it.) The end-of-run `payload_callback` is separate — it fires once with the serialized session payload.
+
+## Custom Nodes — `rt.broadcast_stream`
+
+Inside a custom node, call the model's streaming API directly and forward the stream to whoever is consuming the run with `rt.broadcast_stream`. It broadcasts each `str` chunk and returns the model's final complete `Response` (use `response.text` for its text content), so your node builds its return value as usual:
+
+```python
+--8<-- "docs/scripts/streaming.py:custom_node"
+```
+
+If nothing is listening (a plain `rt.call` with no consumers), the chunks are simply dropped and the node behaves exactly like a buffered call — the same node works in both modes.
+
+For one-off chunks (progress messages, notes), `rt.broadcast(item, channel=...)` publishes a single item the same way.
+
+### Channels
+
+Every chunk is emitted on a named channel (default: `"default"`). Channels let multiple streams coexist within one run and let consumers filter or route:
+
+- Producers: `rt.broadcast_stream(gen, channel="draft")`, `rt.broadcast("note", channel="progress")`.
+- Pull consumers: chain `.on_channel("final")` on the stream handle to yield only that channel (by default a stream yields everything in the run).
+- Push consumers: `stream_callback={"draft": fn1, "final": fn2}` routes per channel.
+
+```python
+--8<-- "docs/scripts/streaming.py:custom_channels"
+```
+
+### Binding a prebuilt agent to a channel — `stream_channel`
+
+Custom nodes pick their channel at each `broadcast_stream` call. Prebuilt agents bind theirs at construction with `agent_node(..., stream_channel="...")` — every token the agent streams (including every round of its tool-calling loop) is emitted on that bus. Combined with a `stream_callback` dict, different agents in one flow route to different consumers:
+
+```python
+--8<-- "docs/scripts/streaming.py:agent_stream_channel"
+```
+
+Note the nested `rt.astream(writer, ...)` inside the pipeline: nested `rt.call`s run buffered (frame-local rule), so a child agent must be *opted in* with a nested `astream` for its tokens to reach the bus. The binding is per node class, not per invocation — two agents needing different buses should be two `agent_node`s.
+
+## Consuming a Channel From Inside a Run
+
+`rt.astream` and `stream_callback` both consume at the *top* of a run. To consume a channel **from inside** a run — e.g. an orchestrator node that runs a child concurrently and folds the child's live tokens into its own work — use `rt.context.get_stream(channel)`:
+
+```python
+--8<-- "docs/scripts/streaming.py:get_stream"
+```
+
+**Termination — counted end-markers.** Every `rt.broadcast_stream` is a bounded production: when it finishes (even if the producer raised), it publishes a `StreamEnd` marker on its channel, after all of its chunks. `get_stream` counts these markers:
+
+- `streams=1` (default): stop after one production — the single-producer fold above ends by itself, no extra signal needed.
+- `streams=N`: several producers share the channel; stop after N productions. (Channels are reused in practice — e.g. each round of a tool-calling agent is one production on the agent's channel.)
+- `streams=None`: open-ended feed (unknown producers, or bare `rt.broadcast` items, which carry no markers) — bound the loop yourself with `break` or `until=task`.
+- `until=task` (optional, combines with the above; whichever fires first wins): also useful as a **safety net** for a producer that crashes *before ever reaching* `broadcast_stream`, in which case no marker is published.
+
+A channel itself never "closes" — a marker ends one production, not the channel. Other rules:
+
+- Only chunks in the current stream scope are delivered (a child started with `rt.call` here is included; unrelated concurrent runs are not). Scope is keyed by `(stream_id, channel)`; in a plain non-streamed run `stream_id` is `None`, so give concurrent independent folds distinct channel names.
+- The producer must broadcast explicitly (`rt.broadcast_stream` / `rt.broadcast`) — a nested `rt.call` is buffered otherwise (frame-local rule).
+- Subscription is eager (at the `get_stream()` call), so chunks emitted before the loop starts are not missed.
+
+!!! Tip "Simpler for a single call"
+    To fold just one child call's stream, a nested `rt.astream(child, ...)` also works in one line — it launches the child, enables streaming on it, and isolates by its own scope. Reach for `get_stream` when several producers share a channel, or when you consume while doing other work in the same frame.
+
+## Model-Level Streaming
+
+At the lowest level, every model exposes `astream_chat` (and `astream_chat_with_tools` / `astream_structured`): async generators that yield `str` chunks followed by a single final `Response`:
+
+```python
+--8<-- "docs/scripts/streaming.py:model_astream"
+```
+
+This is what the framework uses internally, and what you pass to `rt.broadcast_stream` in custom nodes.
+
+## Behavior Details
+
+- **Tool-calling agents**: all text produced during the tool-call loop streams (including text in rounds that end in tool calls); tool-call arguments are not streamed. Tool nodes themselves run buffered (frame-local rule).
+- **Structured output**: the raw JSON tokens stream; the final `StructuredResponse` is parsed and validated once the stream completes, so a schema failure surfaces at the end of the stream.
+- **Guardrails**: output guardrails run on the complete buffered response. Streamed chunks are raw — already-emitted tokens cannot be recalled — but the final result is always the gated one.
+- **Errors**: if the node fails mid-stream, the exception is raised out of the `async for` loop (or the `await`), exactly like `rt.call`.
+- **Early exit**: `break`-ing out of the loop does not cancel the run — it continues to completion in the background. `await stream` afterwards to get the final result.
+- **Timeouts**: the session's `timeout` applies to the whole streamed run as a wall-clock limit.
+
+!!! Warning "Provider support for tool calling"
+    Token streaming with **tool calling** is currently supported on OpenAI models only. Streamed runs of tool-calling agents on other providers automatically fall back to a buffered model call (a warning is logged) — the final result is unaffected; you just don't get incremental chunks.
+
+!!! Warning "Deprecated: `stream=True` on the model"
+    Constructing a model with `stream=True` (e.g. `OpenAILLM("gpt-4o", stream=True)`) is deprecated. It no longer changes agent behavior — agents built from such models return complete responses. Use `rt.astream(...)` or a `stream_callback` instead.

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -36,7 +36,7 @@ A `Stream` is also awaitable — `await stream` consumes it to completion and re
 --8<-- "docs/scripts/streaming.py:flow_astream"
 ```
 
-## Push — `Stream.route()` and `broadcast_callback`
+## Push — `Stream.route()` and `stream_callback`
 
 **Callbacks never enable streaming — only `astream` does.** For push-style consumption of a streamed call, `route()` the stream: it dispatches each chunk to your handler(s) by channel and returns the final result. Never construct a `Session` yourself — it is an internal object:
 
@@ -44,17 +44,19 @@ A `Stream` is also awaitable — `await stream` consumes it to completion and re
 --8<-- "docs/scripts/streaming.py:route"
 ```
 
-Separately, a **`broadcast_callback`** (on the `Flow`, or globally via `rt.set_config`) is a *passive* session-wide listener: it receives every streamed/broadcast item of the run — including one-off `rt.broadcast` progress notes and chunks from *any* scope (e.g. nested `astream`s) — but it does not turn streaming on. Prefer the dict form (channel name → callback); a bare callable is the firehose and will also receive token chunks whenever something streams:
+Separately, a **`stream_callback`** (on the `Flow`, or globally via `rt.set_config`) is a *passive* session-wide listener for **stream chunks**: it receives every `rt.broadcast_stream` chunk of the run — LLM tokens included, from *any* scope (e.g. nested `astream`s) — but it does not turn streaming on. Prefer the dict form (channel name → callback); a bare callable is the firehose and receives every chunk on every channel.
+
+One-off **events** published with `rt.broadcast` (progress notes, tool events, …) ride a separate lane: they go to the **`broadcast_callback`** — see [Broadcasting](../../observability/tracking/broadcasting.md). Streams are continuous productions; broadcasts are discrete events — the two callbacks keep those mental models apart:
 
 ```python
---8<-- "docs/scripts/streaming.py:broadcast_callback"
+--8<-- "docs/scripts/streaming.py:stream_callback"
 ```
 
 !!! Note "Which push consumer?"
-    `route()` = **this call's** chunks (per-call isolated, enables the streaming, returns the result). `broadcast_callback` = **everything in the session**, passively (buffered runs included — explicit `rt.broadcast`/`rt.broadcast_stream` items always flow). The end-of-run `payload_callback` is separate — it fires once with the serialized session payload.
+    `route()` = **this call's** traffic (per-call isolated, enables the streaming, returns the result — it sees both chunks and events, separated by channel). `stream_callback` = **every streamed chunk in the session**, passively. `broadcast_callback` = **every `rt.broadcast` event in the session**, passively (buffered runs included — explicit broadcasts always flow). The end-of-run `payload_callback` is separate — it fires once with the serialized session payload.
 
 !!! Tip "Unused-callback warnings"
-    If a `broadcast_callback` (or any of its channel entries) never fires during a session, a warning is logged at close — distinguishing "nothing was broadcast (did you forget `astream`?)" from "traffic existed on other channels (channel-name typo?)". `route()` logs the same for handler channels that never matched.
+    If a `stream_callback` / `broadcast_callback` (or any of its channel entries) never fires during a session, a `UserWarning` is emitted at close (visible by default, no logging setup needed) — distinguishing "nothing streamed (did you forget `astream`?)" from "traffic existed on other channels (channel-name typo?)". It even flags lane mix-ups: a `broadcast_callback` on a channel that only carried stream chunks is pointed to `stream_callback`, and vice versa. `route()` emits the same for handler channels that never matched.
 
 ## Custom Nodes — `rt.broadcast_stream`
 
@@ -66,7 +68,7 @@ Inside a custom node, call the model's streaming API directly and forward the st
 
 If nothing is listening (a plain `rt.call` with no consumers), the chunks are simply dropped and the node behaves exactly like a buffered call — the same node works in both modes.
 
-For one-off chunks (progress messages, notes), `rt.broadcast(item, channel=...)` publishes a single item the same way.
+For one-off **events** (progress messages, notes), `rt.broadcast(item, channel=...)` publishes a single item — but on the event lane: it reaches `broadcast_callback` (and scoped consumers like `route()`/`get_stream`), not `stream_callback`.
 
 ### Channels
 
@@ -74,7 +76,7 @@ Every chunk is emitted on a named channel (default: `"default"`). Channels let m
 
 - Producers: `rt.broadcast_stream(gen, channel="draft")`, `rt.broadcast("note", channel="progress")`.
 - Pull consumers: chain `.on_channel("final")` on the stream handle to yield only that channel (by default a stream yields everything in the run).
-- Push consumers: `stream.route({"draft": fn1, "final": fn2})` for one call, or a passive `broadcast_callback` dict for the whole session.
+- Push consumers: `stream.route({"draft": fn1, "final": fn2})` for one call, or a passive `stream_callback` dict for the whole session.
 
 ```python
 --8<-- "docs/scripts/streaming.py:custom_channels"
@@ -82,7 +84,7 @@ Every chunk is emitted on a named channel (default: `"default"`). Channels let m
 
 ### Binding a prebuilt agent to a channel — `stream_channel`
 
-Custom nodes pick their channel at each `broadcast_stream` call. Prebuilt agents bind theirs at construction with `agent_node(..., stream_channel="...")` — every token the agent streams (including every round of its tool-calling loop) is emitted on that bus. Combined with a passive `broadcast_callback` dict, different agents in one flow route to different consumers:
+Custom nodes pick their channel at each `broadcast_stream` call. Prebuilt agents bind theirs at construction with `agent_node(..., stream_channel="...")` — every token the agent streams (including every round of its tool-calling loop) is emitted on that bus. Combined with a passive `stream_callback` dict, different agents in one flow route to different consumers:
 
 ```python
 --8<-- "docs/scripts/streaming.py:agent_stream_channel"
@@ -92,7 +94,7 @@ Note the nested `rt.astream(writer, ...)` inside the pipeline: nested `rt.call`s
 
 ## Consuming a Channel From Inside a Run
 
-`rt.astream` (with or without `route()`) and `broadcast_callback` both consume at the *top* of a run. To consume a channel **from inside** a run — e.g. an orchestrator node that runs a child concurrently and folds the child's live tokens into its own work — use `rt.context.get_stream(channel)`:
+`rt.astream` (with or without `route()`) and `stream_callback` both consume at the *top* of a run. To consume a channel **from inside** a run — e.g. an orchestrator node that runs a child concurrently and folds the child's live tokens into its own work — use `rt.context.get_stream(channel)`:
 
 ```python
 --8<-- "docs/scripts/streaming.py:get_stream"

--- a/docs/observability/tracking/broadcasting.md
+++ b/docs/observability/tracking/broadcasting.md
@@ -10,7 +10,7 @@ Railtracks supports basic **data broadcasting**, enabling you to receive these u
 
 ## Usage
 
-To enable broadcasting, provide a **callback function** to the `stream_callback` parameter in `set_config` (or on your `Flow`). It receives every broadcast item; pass a dict mapping channel name -> callback to route items per channel. Note: providing a `stream_callback` also enables token streaming for top-level calls (see [Streaming](../../integrations/llms/streaming.md)).
+To observe broadcasts, provide a **callback** to the `broadcast_callback` parameter on your `Flow` (or globally via `set_config`). Prefer the dict form mapping channel name -> callback to route items per channel; a bare callable receives every item on every channel. It is a *passive* listener — it never enables token streaming (see [Streaming](../../integrations/llms/streaming.md)); if it never fires during a session, a warning is logged at close.
 
 ```python
 --8<-- "docs/scripts/broadcast.py:callback_creation"

--- a/docs/observability/tracking/broadcasting.md
+++ b/docs/observability/tracking/broadcasting.md
@@ -10,7 +10,9 @@ Railtracks supports basic **data broadcasting**, enabling you to receive these u
 
 ## Usage
 
-To observe broadcasts, provide a **callback** to the `broadcast_callback` parameter on your `Flow` (or globally via `set_config`). Prefer the dict form mapping channel name -> callback to route items per channel; a bare callable receives every item on every channel. It is a *passive* listener — it never enables token streaming (see [Streaming](../../integrations/llms/streaming.md)); if it never fires during a session, a warning is logged at close.
+To observe broadcasts, provide a **callback** to the `broadcast_callback` parameter on your `Flow` (or globally via `set_config`). Prefer the dict form mapping channel name -> callback to route events per channel; a bare callable receives every event on every channel. If it never fires during a session, a `UserWarning` is emitted at close.
+
+`broadcast_callback` is the **event lane**: it receives the one-off items published with `rt.broadcast`. Continuous *stream* chunks — `rt.broadcast_stream` productions, including LLM token streams — ride a separate lane and go to the `stream_callback` instead (see [Streaming](../../integrations/llms/streaming.md)). Neither callback enables token streaming.
 
 ```python
 --8<-- "docs/scripts/broadcast.py:callback_creation"

--- a/docs/observability/tracking/broadcasting.md
+++ b/docs/observability/tracking/broadcasting.md
@@ -10,7 +10,7 @@ Railtracks supports basic **data broadcasting**, enabling you to receive these u
 
 ## Usage
 
-To enable broadcasting, provide a **callback function** to the `broadcast_callback` parameter in `set_config`. This function will receive broadcasting updates:
+To enable broadcasting, provide a **callback function** to the `stream_callback` parameter in `set_config` (or on your `Flow`). It receives every broadcast item; pass a dict mapping channel name -> callback to route items per channel. Note: providing a `stream_callback` also enables token streaming for top-level calls (see [Streaming](../../integrations/llms/streaming.md)).
 
 ```python
 --8<-- "docs/scripts/broadcast.py:callback_creation"

--- a/docs/scripts/broadcast.py
+++ b/docs/scripts/broadcast.py
@@ -5,7 +5,7 @@ import railtracks as rt
 def example_broadcasting_handler(data):
     print(f"Received data: {data}")
 
-rt.set_config(stream_callback=example_broadcasting_handler)
+rt.set_config(broadcast_callback=example_broadcasting_handler)
 # --8<-- [end: callback_creation]
 
 # --8<-- [start: broadcast_call]

--- a/docs/scripts/broadcast.py
+++ b/docs/scripts/broadcast.py
@@ -1,10 +1,11 @@
 import railtracks as rt
 
+
 # --8<-- [start: callback_creation]
 def example_broadcasting_handler(data):
     print(f"Received data: {data}")
 
-rt.set_config(broadcast_callback=example_broadcasting_handler)
+rt.set_config(stream_callback=example_broadcasting_handler)
 # --8<-- [end: callback_creation]
 
 # --8<-- [start: broadcast_call]

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -1,44 +1,196 @@
-# --8<-- [start: streaming_flag]
-import railtracks.llm as llm
-
-model = llm.OpenAILLM(model_name="gpt-4o", stream=True)
-# --8<-- [end: streaming_flag]
-
-
-# --8<-- [start: streaming_usage]
-model = llm.OpenAILLM(model_name="gpt-4o", stream=True)
-
-response = model.chat(llm.MessageHistory([
-    llm.UserMessage("Tell me who you are are"),
-]))
-
-# The response object can act as an iterator returning string chunks terminating with the complete message.
-for chunk in response:
-    print(chunk)
-# --8<-- [end: streaming_usage]
-
-# --8<-- [start: streaming_with_agents]
+# --8<-- [start: astream_basic]
 import railtracks as rt
 
 agent = rt.agent_node(
-    llm=rt.llm.OpenAILLM(model_name="gpt-4o", stream=True),
+    name="Poet",
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message="You are a concise poet.",
 )
 
-# --8<-- [end: streaming_with_agents]
+
+async def main():
+    stream = rt.astream(agent, user_input="Write a short poem about rain.")
+
+    async for chunk in stream:
+        print(chunk, end="", flush=True)  # str token chunks
+
+    final = stream.result  # the complete StringResponse
+    print("\n\nfinal:", final.text)
+# --8<-- [end: astream_basic]
 
 
-# --8<-- [start: streaming_agent_usage]
-agent = rt.agent_node(
-    llm=rt.llm.OpenAILLM(model_name="gpt-4o", stream=True),
+# --8<-- [start: astream_await]
+async def main_await():
+    # when you only care about the final result of the streamed run
+    final = await rt.astream(agent, user_input="Write a short poem about rain.")
+    print(final.text)
+# --8<-- [end: astream_await]
+
+
+# --8<-- [start: flow_astream]
+flow = rt.Flow(name="poet_flow", entry_point=agent)
+
+
+async def main_flow():
+    stream = flow.astream("Write a short poem about rain.")
+
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+
+    final = stream.result
+# --8<-- [end: flow_astream]
+
+
+# --8<-- [start: stream_callback]
+def on_chunk(chunk: str) -> None:
+    print(chunk, end="", flush=True)
+
+
+# attach the callback to the Flow (scoped) — do not construct a Session yourself
+push_flow = rt.Flow(name="poet_push", entry_point=agent, stream_callback=on_chunk)
+
+
+async def main_push():
+    result = await push_flow.ainvoke("Write a poem.")
+    print("\n\nresult:", result.text)
+# --8<-- [end: stream_callback]
+
+
+# --8<-- [start: stream_callback_channels]
+channel_flow = rt.Flow(
+    name="poet_channels",
+    entry_point=agent,
+    stream_callback={
+        "default": lambda chunk: print(chunk, end="", flush=True),
+        "progress": lambda chunk: print(f"[progress] {chunk}"),
+    },
 )
 
-flow = rt.Flow("streaming-flow", entry_point=agent)
-result = flow.invoke(rt.llm.MessageHistory([
-    rt.llm.UserMessage("Tell me who you are are"),
-]))
 
-# The response object can act as an iterator returning string chunks terminating with the complete message.
+async def main_channels():
+    result = await channel_flow.ainvoke("Write a poem.")
+    return result
+# --8<-- [end: stream_callback_channels]
 
-for chunk_obj in result:
-    print(chunk_obj)
-# --8<-- [end: streaming_agent_usage]
+
+# --8<-- [start: custom_node]
+from railtracks.llm import UserMessage
+
+model = rt.llm.OpenAILLM("gpt-4o-mini")
+
+
+@rt.function_node
+async def poem(topic: str) -> str:
+    # forward the model stream to whoever is consuming this run; if nobody is
+    # listening the chunks are dropped and this behaves like a buffered call.
+    response = await rt.broadcast_stream(
+        model.astream_chat([UserMessage(f"Write a short poem about {topic}.")])
+    )
+    return response.text
+
+
+async def main_custom():
+    stream = rt.astream(poem, topic="sunshine")
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+    final = stream.result  # the node's return value (str here)
+# --8<-- [end: custom_node]
+
+
+# --8<-- [start: custom_channels]
+@rt.function_node
+async def two_streams(topic: str) -> str:
+    draft = await rt.broadcast_stream(
+        model.astream_chat([UserMessage(f"Draft a poem about {topic}.")]),
+        channel="draft",
+    )
+    final = await rt.broadcast_stream(
+        model.astream_chat([UserMessage(f"Polish this poem:\n{draft.text}")]),
+        channel="final",
+    )
+    return final.text
+
+
+async def main_two_streams():
+    # only consume the "final" channel; "draft" chunks are ignored
+    stream = rt.astream(two_streams, topic="sunshine").on_channel("final")
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+# --8<-- [end: custom_channels]
+
+
+# --8<-- [start: agent_stream_channel]
+writer = rt.agent_node(
+    name="Writer",
+    llm=rt.llm.OpenAILLM("gpt-4o-mini"),
+    system_message="Write prose.",
+    stream_channel="writer",     # this agent's tokens are emitted on the «writer» bus
+)
+
+critic = rt.agent_node(
+    name="Critic",
+    llm=rt.llm.OpenAILLM("gpt-4o-mini"),
+    system_message="Critique prose.",
+    stream_channel="critic",     # ...and this one's on the «critic» bus
+)
+
+
+@rt.function_node
+async def review_pipeline(topic: str) -> str:
+    # nested rt.call would run buffered (frame-local rule); nested rt.astream opts each
+    # child into streaming — its tokens flow to the bus named by its stream_channel.
+    draft = await rt.astream(writer, user_input=f"Write about {topic}.")
+    review = await rt.astream(critic, user_input=draft.text)
+    return review.text
+
+
+routed_flow = rt.Flow(
+    name="review",
+    entry_point=review_pipeline,
+    stream_callback={
+        "writer": lambda c: print(c, end="", flush=True),   # writer tokens → pane 1
+        "critic": lambda c: print(f"\x1b[2m{c}\x1b[0m", end="", flush=True),  # critic → pane 2
+    },
+)
+# --8<-- [end: agent_stream_channel]
+
+
+# --8<-- [start: get_stream]
+import asyncio
+
+
+@rt.function_node
+async def token_source(topic: str) -> str:
+    # a child that explicitly streams its tokens onto the "tokens" channel
+    return (
+        await rt.broadcast_stream(
+            model.astream_chat([UserMessage(f"Write two lines about {topic}.")]),
+            channel="tokens",
+        )
+    ).text
+
+
+@rt.function_node
+async def orchestrator(topic: str) -> str:
+    # run the producer concurrently and fold its live tokens in from the channel
+    task = asyncio.create_task(rt.call(token_source, topic=topic))
+    collected = ""
+    # default streams=1: ends by itself once one production completes on the channel
+    async for chunk in rt.context.get_stream("tokens"):
+        print(chunk, end="", flush=True)
+        collected += chunk
+    return await task
+# --8<-- [end: get_stream]
+
+
+# --8<-- [start: model_astream]
+async def main_model():
+    # model-level streaming, outside any node/session
+    final_response = None  # seed so it is always bound (a stream could be empty)
+    async for item in model.astream_chat([UserMessage("Tell me who you are.")]):
+        if isinstance(item, str):
+            print(item, end="", flush=True)  # token chunk
+        else:
+            final_response = item  # the terminal Response (with usage info)
+    assert final_response is not None
+# --8<-- [end: model_astream]

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -58,12 +58,17 @@ async def main_push():
 # --8<-- [end: route]
 
 
-# --8<-- [start: broadcast_callback]
-# a PASSIVE session-wide listener: receives every broadcast item of the flow's runs but
-# never enables streaming. Prefer the dict form; if it never fires, a warning is logged.
+# --8<-- [start: stream_callback]
+# PASSIVE session-wide listeners — neither enables streaming. Two lanes:
+#   stream_callback    -> chunks from rt.broadcast_stream (LLM tokens included)
+#   broadcast_callback -> one-off events from rt.broadcast (progress notes, ...)
+# Prefer the dict form; if a callback never fires, a UserWarning is emitted at close.
 observer_flow = rt.Flow(
     name="poet_observed",
     entry_point=agent,
+    stream_callback={
+        "default": lambda chunk: print(chunk, end="", flush=True),
+    },
     broadcast_callback={
         "progress": lambda item: print(f"[progress] {item}"),
     },
@@ -71,9 +76,10 @@ observer_flow = rt.Flow(
 
 
 async def main_observed():
-    result = await observer_flow.ainvoke("Write a poem.")  # buffered; only explicit
-    return result                                          # rt.broadcast items observed
-# --8<-- [end: broadcast_callback]
+    stream_result = await observer_flow.astream("Write a poem.")  # tokens observed
+    buffered = await observer_flow.ainvoke("Write a poem.")       # buffered: only explicit
+    return stream_result, buffered                                # rt.broadcast events fire
+# --8<-- [end: stream_callback]
 
 
 # --8<-- [start: custom_node]
@@ -147,13 +153,13 @@ async def review_pipeline(topic: str) -> str:
     return review.text
 
 
-# a passive broadcast_callback observes ALL scopes in the session — including the
-# nested astream scopes created inside the pipeline (route() would only see the entry
-# scope, so the multi-agent fan-out uses the session-wide listener instead)
+# a passive stream_callback observes streamed chunks from ALL scopes in the session —
+# including the nested astream scopes created inside the pipeline (route() would only see
+# the entry scope, so the multi-agent fan-out uses the session-wide listener instead)
 routed_flow = rt.Flow(
     name="review",
     entry_point=review_pipeline,
-    broadcast_callback={
+    stream_callback={
         "writer": lambda c: print(c, end="", flush=True),   # writer tokens → pane 1
         "critic": lambda c: print(f"\x1b[2m{c}\x1b[0m", end="", flush=True),  # critic → pane 2
     },

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -41,36 +41,39 @@ async def main_flow():
 # --8<-- [end: flow_astream]
 
 
-# --8<-- [start: stream_callback]
+# --8<-- [start: route]
 def on_chunk(chunk: str) -> None:
     print(chunk, end="", flush=True)
 
 
-# attach the callback to the Flow (scoped) — do not construct a Session yourself
-push_flow = rt.Flow(name="poet_push", entry_point=agent, stream_callback=on_chunk)
-
-
 async def main_push():
-    result = await push_flow.ainvoke("Write a poem.")
+    # push-style consumption of ONE streamed call: route() dispatches chunks to handlers
+    # by channel and returns the final result. route() is what enables the streaming.
+    push_flow = rt.Flow(name="poet_push", entry_point=agent)
+    result = await push_flow.astream("Write a poem.").route(on_chunk)
     print("\n\nresult:", result.text)
-# --8<-- [end: stream_callback]
+
+    # dict form routes per channel (unregistered channels are skipped)
+    result = await push_flow.astream("Write a poem.").route({"default": on_chunk})
+# --8<-- [end: route]
 
 
-# --8<-- [start: stream_callback_channels]
-channel_flow = rt.Flow(
-    name="poet_channels",
+# --8<-- [start: broadcast_callback]
+# a PASSIVE session-wide listener: receives every broadcast item of the flow's runs but
+# never enables streaming. Prefer the dict form; if it never fires, a warning is logged.
+observer_flow = rt.Flow(
+    name="poet_observed",
     entry_point=agent,
-    stream_callback={
-        "default": lambda chunk: print(chunk, end="", flush=True),
-        "progress": lambda chunk: print(f"[progress] {chunk}"),
+    broadcast_callback={
+        "progress": lambda item: print(f"[progress] {item}"),
     },
 )
 
 
-async def main_channels():
-    result = await channel_flow.ainvoke("Write a poem.")
-    return result
-# --8<-- [end: stream_callback_channels]
+async def main_observed():
+    result = await observer_flow.ainvoke("Write a poem.")  # buffered; only explicit
+    return result                                          # rt.broadcast items observed
+# --8<-- [end: broadcast_callback]
 
 
 # --8<-- [start: custom_node]
@@ -144,10 +147,13 @@ async def review_pipeline(topic: str) -> str:
     return review.text
 
 
+# a passive broadcast_callback observes ALL scopes in the session — including the
+# nested astream scopes created inside the pipeline (route() would only see the entry
+# scope, so the multi-agent fan-out uses the session-wide listener instead)
 routed_flow = rt.Flow(
     name="review",
     entry_point=review_pipeline,
-    stream_callback={
+    broadcast_callback={
         "writer": lambda c: print(c, end="", flush=True),   # writer tokens → pane 1
         "critic": lambda c: print(f"\x1b[2m{c}\x1b[0m", end="", flush=True),  # critic → pane 2
     },

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -19,7 +19,10 @@ __all__ = [
     "Session",
     "session",
     "call",
+    "astream",
+    "Stream",
     "broadcast",
+    "broadcast_stream",
     "call_batch",
     "interactive",
     "ExecutionInfo",
@@ -70,10 +73,17 @@ from . import (
     vector_stores,
 )
 from ._session import ExecutionInfo, Session, session
-
 from .built_nodes.llm.middleware import after_llm, before_llm, wrap_llm
 from .context.central import session_id, set_config
-from .interaction import broadcast, call, call_batch, couple
+from .interaction import (
+    Stream,
+    astream,
+    broadcast,
+    broadcast_stream,
+    call,
+    call_batch,
+    couple,
+)
 from .middleware import after_node, wrap_node
 from .nodes.manifest import ToolManifest
 from .orchestration.flow import Flow

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -19,12 +19,12 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .pubsub import RTPublisher, stream_subscriber
+from .pubsub import RTPublisher, stream_chunk_subscriber
 from .state.info import (
     ExecutionInfo,
 )
 from .state.state import RTState
-from .utils.config import ExecutorConfig
+from .utils.config import ExecutorConfig, StreamCallback
 from .utils.logging.create import get_rt_logger
 
 logger = get_rt_logger(__name__)
@@ -48,7 +48,7 @@ class Session:
     - `name`: None
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
-    - `broadcast_callback`: None (no callback for broadcast messages)
+    - `stream_callback`: None (no push-mode streaming)
     - `prompt_injection`: True (the prompt will be automatically injected from context variables)
     - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
 
@@ -60,7 +60,11 @@ class Session:
         flow_id (str | None, optional): The unique identifier of the flow this session is associated with.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
+        stream_callback (Callable or dict[str, Callable], optional): A callback that receives every
+            streamed/broadcast item (push-mode streaming). Providing it enables token streaming for
+            top-level calls made within this session. Pass a dict mapping channel name -> callback
+            to route items per channel; a single callable receives every item on every channel.
+            Callbacks may be sync or async.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
@@ -74,9 +78,7 @@ class Session:
         name: str | None = None,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
+        stream_callback: StreamCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -92,7 +94,7 @@ class Session:
         self.executor_config = self.global_config_precedence(
             timeout=timeout,
             end_on_error=end_on_error,
-            broadcast_callback=broadcast_callback,
+            stream_callback=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -136,12 +138,10 @@ class Session:
         cls,
         timeout: float | None,
         end_on_error: bool | None,
-        broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ),
         prompt_injection: bool | None,
         save_state: bool | None,
         payload_callback: Callable[[dict[str, Any]], None] | None,
+        stream_callback: StreamCallback | None = None,
     ) -> ExecutorConfig:
         """
         Uses the following precedence order to determine the configuration parameters:
@@ -154,7 +154,7 @@ class Session:
         return global_executor_config.precedence_overwritten(
             timeout=timeout,
             end_on_error=end_on_error,
-            subscriber=broadcast_callback,
+            stream_subscriber=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -215,13 +215,13 @@ class Session:
 
     def _setup_subscriber(self):
         """
-        Prepares and attaches the saved broadcast_callback to the publisher attached to this runner.
+        Prepares and attaches the saved stream_callback to the publisher attached to this runner.
         """
 
-        if self.executor_config.subscriber is not None:
+        if self.executor_config.stream_subscriber is not None:
             self.publisher.subscribe(
-                stream_subscriber(self.executor_config.subscriber),
-                name="Streaming Subscriber",
+                stream_chunk_subscriber(self.executor_config.stream_subscriber),
+                name="Stream Callback Subscriber",
             )
 
     def _close(self):
@@ -315,9 +315,7 @@ def session(
     context: Dict[str, Any] | None = None,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    broadcast_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-    ) = None,
+    stream_callback: StreamCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> Callable[
@@ -337,7 +335,9 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
+        stream_callback (Callable or dict[str, Callable], optional): A callback (or channel-name
+            -> callback dict) that receives every streamed/broadcast item; providing it enables
+            push-mode streaming for top-level calls.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
@@ -355,9 +355,7 @@ def session(
     context: Dict[str, Any] | None = None,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    broadcast_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-    ) = None,
+    stream_callback: StreamCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> (
@@ -388,7 +386,9 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
+        stream_callback (Callable or dict[str, Callable], optional): A callback (or channel-name
+            -> callback dict) that receives every streamed/broadcast item; providing it enables
+            push-mode streaming for top-level calls.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
@@ -417,7 +417,7 @@ def session(
                 context=context,
                 timeout=timeout,
                 end_on_error=end_on_error,
-                broadcast_callback=broadcast_callback,
+                stream_callback=stream_callback,
                 name=name,
                 prompt_injection=prompt_injection,
                 save_state=save_state,

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -19,12 +19,12 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .pubsub import RTPublisher, stream_chunk_subscriber
+from .pubsub import BroadcastCallbackSubscriber, RTPublisher
 from .state.info import (
     ExecutionInfo,
 )
 from .state.state import RTState
-from .utils.config import ExecutorConfig, StreamCallback
+from .utils.config import BroadcastCallback, ExecutorConfig
 from .utils.logging.create import get_rt_logger
 
 logger = get_rt_logger(__name__)
@@ -48,7 +48,7 @@ class Session:
     - `name`: None
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
-    - `stream_callback`: None (no push-mode streaming)
+    - `broadcast_callback`: None (no bus listener)
     - `prompt_injection`: True (the prompt will be automatically injected from context variables)
     - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
 
@@ -60,11 +60,11 @@ class Session:
         flow_id (str | None, optional): The unique identifier of the flow this session is associated with.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        stream_callback (Callable or dict[str, Callable], optional): A callback that receives every
-            streamed/broadcast item (push-mode streaming). Providing it enables token streaming for
-            top-level calls made within this session. Pass a dict mapping channel name -> callback
-            to route items per channel; a single callable receives every item on every channel.
-            Callbacks may be sync or async.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on the
+            broadcast bus. Pass a dict mapping channel name -> callback to route items per channel
+            (preferred); a single callable receives every item on every channel. It never enables
+            streaming — only `rt.astream` / `Flow.astream` do. Callbacks may be sync or async.
+            If it never fires during the session, a warning is logged at close.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
@@ -78,7 +78,7 @@ class Session:
         name: str | None = None,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        stream_callback: StreamCallback | None = None,
+        broadcast_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -94,7 +94,7 @@ class Session:
         self.executor_config = self.global_config_precedence(
             timeout=timeout,
             end_on_error=end_on_error,
-            stream_callback=stream_callback,
+            broadcast_callback=broadcast_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -141,7 +141,7 @@ class Session:
         prompt_injection: bool | None,
         save_state: bool | None,
         payload_callback: Callable[[dict[str, Any]], None] | None,
-        stream_callback: StreamCallback | None = None,
+        broadcast_callback: BroadcastCallback | None = None,
     ) -> ExecutorConfig:
         """
         Uses the following precedence order to determine the configuration parameters:
@@ -154,7 +154,7 @@ class Session:
         return global_executor_config.precedence_overwritten(
             timeout=timeout,
             end_on_error=end_on_error,
-            stream_subscriber=stream_callback,
+            broadcast_callback=broadcast_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -215,22 +215,32 @@ class Session:
 
     def _setup_subscriber(self):
         """
-        Prepares and attaches the saved stream_callback to the publisher attached to this runner.
+        Prepares and attaches the saved broadcast_callback to the publisher attached to this
+        runner. The subscriber instance is kept so `_close` can warn if it never fired.
         """
+        self._broadcast_subscriber: BroadcastCallbackSubscriber | None = None
 
-        if self.executor_config.stream_subscriber is not None:
+        if self.executor_config.broadcast_callback is not None:
+            self._broadcast_subscriber = BroadcastCallbackSubscriber(
+                self.executor_config.broadcast_callback
+            )
             self.publisher.subscribe(
-                stream_chunk_subscriber(self.executor_config.stream_subscriber),
-                name="Stream Callback Subscriber",
+                self._broadcast_subscriber,
+                name="Broadcast Callback Subscriber",
             )
 
     def _close(self):
         """
         Closes the runner and cleans up all resources.
 
+        - Warns if a registered broadcast_callback never fired
         - Shuts down the state object
         - Deletes all the global variables that were registered in the context
         """
+        # surface silent-callback issues (channel typos, expecting tokens without astream)
+        if self._broadcast_subscriber is not None:
+            self._broadcast_subscriber.warn_if_unused()
+
         # FIX: Resource leak - publisher background task wasn't being shut down on Session exit
         # VISION: Session owns publisher lifecycle and must clean up all resources when exiting
         if self.publisher.is_running():
@@ -315,7 +325,7 @@ def session(
     context: Dict[str, Any] | None = None,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    stream_callback: StreamCallback | None = None,
+    broadcast_callback: BroadcastCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> Callable[
@@ -335,9 +345,9 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        stream_callback (Callable or dict[str, Callable], optional): A callback (or channel-name
-            -> callback dict) that receives every streamed/broadcast item; providing it enables
-            push-mode streaming for top-level calls.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on
+            the broadcast bus (or a channel-name -> callback dict routing items per channel).
+            It never enables streaming; use rt.astream for that.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
@@ -355,7 +365,7 @@ def session(
     context: Dict[str, Any] | None = None,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    stream_callback: StreamCallback | None = None,
+    broadcast_callback: BroadcastCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> (
@@ -386,9 +396,9 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        stream_callback (Callable or dict[str, Callable], optional): A callback (or channel-name
-            -> callback dict) that receives every streamed/broadcast item; providing it enables
-            push-mode streaming for top-level calls.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on
+            the broadcast bus (or a channel-name -> callback dict routing items per channel).
+            It never enables streaming; use rt.astream for that.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
@@ -417,7 +427,7 @@ def session(
                 context=context,
                 timeout=timeout,
                 end_on_error=end_on_error,
-                stream_callback=stream_callback,
+                broadcast_callback=broadcast_callback,
                 name=name,
                 prompt_injection=prompt_injection,
                 save_state=save_state,

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -48,7 +48,8 @@ class Session:
     - `name`: None
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
-    - `broadcast_callback`: None (no bus listener)
+    - `broadcast_callback`: None (no event listener)
+    - `stream_callback`: None (no stream-chunk listener)
     - `prompt_injection`: True (the prompt will be automatically injected from context variables)
     - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
 
@@ -60,11 +61,17 @@ class Session:
         flow_id (str | None, optional): The unique identifier of the flow this session is associated with.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on the
-            broadcast bus. Pass a dict mapping channel name -> callback to route items per channel
-            (preferred); a single callable receives every item on every channel. It never enables
-            streaming — only `rt.astream` / `Flow.astream` do. Callbacks may be sync or async.
-            If it never fires during the session, a warning is logged at close.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener for
+            one-off **events** published with `rt.broadcast`. Pass a dict mapping channel name ->
+            callback to route events per channel (preferred); a single callable receives every
+            event on every channel. It does not receive streamed chunks — see `stream_callback`.
+            Callbacks may be sync or async. If it never fires during the session, a
+            `UserWarning` is emitted at close.
+        stream_callback (Callable or dict[str, Callable], optional): A passive listener for
+            **stream chunks** published through `rt.broadcast_stream` (LLM token streams
+            included). Same shapes as `broadcast_callback`. It never enables streaming — only
+            `rt.astream` / `Flow.astream` do. If it never fires during the session, a
+            `UserWarning` is emitted at close.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
@@ -79,6 +86,7 @@ class Session:
         timeout: float | None = None,
         end_on_error: bool | None = None,
         broadcast_callback: BroadcastCallback | None = None,
+        stream_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -95,6 +103,7 @@ class Session:
             timeout=timeout,
             end_on_error=end_on_error,
             broadcast_callback=broadcast_callback,
+            stream_callback=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -142,6 +151,7 @@ class Session:
         save_state: bool | None,
         payload_callback: Callable[[dict[str, Any]], None] | None,
         broadcast_callback: BroadcastCallback | None = None,
+        stream_callback: BroadcastCallback | None = None,
     ) -> ExecutorConfig:
         """
         Uses the following precedence order to determine the configuration parameters:
@@ -155,6 +165,7 @@ class Session:
             timeout=timeout,
             end_on_error=end_on_error,
             broadcast_callback=broadcast_callback,
+            stream_callback=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -215,31 +226,49 @@ class Session:
 
     def _setup_subscriber(self):
         """
-        Prepares and attaches the saved broadcast_callback to the publisher attached to this
-        runner. The subscriber instance is kept so `_close` can warn if it never fired.
+        Prepares and attaches the saved callbacks to the publisher attached to this runner:
+        `broadcast_callback` listens to one-off events (`rt.broadcast`), `stream_callback`
+        to stream chunks (`rt.broadcast_stream` / LLM token streams). The subscriber
+        instances are kept so `_close` can warn if they never fired.
         """
         self._broadcast_subscriber: BroadcastCallbackSubscriber | None = None
+        self._stream_subscriber: BroadcastCallbackSubscriber | None = None
 
         if self.executor_config.broadcast_callback is not None:
             self._broadcast_subscriber = BroadcastCallbackSubscriber(
-                self.executor_config.broadcast_callback
+                self.executor_config.broadcast_callback,
+                kind="event",
+                param_name="broadcast_callback",
             )
             self.publisher.subscribe(
                 self._broadcast_subscriber,
                 name="Broadcast Callback Subscriber",
             )
 
+        if self.executor_config.stream_callback is not None:
+            self._stream_subscriber = BroadcastCallbackSubscriber(
+                self.executor_config.stream_callback,
+                kind="stream",
+                param_name="stream_callback",
+            )
+            self.publisher.subscribe(
+                self._stream_subscriber,
+                name="Stream Callback Subscriber",
+            )
+
     def _close(self):
         """
         Closes the runner and cleans up all resources.
 
-        - Warns if a registered broadcast_callback never fired
+        - Warns if a registered broadcast_callback / stream_callback never fired
         - Shuts down the state object
         - Deletes all the global variables that were registered in the context
         """
-        # surface silent-callback issues (channel typos, expecting tokens without astream)
+        # surface silent-callback issues (channel typos, wrong lane, tokens without astream)
         if self._broadcast_subscriber is not None:
             self._broadcast_subscriber.warn_if_unused()
+        if self._stream_subscriber is not None:
+            self._stream_subscriber.warn_if_unused()
 
         # FIX: Resource leak - publisher background task wasn't being shut down on Session exit
         # VISION: Session owns publisher lifecycle and must clean up all resources when exiting
@@ -326,6 +355,7 @@ def session(
     timeout: float | None = None,
     end_on_error: bool | None = None,
     broadcast_callback: BroadcastCallback | None = None,
+    stream_callback: BroadcastCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> Callable[
@@ -345,8 +375,11 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on
-            the broadcast bus (or a channel-name -> callback dict routing items per channel).
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener for
+            one-off events published with rt.broadcast (or a channel-name -> callback dict
+            routing events per channel). Streamed chunks go to `stream_callback` instead.
+        stream_callback (Callable or dict[str, Callable], optional): A passive listener for
+            stream chunks published through rt.broadcast_stream (LLM token streams included).
             It never enables streaming; use rt.astream for that.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
@@ -366,6 +399,7 @@ def session(
     timeout: float | None = None,
     end_on_error: bool | None = None,
     broadcast_callback: BroadcastCallback | None = None,
+    stream_callback: BroadcastCallback | None = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> (
@@ -396,8 +430,11 @@ def session(
         context (Dict[str, Any], optional): A dictionary of global context variables to be used during the execution.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on
-            the broadcast bus (or a channel-name -> callback dict routing items per channel).
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener for
+            one-off events published with rt.broadcast (or a channel-name -> callback dict
+            routing events per channel). Streamed chunks go to `stream_callback` instead.
+        stream_callback (Callable or dict[str, Callable], optional): A passive listener for
+            stream chunks published through rt.broadcast_stream (LLM token streams included).
             It never enables streaming; use rt.astream for that.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
@@ -428,6 +465,7 @@ def session(
                 timeout=timeout,
                 end_on_error=end_on_error,
                 broadcast_callback=broadcast_callback,
+                stream_callback=stream_callback,
                 name=name,
                 prompt_injection=prompt_injection,
                 save_state=save_state,

--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -140,6 +140,7 @@ class NodeBuilder(Generic[_P, _T]):
         | None = None,
         guardrails: Guard | None = None,
         context_injection: bool = True,
+        stream_channel: str = "default",
     ) -> NodeBuilder[[UserInput], StringResponse]: ...
 
     @overload
@@ -160,6 +161,7 @@ class NodeBuilder(Generic[_P, _T]):
         model_middleware: Iterable[ModelMiddleware] | None = None,
         guardrails: Guard | None = None,
         context_injection: bool = True,
+        stream_channel: str = "default",
     ) -> NodeBuilder[[UserInput], StructuredResponse[_TStructured]]: ...
 
     @classmethod
@@ -178,6 +180,7 @@ class NodeBuilder(Generic[_P, _T]):
         model_middleware: Iterable[ModelMiddleware] | None = None,
         guardrails: Guard | None = None,
         context_injection: bool = True,
+        stream_channel: str = "default",
     ) -> NodeBuilder[[UserInput], _R]:
         instance = cls()
         casted_instance = cast(NodeBuilder, instance)
@@ -204,7 +207,9 @@ class NodeBuilder(Generic[_P, _T]):
             unwrapped_model_middleware.append(guardrail_input_middleware(guardrails))
 
         model_invoker = ModelInvoker.create_with_llm_observe(
-            model, middleware=unwrapped_model_middleware
+            model,
+            middleware=unwrapped_model_middleware,
+            stream_channel=stream_channel,
         )
 
         casted_instance._invoke = llm_invoke_factory(

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/__init__.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/__init__.py
@@ -3,11 +3,8 @@ __all__ = [
     "StructuredResponse",
     "TerminalLLM",
     "GuardedTerminalLLM",
-    "GuardedStreamingTerminalLLM",
     "GuardedStructuredLLM",
-    "GuardedStreamingStructuredLLM",
     "GuardedToolCallLLM",
-    "GuardedStreamingToolCallLLM",
     "GuardedStructuredToolCallLLM",
     "StructuredLLM",
     "ToolCallLLM",
@@ -27,9 +24,6 @@ from .function_base import (
     RTFunction,
 )
 from .guarded_llm import (
-    GuardedStreamingStructuredLLM,
-    GuardedStreamingTerminalLLM,
-    GuardedStreamingToolCallLLM,
     GuardedStructuredLLM,
     GuardedStructuredToolCallLLM,
     GuardedTerminalLLM,

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
@@ -306,7 +306,7 @@ class LLMBase(Node[..., _TCollectedOutput], ABC, Generic[_TCollectedOutput]):
         The named channel this node emits its streamed chunks on.
 
         Override this on a node subclass to route its tokens to a dedicated channel (consumed
-        with `stream.on_channel(...)`, `route()` handlers, or a `broadcast_callback` dict
+        with `stream.on_channel(...)`, `route()` handlers, or a `stream_callback` dict
         keyed by channel name).
         """
         return "default"

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
@@ -55,7 +55,7 @@ class LLMBase(Node[..., _TCollectedOutput], ABC, Generic[_TCollectedOutput]):
     store debugging details that will allow us to determine token usage.
 
     Streaming: LLM nodes decide *per invocation* whether to stream. When the frame was entered
-    via `rt.astream` (or a configured `stream_callback`), `self._should_stream()` is True and the
+    via `rt.astream` / `Flow.astream`, `self._should_stream()` is True and the
     node consumes the model's streamed response internally, broadcasting each chunk with
     `rt.broadcast` before returning its regular (complete) response object. Nested `rt.call`
     children always run buffered — streaming is frame-local.
@@ -293,7 +293,7 @@ class LLMBase(Node[..., _TCollectedOutput], ABC, Generic[_TCollectedOutput]):
     def _should_stream(self) -> bool:
         """
         Returns True when this node's frame was invoked with streaming enabled (via
-        `rt.astream` or a configured `stream_callback`).
+        `rt.astream` / `Flow.astream` — callbacks never enable streaming).
 
         Streaming is frame-local: nested nodes started with `rt.call` from within this node
         will see False here and run buffered.
@@ -306,7 +306,8 @@ class LLMBase(Node[..., _TCollectedOutput], ABC, Generic[_TCollectedOutput]):
         The named channel this node emits its streamed chunks on.
 
         Override this on a node subclass to route its tokens to a dedicated channel (consumed
-        with `rt.astream(..., channel=...)` or a `stream_callback` dict keyed by channel name).
+        with `stream.on_channel(...)`, `route()` handlers, or a `broadcast_callback` dict
+        keyed by channel name).
         """
         return "default"
 

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_llm_base.py
@@ -4,20 +4,23 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import (
     Any,
+    AsyncGenerator,
     Dict,
     Generator,
     Generic,
     Iterable,
-    Literal,
     TypeVar,
+    cast,
 )
 
 from pydantic import BaseModel
 from typing_extensions import Self
 
 from railtracks.built_nodes.llm.request_details import RequestDetails
+from railtracks.context.central import is_streaming_enabled
 from railtracks.exceptions.errors import LLMError, NodeInvocationError
 from railtracks.exceptions.messages.exception_messages import get_message
+from railtracks.interaction.broadcast_ import broadcast_stream
 from railtracks.llm import (
     Message,
     MessageHistory,
@@ -40,19 +43,22 @@ from .response import LLMResponse, StringResponse, StructuredResponse
 # Global logger for LLM nodes
 logger = get_rt_logger(__name__)
 
-_T = TypeVar("_T")
 
-
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
 _TCollectedOutput = TypeVar("_TCollectedOutput", bound=LLMResponse)
 
 
-class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
+class LLMBase(Node[..., _TCollectedOutput], ABC, Generic[_TCollectedOutput]):
     """
     A basic LLM base class that encapsulates the attaching of an LLM model and message history object.
 
     The main functionality of the class is contained within the attachment of pre and post hooks to the model so we can
     store debugging details that will allow us to determine token usage.
+
+    Streaming: LLM nodes decide *per invocation* whether to stream. When the frame was entered
+    via `rt.astream` (or a configured `stream_callback`), `self._should_stream()` is True and the
+    node consumes the model's streamed response internally, broadcasting each chunk with
+    `rt.broadcast` before returning its regular (complete) response object. Nested `rt.call`
+    children always run buffered — streaming is frame-local.
 
     Args:
         user_input: The message history to use. Can be a MessageHistory object, a UserMessage object, or a string.
@@ -64,7 +70,7 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
     def __init__(
         self,
         user_input: MessageHistory | UserMessage | str | list[Message],
-        llm: ModelBase[_TStream] | None = None,
+        llm: ModelBase | None = None,
     ):
         super().__init__()
 
@@ -84,8 +90,9 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
         )  # Ensure we don't modify the original message history
 
         # If there is a system_message method we add it to message history
-        if self.system_message() is not None:
-            if not isinstance(self.system_message(), (SystemMessage, str)):
+        system_message = self.system_message()
+        if system_message is not None:
+            if not isinstance(system_message, (SystemMessage, str)):
                 raise NodeInvocationError(
                     message=get_message("INVALID_SYSTEM_MESSAGE_MSG"),
                     fatal=True,
@@ -98,9 +105,9 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
             message_history_copy.insert(
                 0,
                 (
-                    SystemMessage(self.system_message())
-                    if isinstance(self.system_message(), str)
-                    else self.system_message()
+                    SystemMessage(system_message)
+                    if isinstance(system_message, str)
+                    else system_message
                 ),
             )
 
@@ -125,8 +132,9 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
 
         self.message_hist = message_history_copy
 
-        self._details["guard_details"] = []
-        self._details["llm_details"] = []
+        # detail storage consumed by the guardrails mixin and request bookkeeping
+        # (Node no longer provides this attribute, so it is created here)
+        self._details: Dict[str, Any] = {"guard_details": [], "llm_details": []}
 
         self._attach_llm_hooks()
 
@@ -140,9 +148,16 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
 
     @classmethod
     def prepare_tool_message_history(
-        cls, tool_parameters: Dict[str, Any], tool_params: Iterable[Parameter] = None
-    ) -> MessageHistory:
-        pass
+        cls,
+        tool_parameters: Dict[str, Any],
+        tool_params: Iterable[Parameter] | None = None,
+    ) -> MessageHistory | None:
+        """Hook for building a message history from tool parameters.
+
+        The default implementation returns None; node builders override this when the node
+        is exposed as a tool.
+        """
+        return None
 
     @abstractmethod
     def return_output(self, message: Message | None = None) -> _TCollectedOutput: ...
@@ -153,12 +168,12 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
         check_message_history(message_history, cls.system_message())
 
     @classmethod
-    def _verify_llm_model(cls, llm: ModelBase[_TStream] | None):
+    def _verify_llm_model(cls, llm: ModelBase | None):
         """Verify the llm model is valid for this LLM."""
         check_llm_model(llm)
 
     @classmethod
-    def get_llm(cls) -> ModelBase[_TStream] | None:
+    def get_llm(cls) -> ModelBase | None:
         return None
 
     @classmethod
@@ -232,7 +247,7 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
         """
         return None
 
-    def format_for_return(self, result: _T) -> Any:
+    def format_for_return(self, result: _TCollectedOutput) -> Any:
         """
         Format the result for return when return_into is provided. This method can be overridden by subclasses to
         customize the return format. By default, it returns None.
@@ -245,7 +260,7 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
         """
         return None
 
-    def format_for_context(self, result: _T) -> Any:
+    def format_for_context(self, result: _TCollectedOutput) -> Any:
         """
         Format the result for context when return_into is provided. This method can be overridden by subclasses to
         customize the context format. By default, it returns the result as is.
@@ -259,7 +274,8 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
         return result
 
     def safe_copy(self) -> Self:
-        new_instance: LLMBase = super().safe_copy()
+        # Node.safe_copy is typed as returning Node; the copy is always this concrete type.
+        new_instance = cast(Self, super().safe_copy())
 
         # This has got to be one of the weirdest things I've seen working with python
         # basically if we don't reattach the hooks, the `self` inserted into the model hooks will be the old memory address
@@ -274,30 +290,61 @@ class LLMBase(Node[..., _T], ABC, Generic[_T, _TCollectedOutput, _TStream]):
     def type(cls):
         return "Agent"
 
-    def _gen_wrapper(
-        self, returned_mess: Generator[str | Response, None, Response]
-    ) -> Generator[str | _TCollectedOutput, None, _TCollectedOutput]:
-        for r in returned_mess:
-            if isinstance(r, Response):
-                r = self._post_invoke(self.message_hist, r)
-                message = r.message
+    def _should_stream(self) -> bool:
+        """
+        Returns True when this node's frame was invoked with streaming enabled (via
+        `rt.astream` or a configured `stream_callback`).
 
-                self._handle_output(message)
-                response = self.return_output(message)
-                yield response
-                return response
-            elif isinstance(r, str):
-                yield r
-            else:
+        Streaming is frame-local: nested nodes started with `rt.call` from within this node
+        will see False here and run buffered.
+        """
+        return is_streaming_enabled()
+
+    @classmethod
+    def stream_channel(cls) -> str:
+        """
+        The named channel this node emits its streamed chunks on.
+
+        Override this on a node subclass to route its tokens to a dedicated channel (consumed
+        with `rt.astream(..., channel=...)` or a `stream_callback` dict keyed by channel name).
+        """
+        return "default"
+
+    async def _stream_model_response(
+        self, model_stream: AsyncGenerator[str | Response, None]
+    ) -> Response:
+        """
+        Consumes a model stream (e.g. `llm_model.astream_chat(...)`), broadcasting each `str`
+        chunk on this node's `stream_channel`, and returns the final complete `Response`.
+        """
+        result = await broadcast_stream(model_stream, channel=self.stream_channel())
+        if not isinstance(result, Response):
+            raise LLMError(
+                reason="The model stream did not yield a final Response object.",
+                message_history=self.message_hist,
+            )
+        return result
+
+    def _collect_streamed_response(
+        self, returned: Response | Generator[str | Response, None, Response]
+    ) -> Response:
+        """
+        Backwards-compatibility shim for models constructed with the deprecated `stream=True`
+        flag: their sync chat methods return a generator, which we drain here so buffered
+        invocations still produce a complete `Response`.
+        """
+        if isinstance(returned, Generator):
+            final: Response | None = None
+            for item in returned:
+                if isinstance(item, Response):
+                    final = item
+            if final is None:
                 raise LLMError(
-                    reason=f"ModelLLM returned unexpected type in generator. Expected str or Response, got {type(r)}",
+                    reason="The generator did not yield a final Response object",
                     message_history=self.message_hist,
                 )
-
-        raise LLMError(
-            reason="The generator did not yield a final Response object",
-            message_history=self.message_hist,
-        )
+            return final
+        return returned
 
     def _handle_output(self, output: Message):
         if output.role != "assistant":

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/_tool_call_base.py
@@ -5,13 +5,13 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     Dict,
-    Generator,
     Generic,
     Literal,
     ParamSpec,
     Set,
     Type,
     TypeVar,
+    cast,
 )
 
 from railtracks.built_nodes.concrete.response import LLMResponse
@@ -29,25 +29,26 @@ from railtracks.llm import (
 )
 from railtracks.llm.content import Content
 from railtracks.llm.message import Role
-from railtracks.llm.providers import ModelProvider
+from railtracks.llm.providers import TOOL_CALLING_STREAMING_BLACKLIST
 from railtracks.llm.response import Response
 from railtracks.nodes.nodes import Node
+from railtracks.utils.logging import get_rt_logger
 from railtracks.validation.node_creation.validation import check_connected_nodes
 
 from ._llm_base import LLMBase
 
-_T = TypeVar("_T")
 _P = ParamSpec("_P")
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
 _TCollectedOutput = TypeVar("_TCollectedOutput", bound=LLMResponse)
 
 _TContent = TypeVar("_TContent", bound=Content)
 
+logger = get_rt_logger(__name__)
+
 
 class OutputLessToolCallLLMBase(
-    LLMBase[_T, _TCollectedOutput, _TStream],
+    LLMBase[_TCollectedOutput],
     ABC,
-    Generic[_T, _TCollectedOutput, _TStream],
+    Generic[_TCollectedOutput],
 ):
     """A base class that is a node which contains
      an LLm that can make tool calls. The tool calls will be returned
@@ -76,33 +77,33 @@ class OutputLessToolCallLLMBase(
 
     @classmethod
     def streaming_blacklist(cls):
-        return {
-            ModelProvider.ANTHROPIC,
-            ModelProvider.AZUREAI,
-            ModelProvider.GEMINI,
-            ModelProvider.OLLAMA,
-            ModelProvider.HUGGINGFACE,
-        }
+        """Providers we do not support token streaming for when tool calling is involved.
+
+        When a streamed invocation hits one of these providers, the node falls back to a
+        buffered model call (with a warning) instead of erroring — the final response is
+        unaffected, you just don't get incremental chunks.
+        """
+        return set(TOOL_CALLING_STREAMING_BLACKLIST)
 
     def __init__(
         self,
         user_input: MessageHistory | UserMessage | str | list[Message],
-        llm: ModelBase[_TStream] | None = None,
+        llm: ModelBase | None = None,
     ):
         super().__init__(llm=llm, user_input=user_input)
-        model = self.get_llm()
-        # we only support Openai for streaming calls atm.
-        if (
-            model is not None
-            and model.stream
-            and model.model_provider() in self.streaming_blacklist()
-        ):
-            raise NodeCreationError(
-                f"Currently we do not allow streaming with {model.model_provider()} (specifically for tool calling)",
-                notes=[
-                    "Create a new issue on the railtracks repo or switch to openai's models"
-                ],
+
+    def _should_stream(self) -> bool:
+        """Frame-level streaming decision, including the tool-calling provider blacklist."""
+        if not super()._should_stream():
+            return False
+        if self.llm_model.model_provider() in self.streaming_blacklist():
+            logger.warning(
+                "Streaming is not supported with %s for tool calling; falling back to a "
+                "buffered response.",
+                self.llm_model.model_provider(),
             )
+            return False
+        return True
 
     @classmethod
     def name(cls) -> str:
@@ -129,7 +130,8 @@ class OutputLessToolCallLLMBase(
                 message=f"Tool {tool_name} has multiple nodes, this is not allowed. Current Node include {[x.tool_info().name for x in self.tool_nodes()]}",
                 notes=["Please check the tool names in the connected nodes."],
             )
-        return node[0].prepare_tool(arguments)
+        # `prepare_tool` is attached dynamically by the node builder; Node has no static stub.
+        return cast(Any, node[0]).prepare_tool(arguments)
 
     def get_node_from_name(self, tool_name: str):
         """
@@ -152,7 +154,8 @@ class OutputLessToolCallLLMBase(
     async def run_node_from_tool(self, tool_name: str, arguments: dict[str, Any]):
         node = self.get_node_from_name(tool_name)
 
-        return await call(node.prepare_tool, **arguments)
+        # `prepare_tool` is attached dynamically by the node builder; Node has no static stub.
+        return await call(cast(Any, node).prepare_tool, **arguments)
 
     @classmethod
     def tools(cls):
@@ -223,7 +226,7 @@ class OutputLessToolCallLLMBase(
 
 
 class OutputLessToolCallLLM(
-    OutputLessToolCallLLMBase[_TCollectedOutput, _TCollectedOutput, Literal[False]],
+    OutputLessToolCallLLMBase[_TCollectedOutput],
     ABC,
     Generic[_TCollectedOutput],
 ):
@@ -238,6 +241,11 @@ class OutputLessToolCallLLM(
         - Executes a tool call and appends the results to the message history.
         - Handles malformed LLM responses and raises errors as needed.
 
+        Streaming: when the frame has streaming enabled, every round of the tool-call loop is
+        requested as a streamed model call and all text chunks are broadcast as they arrive —
+        including text produced in rounds that end in tool calls. The returned `Response` is
+        always the complete (accumulated) one, so the loop logic is identical either way.
+
         Returns:
             A 3-tuple ``(still_looping, final_message, final_response)``.
             ``still_looping`` is True when tool calls were dispatched and the
@@ -249,9 +257,16 @@ class OutputLessToolCallLLM(
             LLMError: If the LLM returns an unexpected message type or the message is malformed.
         """
         try:
-            response = await asyncio.to_thread(
-                self.llm_model.chat_with_tools, self.message_hist, tools=self.tools()
-            )
+            if self._should_stream():
+                response = await self._stream_model_response(
+                    self.llm_model.astream_chat_with_tools(
+                        self.message_hist, tools=self.tools()
+                    )
+                )
+            else:
+                response = await asyncio.to_thread(self._buffered_chat_with_tools)
+        except LLMError:
+            raise
         except Exception as e:
             raise LLMError(
                 reason=f"Exception during llm model chat: {repr(e)}",
@@ -267,6 +282,12 @@ class OutputLessToolCallLLM(
         is_tool, message = await self._handle_response(response.message)
         final_response = None if is_tool else response
         return is_tool, message, final_response
+
+    def _buffered_chat_with_tools(self) -> Response:
+        """Runs a regular (non-streaming) tool call, draining legacy stream=True generators."""
+        return self._collect_streamed_response(
+            self.llm_model.chat_with_tools(self.message_hist, tools=self.tools())
+        )
 
     async def invoke(self):
         context = self._pre_invoke(self.message_hist)
@@ -286,83 +307,3 @@ class OutputLessToolCallLLM(
                 self.message_hist[-1] = message
 
         return self.return_output(message)
-
-
-class StreamingOutputLessToolCallLLM(
-    OutputLessToolCallLLMBase[
-        Generator[str | _TCollectedOutput, None, _TCollectedOutput],
-        _TCollectedOutput,
-        Literal[True],
-    ],
-    ABC,
-    Generic[_TCollectedOutput],
-):
-    async def _handle_tool_calls(self):  # noqa: C901
-        try:
-            returned_mess = await asyncio.to_thread(
-                self.llm_model.chat_with_tools, self.message_hist, tools=self.tools()
-            )
-        except Exception as e:
-            raise LLMError(
-                reason=f"Exception during llm model chat: {repr(e)}",
-                message_history=self.message_hist,
-            ) from e
-
-        first_item = next(returned_mess)
-        if isinstance(first_item, str):
-
-            def gen_wrapper():
-                yield first_item
-                # yield the rest of the items
-                for chunk in returned_mess:
-                    if isinstance(chunk, str):
-                        yield chunk
-                    elif isinstance(chunk, Response):
-                        if chunk.message.role != Role.assistant:
-                            raise LLMError(
-                                reason="ModelLLM returned an unexpected message type.",
-                                message_history=self.message_hist,
-                            )
-                        self.message_hist.append(chunk.message)
-                        response = self.return_output(chunk.message)
-                        yield response
-                        return response
-
-                raise LLMError(
-                    "Badly formatted response from the LLM",
-                    message_history=self.message_hist,
-                )
-
-            return gen_wrapper()
-
-        if isinstance(first_item, Response):
-            assert first_item.message.role == Role.assistant
-
-            if len(first_item.message.tool_calls) > 0:
-                is_tool, _ = await self._handle_response(first_item.message)
-
-                if not is_tool:
-                    raise LLMError(
-                        "Message returned did not contain tool calls and it should have.",
-                        message_history=self.message_hist,
-                    )
-            else:
-                raise LLMError(
-                    "Message returned did not contain tool calls and it should have.",
-                    message_history=self.message_hist,
-                )
-
-    async def invoke(self):
-        """Makes a call containing the inputted message and system prompt to the llm model and returns the response.
-
-        Note: only input guardrails are wired here.  Output guardrails on the
-        streaming tool-call path are deferred because the inner generator
-        bypasses ``LLMBase._gen_wrapper`` where ``_post_invoke`` normally runs.
-        """
-        context = self._pre_invoke(self.message_hist)
-        self.message_hist = context
-
-        while True:
-            result = await self._handle_tool_calls()
-            if result is not None:
-                return result

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/guarded_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/guarded_llm.py
@@ -5,6 +5,11 @@ Uses the higher-level design: hooks (_pre_invoke / _post_invoke) on LLMBase, imp
 by the mixin. No separate invoke() logic; each base type's invoke() calls the hooks.
 
 Set guardrails= when building the node (e.g. via agent_node(..., guardrails=Guard(...))).
+
+Streaming note: streaming is decided at the call site (`rt.astream`) rather than by the node
+class, so there are no separate streaming variants. When a guarded node streams, the raw
+chunks are broadcast as they arrive and the output guardrails run on the complete buffered
+response — the final returned response is gated, but chunks already emitted are not recalled.
 """
 
 from __future__ import annotations
@@ -15,19 +20,15 @@ from pydantic import BaseModel
 
 from railtracks.guardrails.llm.mixin import LLMGuardrailsMixin
 
-from .structured_llm_base import StreamingStructuredLLM, StructuredLLM
+from .structured_llm_base import StructuredLLM
 from .structured_tool_call_llm_base import StructuredToolCallLLM
-from .terminal_llm_base import StreamingTerminalLLM, TerminalLLM
-from .tool_call_llm_base import StreamingToolCallLLM, ToolCallLLM
+from .terminal_llm_base import TerminalLLM
+from .tool_call_llm_base import ToolCallLLM
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 
 
 class GuardedTerminalLLM(LLMGuardrailsMixin, TerminalLLM):
-    pass
-
-
-class GuardedStreamingTerminalLLM(LLMGuardrailsMixin, StreamingTerminalLLM):
     pass
 
 
@@ -37,17 +38,7 @@ class GuardedStructuredLLM(
     pass
 
 
-class GuardedStreamingStructuredLLM(
-    LLMGuardrailsMixin, StreamingStructuredLLM[_TBaseModel], Generic[_TBaseModel]
-):
-    pass
-
-
 class GuardedToolCallLLM(LLMGuardrailsMixin, ToolCallLLM):
-    pass
-
-
-class GuardedStreamingToolCallLLM(LLMGuardrailsMixin, StreamingToolCallLLM):
     pass
 
 

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import asyncio
 from abc import ABC
-from typing import Generator, Generic, Literal, TypeVar
+from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
 from railtracks.exceptions.errors import LLMError
 from railtracks.llm import Message, MessageHistory, ModelBase, UserMessage
+from railtracks.llm.response import Response
 from railtracks.validation.node_creation.validation import (
     check_classmethod,
     check_schema,
@@ -14,24 +17,20 @@ from railtracks.validation.node_creation.validation import (
 from ._llm_base import LLMBase, StructuredOutputMixIn
 from .response import StructuredResponse
 
-_TOutput = TypeVar("_TOutput", bound=StructuredResponse)
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
-_T = TypeVar("_T")
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 
 
 class StructuredLLMBase(
     StructuredOutputMixIn[_TBaseModel],
-    LLMBase[_T, StructuredResponse[_TBaseModel], _TStream],
+    LLMBase[StructuredResponse[_TBaseModel]],
     ABC,
-    Generic[_T, _TStream, _TBaseModel],
+    Generic[_TBaseModel],
 ):
     """
-    Python typing doesn't work great, so please ensure that you fit the following requirements when defining generics:
-    - _T is the final output type of the invoke method
-    - _TStream is a Literal type, either Literal[True] or Literal[False]
-    - _TBaseModel is a subclass of pydantic.BaseModel that defines the schema for the structured output
+    Base class for LLM nodes returning structured (pydantic) output.
 
+    Generics:
+    - _TBaseModel is a subclass of pydantic.BaseModel that defines the schema for the structured output
     """
 
     def __init_subclass__(cls):
@@ -46,7 +45,7 @@ class StructuredLLMBase(
     def __init__(
         self,
         user_input: MessageHistory | UserMessage | str | list[Message],
-        llm: ModelBase[_TStream] | None = None,
+        llm: ModelBase | None = None,
     ):
         super().__init__(llm=llm, user_input=user_input)
 
@@ -63,11 +62,16 @@ class StructuredLLMBase(
 
 
 class StructuredLLM(
-    StructuredLLMBase[StructuredResponse[_TBaseModel], Literal[False], _TBaseModel],
+    StructuredLLMBase[_TBaseModel],
     ABC,
     Generic[_TBaseModel],
 ):
     """Creates a new instance of the StructuredlLLM class
+
+    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), the
+    raw JSON tokens of the structured response are streamed chunk-by-chunk; the final returned
+    `StructuredResponse` is parsed and validated once the stream completes. In a regular
+    `rt.call` the model is invoked buffered.
 
     Args:
         user_input (MessageHistory | UserMessage | str | list[Message]): The input to use for the LLM. Can be a MessageHistory object, a UserMessage object, or a string.
@@ -88,59 +92,22 @@ class StructuredLLM(
         context = self._pre_invoke(self.message_hist)
         self.message_hist = context
 
-        returned_mess = await asyncio.to_thread(
-            self.llm_model.structured, self.message_hist, schema=self.output_schema()
-        )
+        if self._should_stream():
+            returned_mess = await self._stream_model_response(
+                self.llm_model.astream_structured(
+                    self.message_hist, schema=self.output_schema()
+                )
+            )
+        else:
+            returned_mess = await asyncio.to_thread(self._buffered_structured)
 
         returned_mess = self._post_invoke(self.message_hist, returned_mess)
 
         self._handle_output(returned_mess.message)
         return self.return_output(returned_mess.message)
 
-
-class StreamingStructuredLLM(
-    StructuredLLMBase[
-        Generator[
-            StructuredResponse[_TBaseModel] | str, None, StructuredResponse[_TBaseModel]
-        ],
-        Literal[True],
-        _TBaseModel,
-    ],
-    ABC,
-    Generic[_TBaseModel],
-):
-    """A simple streaming LLM node that takes in a message and returns a response. It is the simplest of all LLMs.
-    This node accepts message_history in the following formats:
-    - MessageHistory: A list of Message objects
-    - UserMessage: A single UserMessage object
-    - str: A string that will be converted to a UserMessage
-
-    Examples:
-        ```python
-        # Using MessageHistory
-        mh = MessageHistory([UserMessage("Tell me about the world around us")])
-        result = await rt.call(StreamingStructuredLLM, user_input=mh)
-        # Using UserMessage
-        user_msg = UserMessage("Tell me about the world around us")
-        result = await rt.call(StreamingStructuredLLM, user_input=user_msg)
-        # Using string
-        result = await rt.call(
-            StreamingStructuredLLM, user_input="Tell me about the world around us"
+    def _buffered_structured(self) -> Response:
+        """Runs a regular (non-streaming) structured call, draining legacy stream=True generators."""
+        return self._collect_streamed_response(
+            self.llm_model.structured(self.message_hist, schema=self.output_schema())
         )
-        ```
-    """
-
-    async def invoke(self):
-        """Makes a call containing the inputted message and system prompt to the llm model and returns the response
-
-        Returns:
-            (StructuredlLLM.Output): The response message from the llm model
-        """
-        context = self._pre_invoke(self.message_hist)
-        self.message_hist = context
-
-        returned_mess = await asyncio.to_thread(
-            self.llm_model.structured, self.message_hist, schema=self.output_schema()
-        )
-
-        return self._gen_wrapper(returned_mess)

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_llm_base.py
@@ -68,7 +68,7 @@ class StructuredLLM(
 ):
     """Creates a new instance of the StructuredlLLM class
 
-    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), the
+    Streaming: when invoked through `rt.astream` / `Flow.astream`, the
     raw JSON tokens of the structured response are streamed chunk-by-chunk; the final returned
     `StructuredResponse` is parsed and validated once the stream completes. In a regular
     `rt.call` the model is invoked buffered.

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/structured_tool_call_llm_base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, ClassVar, Generic, Literal, Type, TypeVar, cast
+from typing import Any, ClassVar, Generic, Type, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -19,7 +19,6 @@ from .response import StructuredResponse
 from .structured_llm_base import StructuredLLM
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
 
 
 class StructuredToolCallLLM(
@@ -74,12 +73,8 @@ class StructuredToolCallLLM(
     def __init__(
         self,
         user_input: MessageHistory | UserMessage | str | list[Message],
-        llm: ModelBase[Literal[False]] | None = None,
+        llm: ModelBase | None = None,
     ):
-        # as of right now we do not support streaming with structured tool calls.
-        if llm is not None and llm.stream:
-            raise ValueError("StructuredToolCallLLM does not support streaming.")
-
         super().__init__(user_input=user_input, llm=llm)
         self.structured_output: _TBaseModel | Exception | None = None
 

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
@@ -2,25 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from abc import ABC
-from typing import Generator, Generic, Literal, TypeVar
 
 from railtracks.exceptions import LLMError
 from railtracks.llm.response import Response
 
 from ._llm_base import LLMBase, StringOutputMixIn
-from .response import LLMResponse, StringResponse
-
-_T = TypeVar(
-    "_T", Generator[str | StringResponse, None, StringResponse], StringResponse
-)
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
-_TCollectedOutput = TypeVar("_TCollectedOutput", bound=LLMResponse)
+from .response import StringResponse
 
 
 class TerminalLLMBase(
-    LLMBase[_T, _TCollectedOutput, _TStream],
+    LLMBase[StringResponse],
     ABC,
-    Generic[_T, _TCollectedOutput, _TStream],
 ):
     @classmethod
     def name(cls) -> str:
@@ -29,13 +21,19 @@ class TerminalLLMBase(
 
 class TerminalLLM(
     StringOutputMixIn,
-    TerminalLLMBase[StringResponse, StringResponse, Literal[False]],
+    TerminalLLMBase,
 ):
     """A simple LLM node that takes in a message and returns a response. It is the simplest of all LLMs.
     This node accepts message_history in the following formats:
     - MessageHistory: A list of Message objects
     - UserMessage: A single UserMessage object
     - str: A string that will be converted to a UserMessage
+
+    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), this
+    node streams the model response token-by-token — each chunk is broadcast on the node's
+    `stream_channel` — and still returns the complete `StringResponse` at the end. In a regular
+    `rt.call` the model is invoked buffered (no streaming overhead).
+
     Examples:
         ```python
         # Using MessageHistory
@@ -48,6 +46,10 @@ class TerminalLLM(
         result = await rt.call(
             TerminalLLM, user_input="Tell me about the world around us"
         )
+        # Streaming the tokens of the response
+        async for chunk in (stream := rt.astream(TerminalLLM, user_input="Tell me a story")):
+            print(chunk, end="", flush=True)
+        result = stream.result
         ```
     """
 
@@ -60,9 +62,14 @@ class TerminalLLM(
         self.message_hist = context
 
         try:
-            returned_mess = await asyncio.to_thread(
-                self.llm_model.chat, self.message_hist
-            )
+            if self._should_stream():
+                returned_mess = await self._stream_model_response(
+                    self.llm_model.astream_chat(self.message_hist)
+                )
+            else:
+                returned_mess = await asyncio.to_thread(self._buffered_chat)
+        except LLMError:
+            raise
         except Exception as e:
             raise LLMError(
                 reason=f"Exception during llm model chat: {str(e)}",
@@ -81,51 +88,6 @@ class TerminalLLM(
                 message_history=self.message_hist,
             )
 
-
-class StreamingTerminalLLM(
-    StringOutputMixIn,
-    TerminalLLMBase[
-        Generator[str | StringResponse, None, StringResponse],
-        StringResponse,
-        Literal[True],
-    ],
-):
-    """A simple streaming LLM node that takes in a message and returns a response. It is the simplest of all LLMs.
-    This node accepts message_history in the following formats:
-    - MessageHistory: A list of Message objects
-    - UserMessage: A single UserMessage object
-    - str: A string that will be converted to a UserMessage
-    Examples:
-        ```python
-        # Using MessageHistory
-        mh = MessageHistory([UserMessage("Tell me about the world around us")])
-        result = await rt.call(StreamingTerminalLLM, user_input=mh)
-        # Using UserMessage
-        user_msg = UserMessage("Tell me about the world around us")
-        result = await rt.call(StreamingTerminalLLM, user_input=user_msg)
-        # Using string
-        result = await rt.call(
-            StreamingTerminalLLM, user_input="Tell me about the world around us"
-        )
-        ```
-    """
-
-    async def invoke(self):
-        """Makes a call containing the inputted message and system prompt to the llm model and returns the response
-        Returns:
-            (TerminalLLM.Output): The response message from the llm model
-        """
-        context = self._pre_invoke(self.message_hist)
-        self.message_hist = context
-
-        try:
-            returned_mess = await asyncio.to_thread(
-                self.llm_model.chat, self.message_hist
-            )
-        except Exception as e:
-            raise LLMError(
-                reason=f"Exception during llm model chat: {repr(e)}",
-                message_history=self.message_hist,
-            ) from e
-
-        return self._gen_wrapper(returned_mess)
+    def _buffered_chat(self) -> Response:
+        """Runs a regular (non-streaming) chat call, draining legacy stream=True generators."""
+        return self._collect_streamed_response(self.llm_model.chat(self.message_hist))

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/terminal_llm_base.py
@@ -29,7 +29,7 @@ class TerminalLLM(
     - UserMessage: A single UserMessage object
     - str: A string that will be converted to a UserMessage
 
-    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), this
+    Streaming: when invoked through `rt.astream` / `Flow.astream`, this
     node streams the model response token-by-token — each chunk is broadcast on the node's
     `stream_channel` — and still returns the complete `StringResponse` at the end. In a regular
     `rt.call` the model is invoked buffered (no streaming overhead).

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/tool_call_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/tool_call_llm_base.py
@@ -9,7 +9,7 @@ class ToolCallLLM(
 ):
     """A tool-calling LLM node that returns the final assistant text as a `StringResponse`.
 
-    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), all
+    Streaming: when invoked through `rt.astream` / `Flow.astream`, all
     text produced during the tool-call loop is streamed chunk-by-chunk; the node still returns
     the complete `StringResponse` at the end. Nested tool nodes always run buffered.
     """

--- a/packages/railtracks/src/railtracks/built_nodes/concrete/tool_call_llm_base.py
+++ b/packages/railtracks/src/railtracks/built_nodes/concrete/tool_call_llm_base.py
@@ -1,20 +1,17 @@
-from typing import Literal, TypeVar
-
 from ._llm_base import StringOutputMixIn
-from ._tool_call_base import OutputLessToolCallLLM, StreamingOutputLessToolCallLLM
+from ._tool_call_base import OutputLessToolCallLLM
 from .response import StringResponse
-
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
 
 
 class ToolCallLLM(
     StringOutputMixIn,
     OutputLessToolCallLLM[StringResponse],
 ):
-    pass
+    """A tool-calling LLM node that returns the final assistant text as a `StringResponse`.
 
+    Streaming: when invoked through `rt.astream` (or with a `stream_callback` configured), all
+    text produced during the tool-call loop is streamed chunk-by-chunk; the node still returns
+    the complete `StringResponse` at the end. Nested tool nodes always run buffered.
+    """
 
-class StreamingToolCallLLM(
-    StringOutputMixIn, StreamingOutputLessToolCallLLM[StringResponse]
-):
     pass

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -174,9 +174,9 @@ def agent_node(
             of the session-level prompt_injection setting. Can also be controlled at the session level via
             rt.Session(prompt_injection=False) or per-message via message.inject_prompt = False.
         stream_channel (str): The named channel this agent's streamed tokens are broadcast on
-            when a run streams (see `rt.astream` / `stream_callback`). Defaults to "default".
+            when a run streams (see `rt.astream` / `Flow.astream`). Defaults to "default".
             Give different agents in one flow distinct channels to route their tokens to
-            different consumers (e.g. `stream_callback={"writer": fn1, "critic": fn2}` or
+            different consumers (e.g. `broadcast_callback={"writer": fn1, "critic": fn2}` or
             `stream.on_channel("writer")`). Note each round of a tool-calling loop is one
             production on this channel.
     """

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -176,7 +176,7 @@ def agent_node(
         stream_channel (str): The named channel this agent's streamed tokens are broadcast on
             when a run streams (see `rt.astream` / `Flow.astream`). Defaults to "default".
             Give different agents in one flow distinct channels to route their tokens to
-            different consumers (e.g. `broadcast_callback={"writer": fn1, "critic": fn2}` or
+            different consumers (e.g. `stream_callback={"writer": fn1, "critic": fn2}` or
             `stream.on_channel("writer")`). Note each round of a tool-calling loop is one
             production on this channel.
     """

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/agent.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Literal, Type, TypeVar, overload
+from typing import Iterable, Type, TypeVar, overload
 
 from pydantic import BaseModel
 
@@ -19,7 +19,6 @@ from railtracks.nodes.utils import extract_node_from_function
 from .._node_builder import NodeBuilder, UserInput
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
-_TStream = TypeVar("_TStream", Literal[True], Literal[False])
 _R = TypeVar("_R", bound=StructuredResponse | StringResponse)
 
 
@@ -51,6 +50,7 @@ def _build_dynamic_agent(
     model_middleware: list[ModelMiddleware] | None = None,
     guardrails: Guard | None = None,
     context_injection: bool = True,
+    stream_channel: str = "default",
 ):
     resolved_system = (
         SystemMessage(content=system_message)
@@ -70,6 +70,7 @@ def _build_dynamic_agent(
             model_middleware=model_middleware,
             guardrails=guardrails,
             context_injection=context_injection,
+            stream_channel=stream_channel,
         )
     else:
         nb = NodeBuilder.llm(
@@ -84,6 +85,7 @@ def _build_dynamic_agent(
             model_middleware=model_middleware,
             guardrails=guardrails,
             context_injection=context_injection,
+            stream_channel=stream_channel,
         )
 
     return nb.build()
@@ -105,7 +107,10 @@ def agent_node(
     model_middleware: list[ModelMiddleware] | None = None,
     guardrails: Guard | None = None,
     context_injection: bool = True,
-) -> type[Node[[UserInput], StringResponse]]: ...
+    stream_channel: str = "default",
+    # note: the parameter spec is `...` (not `[UserInput]`) so both the canonical keyword
+    # style `rt.call(agent, user_input=...)` and the positional style type-check.
+) -> type[Node[..., StringResponse]]: ...
 
 
 @overload
@@ -122,7 +127,10 @@ def agent_node(
     model_middleware: list[ModelMiddleware] | None = None,
     guardrails: Guard | None = None,
     context_injection: bool = True,
-) -> type[Node[[UserInput], StructuredResponse[_TBaseModel]]]: ...
+    stream_channel: str = "default",
+    # note: the parameter spec is `...` (not `[UserInput]`) so both the canonical keyword
+    # style `rt.call(agent, user_input=...)` and the positional style type-check.
+) -> type[Node[..., StructuredResponse[_TBaseModel]]]: ...
 
 
 def agent_node(
@@ -140,6 +148,7 @@ def agent_node(
     model_middleware: list[ModelMiddleware] | None = None,
     guardrails: Guard | None = None,
     context_injection: bool = True,
+    stream_channel: str = "default",
 ):
     """
     Dynamically creates an agent based on the provided parameters.
@@ -164,6 +173,12 @@ def agent_node(
             Defaults to True. Set to False to disable context injection for this specific agent regardless
             of the session-level prompt_injection setting. Can also be controlled at the session level via
             rt.Session(prompt_injection=False) or per-message via message.inject_prompt = False.
+        stream_channel (str): The named channel this agent's streamed tokens are broadcast on
+            when a run streams (see `rt.astream` / `stream_callback`). Defaults to "default".
+            Give different agents in one flow distinct channels to route their tokens to
+            different consumers (e.g. `stream_callback={"writer": fn1, "critic": fn2}` or
+            `stream.on_channel("writer")`). Note each round of a tool-calling loop is one
+            production on this channel.
     """
     unpacked_tool_nodes = _unpack_tool_nodes(tool_nodes)
 
@@ -187,6 +202,7 @@ def agent_node(
         model_middleware=model_middleware,
         guardrails=guardrails,
         context_injection=context_injection,
+        stream_channel=stream_channel,
     )
 
     return agent

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/structured_llm.py
@@ -4,11 +4,9 @@ from pydantic import BaseModel
 
 from railtracks.built_nodes._node_builder import NodeBuilder
 from railtracks.built_nodes.concrete.guarded_llm import (
-    GuardedStreamingStructuredLLM,
     GuardedStructuredLLM,
 )
 from railtracks.built_nodes.concrete.structured_llm_base import (
-    StreamingStructuredLLM,
     StructuredLLM,
 )
 from railtracks.guardrails.core import Guard
@@ -33,7 +31,7 @@ def structured_llm(
     return_into: str | None = None,
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
-) -> Type[StructuredLLM[_TOutput] | StreamingStructuredLLM[_TOutput]]:
+) -> Type[StructuredLLM[_TOutput]]:
     """
     Dynamically create a StructuredLastMessageLLM node class with custom configuration for output_schema.
 
@@ -56,14 +54,12 @@ def structured_llm(
     Returns:
         Type[StructuredLLM]: The dynamically generated node class with the specified configuration.
     """
-    is_streaming = llm is not None and llm.stream
-
+    # streaming is decided at the call site (rt.astream); the same node class serves both
+    # streaming and buffered invocations.
     if guardrails is not None:
-        base_cls = (
-            GuardedStreamingStructuredLLM if is_streaming else GuardedStructuredLLM
-        )
+        base_cls = GuardedStructuredLLM
     else:
-        base_cls = StreamingStructuredLLM if is_streaming else StructuredLLM
+        base_cls = StructuredLLM
 
     builder = NodeBuilder(
         base_cls,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/terminal_llm.py
@@ -2,11 +2,9 @@ from typing import Any, Callable
 
 from railtracks.built_nodes._node_builder import NodeBuilder
 from railtracks.built_nodes.concrete.guarded_llm import (
-    GuardedStreamingTerminalLLM,
     GuardedTerminalLLM,
 )
 from railtracks.built_nodes.concrete.terminal_llm_base import (
-    StreamingTerminalLLM,
     TerminalLLM,
 )
 from railtracks.guardrails.core import Guard
@@ -47,12 +45,12 @@ def terminal_llm(
     Returns:
         Type[LastMessageTerminalLLM]: The dynamically generated node class with the specified configuration.
     """
-    is_streaming = llm is not None and llm.stream
-
+    # streaming is decided at the call site (rt.astream); the same node class serves both
+    # streaming and buffered invocations.
     if guardrails is not None:
-        base_cls = GuardedStreamingTerminalLLM if is_streaming else GuardedTerminalLLM
+        base_cls = GuardedTerminalLLM
     else:
-        base_cls = StreamingTerminalLLM if is_streaming else TerminalLLM
+        base_cls = TerminalLLM
 
     builder = NodeBuilder(
         base_cls,

--- a/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/easy_usage_wrappers/helpers/tool_call_llm.py
@@ -4,7 +4,6 @@ from typing import Any, Callable, Iterable, Type, Union
 
 from railtracks.built_nodes._node_builder import NodeBuilder
 from railtracks.built_nodes.concrete.tool_call_llm_base import (
-    StreamingToolCallLLM,
     ToolCallLLM,
 )
 from railtracks.guardrails.core import Guard
@@ -28,7 +27,7 @@ def tool_call_llm(
     format_for_return: Callable[[Any], Any] | None = None,
     format_for_context: Callable[[Any], Any] | None = None,
     guardrails: Guard | None = None,
-) -> Type[ToolCallLLM | StreamingToolCallLLM]:
+) -> Type[ToolCallLLM]:
     """
     Dynamically create a ToolCallLLM node class with custom configuration for tool calling.
 
@@ -52,16 +51,16 @@ def tool_call_llm(
     Returns:
         Type[ToolCallLLM]: The dynamically generated node class with the specified configuration.
     """
-    is_streaming = llm is not None and llm.stream
+    # streaming is decided at the call site (rt.astream); the same node class serves both
+    # streaming and buffered invocations.
     if guardrails is not None:
         from railtracks.built_nodes.concrete.guarded_llm import (
-            GuardedStreamingToolCallLLM,
             GuardedToolCallLLM,
         )
 
-        base_cls = GuardedStreamingToolCallLLM if is_streaming else GuardedToolCallLLM
+        base_cls = GuardedToolCallLLM
     else:
-        base_cls = StreamingToolCallLLM if is_streaming else ToolCallLLM
+        base_cls = ToolCallLLM
 
     builder = NodeBuilder(
         base_cls,

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -1,7 +1,6 @@
 from typing import Awaitable, Callable
 
 from pydantic import BaseModel
-
 from railtracks.built_nodes._types import LLM_CALL
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.response import Response

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
@@ -1,7 +1,6 @@
 from typing import Awaitable, Callable
 
 from pydantic import BaseModel
-
 from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.tools.tool import Tool

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/core.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/core.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
@@ -1,7 +1,6 @@
 from typing import Awaitable, Callable
 
 from pydantic import BaseModel
-
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -27,7 +27,7 @@ def _should_stream(model: ModelBase, tools: list[Tool] | None) -> bool:
     """
     Frame-level streaming decision for a single model call.
 
-    Streaming is requested at the call site (`rt.astream` / a configured `stream_callback`)
+    Streaming is requested at the call site (`rt.astream` / `Flow.astream`)
     and is frame-local, so this returns True only for the entry frame of a streamed
     invocation. Tool-calling requests against blacklisted providers fall back to a buffered
     call (with a warning) instead of erroring.
@@ -151,7 +151,7 @@ class ModelInvoker:
             tools: list[Tool] | None,
         ) -> Response:
             # Streaming path: consume the model stream here, broadcasting each chunk to the
-            # run's consumers (rt.astream / stream_callback), and hand the complete Response
+            # run's consumers (rt.astream / route() / broadcast_callback), and hand the complete Response
             # back through the middleware chain — exit middleware (e.g. output guardrails)
             # operates on the buffered final response.
             if _should_stream(model, tools):

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -2,17 +2,69 @@ from __future__ import annotations
 
 import asyncio
 from copy import deepcopy
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Generator
 
 from pydantic import BaseModel
 from railtracks.built_nodes._types import ModelSource
-from railtracks.built_nodes.llm.request_details import RequestDetails
 from railtracks.built_nodes.llm.middleware.core import ModelMiddleware
 from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
+from railtracks.built_nodes.llm.request_details import RequestDetails
+from railtracks.context.central import is_streaming_enabled
+from railtracks.exceptions.errors import LLMError
+from railtracks.interaction.broadcast_ import broadcast_stream
 from railtracks.llm.history import MessageHistory
+from railtracks.llm.model import ModelBase
+from railtracks.llm.providers import TOOL_CALLING_STREAMING_BLACKLIST
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool
 from railtracks.middleware.chain import MiddlewareChain
+from railtracks.utils.logging import get_rt_logger
+
+logger = get_rt_logger(__name__)
+
+
+def _should_stream(model: ModelBase, tools: list[Tool] | None) -> bool:
+    """
+    Frame-level streaming decision for a single model call.
+
+    Streaming is requested at the call site (`rt.astream` / a configured `stream_callback`)
+    and is frame-local, so this returns True only for the entry frame of a streamed
+    invocation. Tool-calling requests against blacklisted providers fall back to a buffered
+    call (with a warning) instead of erroring.
+    """
+    if not is_streaming_enabled():
+        return False
+    if (
+        tools is not None
+        and len(tools) > 0
+        and model.model_provider() in TOOL_CALLING_STREAMING_BLACKLIST
+    ):
+        logger.warning(
+            "Streaming is not supported with %s for tool calling; falling back to a "
+            "buffered response.",
+            model.model_provider(),
+        )
+        return False
+    return True
+
+
+def _collect_legacy_stream(result: Response | Generator, messages: MessageHistory) -> Response:
+    """
+    Drains the sync generator returned by models constructed with the deprecated
+    `stream=True` flag so buffered invocations still produce a complete `Response`.
+    """
+    if isinstance(result, Generator):
+        final: Response | None = None
+        for item in result:
+            if isinstance(item, Response):
+                final = item
+        if final is None:
+            raise LLMError(
+                reason="The generator did not yield a final Response object",
+                message_history=messages,
+            )
+        return final
+    return result
 
 
 @wrap_llm
@@ -62,19 +114,27 @@ class ModelInvoker:
         self,
         model: ModelSource,
         middleware: list[ModelMiddleware] | None = None,
+        stream_channel: str = "default",
     ):
         self._get_model = model if callable(model) else lambda: model
         self._middleware = MiddlewareChain(middleware or [])
+        # the named channel this invoker's streamed chunks are broadcast on (see rt.broadcast)
+        self._stream_channel = stream_channel
 
     @classmethod
     def create_with_llm_observe(
-        cls, model: ModelSource, middleware: list[ModelMiddleware] | None = None
+        cls,
+        model: ModelSource,
+        middleware: list[ModelMiddleware] | None = None,
+        stream_channel: str = "default",
     ) -> ModelInvoker:
         """
         Creates a new :class:`ModelInvoker` with the given model and middleware, inserting the obersvation middleware as the last element run.
         """
         unwrapped_middleware = deepcopy(middleware) if middleware is not None else []
-        return cls(model, [*unwrapped_middleware, _llm_observe])
+        return cls(
+            model, [*unwrapped_middleware, _llm_observe], stream_channel=stream_channel
+        )
 
     async def invoke(
         self,
@@ -90,16 +150,40 @@ class ModelInvoker:
             schema: type[BaseModel] | None,
             tools: list[Tool] | None,
         ) -> Response:
+            # Streaming path: consume the model stream here, broadcasting each chunk to the
+            # run's consumers (rt.astream / stream_callback), and hand the complete Response
+            # back through the middleware chain — exit middleware (e.g. output guardrails)
+            # operates on the buffered final response.
+            if _should_stream(model, tools):
+                if tools is not None and len(tools) > 0:
+                    model_stream = model.astream_chat_with_tools(messages, tools=tools)
+                elif schema is not None:
+                    model_stream = model.astream_structured(messages, schema=schema)
+                else:
+                    model_stream = model.astream_chat(messages)
+
+                result = await broadcast_stream(
+                    model_stream, channel=self._stream_channel
+                )
+                if not isinstance(result, Response):
+                    raise LLMError(
+                        reason="The model stream did not yield a final Response object.",
+                        message_history=messages,
+                    )
+                return result
+
             if tools is not None and len(tools) > 0:
-                return await asyncio.to_thread(
+                buffered = await asyncio.to_thread(
                     model.chat_with_tools, messages, tools=tools
                 )
             elif schema is not None:
-                return await asyncio.to_thread(
+                buffered = await asyncio.to_thread(
                     model.structured, messages, schema=schema
                 )
             else:
-                return await asyncio.to_thread(model.chat, messages)
+                buffered = await asyncio.to_thread(model.chat, messages)
+
+            return _collect_legacy_stream(buffered, messages)
 
         return await self._middleware.run(_core_llm_call, messages, schema, tools)
 
@@ -113,4 +197,8 @@ class ModelInvoker:
         for m in model_middleware:
             new_middleware_chain.add_middleware(m)
 
-        return ModelInvoker(self._get_model, new_middleware_chain._middleware)
+        return ModelInvoker(
+            self._get_model,
+            new_middleware_chain._middleware,
+            stream_channel=self._stream_channel,
+        )

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -151,7 +151,7 @@ class ModelInvoker:
             tools: list[Tool] | None,
         ) -> Response:
             # Streaming path: consume the model stream here, broadcasting each chunk to the
-            # run's consumers (rt.astream / route() / broadcast_callback), and hand the complete Response
+            # run's consumers (rt.astream / route() / stream_callback), and hand the complete Response
             # back through the middleware chain — exit middleware (e.g. output guardrails)
             # operates on the buffered final response.
             if _should_stream(model, tools):

--- a/packages/railtracks/src/railtracks/context/__init__.py
+++ b/packages/railtracks/src/railtracks/context/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from .central import (
     delete,
     get,
@@ -6,4 +8,20 @@ from .central import (
     update,
 )
 
-__all__ = ["put", "get", "update", "delete", "keys"]
+if TYPE_CHECKING:
+    from railtracks.interaction._astream import get_stream
+
+__all__ = ["put", "get", "update", "delete", "keys", "get_stream"]
+
+
+def __getattr__(name: str):
+    # lazy import to avoid an import cycle (interaction imports from context.central)
+    if name == "get_stream":
+        from railtracks.interaction._astream import get_stream
+
+        return get_stream
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(__all__))

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import warnings
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, KeysView
+from typing import TYPE_CHECKING, Any, Callable, KeysView
 
 from railtracks.exceptions import ContextError
 
@@ -30,13 +30,24 @@ class RunnerContextVars:
         self.internal_context = internal_context
         self.external_context = external_context
 
-    def prepare_new(self, new_parent_id: str, new_run_id: str | None = None):
+    def prepare_new(
+        self,
+        new_parent_id: str,
+        new_run_id: str | None = None,
+        stream: bool = False,
+        stream_id: str | None = None,
+    ):
         """
         Update the parent ID of the internal context.
+
+        `stream` marks the new frame as streaming-enabled (frame-local, never inherited),
+        while `stream_id` (inherited when None) tracks which stream scope the frame belongs to.
         """
         new_internal_context = self.internal_context.prepare_new(
             new_parent_id=new_parent_id,
             run_id=new_run_id,
+            stream=stream,
+            stream_id=stream_id,
         )
 
         return RunnerContextVars(
@@ -101,10 +112,20 @@ def get_publisher() -> RTPublisher:
         RTPublisher: The publisher associated with the current thread's global variables.
 
     Raises:
-        RuntimeError: If the global variables have not been registered.
+        ContextError: If the global variables have not been registered or no publisher is
+            attached to the current context.
     """
     context = safe_get_runner_context()
-    return context.internal_context.publisher
+    publisher = context.internal_context.publisher
+    if publisher is None:
+        raise ContextError(
+            message="No publisher is attached to the current context.",
+            notes=[
+                "You need to have an active runner to access the publisher.",
+                "Eg.-\n with rt.Session():\n    _ = rt.call(node)",
+            ],
+        )
+    return publisher
 
 
 def get_session_id() -> str | None:
@@ -148,6 +169,33 @@ def get_run_id() -> str | None:
     """
     context = safe_get_runner_context()
     return context.internal_context.run_id
+
+
+def is_streaming_enabled() -> bool:
+    """
+    Returns True when the current frame was invoked with streaming enabled (via `rt.astream`
+    or a configured `stream_callback`).
+
+    LLM nodes use this to decide whether to stream their model responses token-by-token.
+    The flag is frame-local: it is True only for the entry frame of a streamed invocation and
+    never propagates to nested `rt.call` children. Returns False when no context is present.
+    """
+    context = runner_context.get()
+    if context is None:
+        return False
+    return context.internal_context.stream_enabled
+
+
+def get_stream_id() -> str | None:
+    """
+    Returns the stream scope id of the current frame (the entry request id of the streamed
+    run this frame belongs to), or None when the frame is not part of a streamed run or no
+    context is present.
+    """
+    context = runner_context.get()
+    if context is None:
+        return None
+    return context.internal_context.stream_id
 
 
 def register_globals(
@@ -199,11 +247,12 @@ async def shutdown_publisher():
     This function should be called to stop the publisher and clean up resources.
     """
     context = safe_get_runner_context()
-    context = context.internal_context
-    assert context is not None
+    internal_context = context.internal_context
 
-    assert context.publisher.is_running()
-    await context.publisher.shutdown()
+    publisher = internal_context.publisher
+    assert publisher is not None, "Cannot shutdown a publisher that was never attached."
+    assert publisher.is_running()
+    await publisher.shutdown()
 
 
 def get_global_config() -> ExecutorConfig:
@@ -240,7 +289,8 @@ def set_local_config(
     """
     context = safe_get_runner_context()
 
-    context.executor_config = executor_config
+    # the config lives on the internal context (RunnerContextVars has no such attribute)
+    context.internal_context.executor_config = executor_config
     runner_context.set(context)
 
 
@@ -256,11 +306,25 @@ def set_global_config(
     global_executor_config.set(executor_config)
 
 
-def update_parent_id(new_parent_id: str, new_run_id: str | None = None):
+def update_parent_id(
+    new_parent_id: str,
+    new_run_id: str | None = None,
+    *,
+    stream: bool = False,
+    stream_id: str | None = None,
+):
     """
     Update the parent ID of the current thread's global variables.
 
     If no run ID is provided, the current run ID will be used.
+
+    Args:
+        new_parent_id: The parent id of the new frame.
+        new_run_id: The run id of the new frame (defaults to the current one).
+        stream: If True, the new frame will have streaming enabled. This is frame-local:
+            child frames created afterwards will NOT inherit it.
+        stream_id: The stream scope id for the new frame. If None, the current stream id is
+            inherited.
     """
     current_context = safe_get_runner_context()
 
@@ -271,7 +335,9 @@ def update_parent_id(new_parent_id: str, new_run_id: str | None = None):
     if current_context is None:
         raise RuntimeError("No global variable set")
 
-    new_context = current_context.prepare_new(new_parent_id, new_run_id=new_run_id)
+    new_context = current_context.prepare_new(
+        new_parent_id, new_run_id=new_run_id, stream=stream, stream_id=stream_id
+    )
 
     runner_context.set(new_context)
 
@@ -357,8 +423,8 @@ def set_config(
     *,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    broadcast_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
+    stream_callback: (
+        Callable[[str], Any] | dict[str, Callable[[str], Any]] | None
     ) = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
@@ -369,7 +435,14 @@ def set_config(
     - If you call this function after the runner has been created, it will not affect the current runner.
     - This function will only overwrite the values that are provided, leaving the rest unchanged.
 
-
+    Args:
+        timeout: The maximum number of seconds to wait for a response to your top-level request.
+        end_on_error: If True, the execution will stop when an exception is encountered.
+        stream_callback: A callback (or dict mapping channel name -> callback) that receives
+            every streamed/broadcast item. Providing this also enables token streaming for
+            top-level calls (push-mode streaming).
+        prompt_injection: If True, the prompt will be automatically injected from context variables.
+        save_state: If True, the state of the execution will be saved to a file at the end of the run.
     """
 
     if is_context_active():
@@ -382,7 +455,7 @@ def set_config(
     new_config = config.precedence_overwritten(
         timeout=timeout,
         end_on_error=end_on_error,
-        subscriber=broadcast_callback,
+        stream_subscriber=stream_callback,
         prompt_injection=prompt_injection,
         save_state=save_state,
     )

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -174,7 +174,7 @@ def get_run_id() -> str | None:
 def is_streaming_enabled() -> bool:
     """
     Returns True when the current frame was invoked with streaming enabled (via `rt.astream`
-    or a configured `stream_callback`).
+    / `Flow.astream` — callbacks never enable streaming).
 
     LLM nodes use this to decide whether to stream their model responses token-by-token.
     The flag is frame-local: it is True only for the entry frame of a streamed invocation and
@@ -423,7 +423,7 @@ def set_config(
     *,
     timeout: float | None = None,
     end_on_error: bool | None = None,
-    stream_callback: (
+    broadcast_callback: (
         Callable[[str], Any] | dict[str, Callable[[str], Any]] | None
     ) = None,
     prompt_injection: bool | None = None,
@@ -438,9 +438,9 @@ def set_config(
     Args:
         timeout: The maximum number of seconds to wait for a response to your top-level request.
         end_on_error: If True, the execution will stop when an exception is encountered.
-        stream_callback: A callback (or dict mapping channel name -> callback) that receives
-            every streamed/broadcast item. Providing this also enables token streaming for
-            top-level calls (push-mode streaming).
+        broadcast_callback: A passive listener on the broadcast bus (or a dict mapping channel
+            name -> callback to route items per channel). It never enables streaming — only
+            `rt.astream` / `Flow.astream` do.
         prompt_injection: If True, the prompt will be automatically injected from context variables.
         save_state: If True, the state of the execution will be saved to a file at the end of the run.
     """
@@ -455,7 +455,7 @@ def set_config(
     new_config = config.precedence_overwritten(
         timeout=timeout,
         end_on_error=end_on_error,
-        stream_subscriber=stream_callback,
+        broadcast_callback=broadcast_callback,
         prompt_injection=prompt_injection,
         save_state=save_state,
     )

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -426,6 +426,9 @@ def set_config(
     broadcast_callback: (
         Callable[[str], Any] | dict[str, Callable[[str], Any]] | None
     ) = None,
+    stream_callback: (
+        Callable[[str], Any] | dict[str, Callable[[str], Any]] | None
+    ) = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ):
@@ -438,9 +441,12 @@ def set_config(
     Args:
         timeout: The maximum number of seconds to wait for a response to your top-level request.
         end_on_error: If True, the execution will stop when an exception is encountered.
-        broadcast_callback: A passive listener on the broadcast bus (or a dict mapping channel
-            name -> callback to route items per channel). It never enables streaming — only
-            `rt.astream` / `Flow.astream` do.
+        broadcast_callback: A passive listener for one-off events published with `rt.broadcast`
+            (or a dict mapping channel name -> callback to route events per channel). Streamed
+            chunks go to `stream_callback` instead.
+        stream_callback: A passive listener for stream chunks published through
+            `rt.broadcast_stream` (LLM token streams included). It never enables streaming —
+            only `rt.astream` / `Flow.astream` do.
         prompt_injection: If True, the prompt will be automatically injected from context variables.
         save_state: If True, the state of the execution will be saved to a file at the end of the run.
     """
@@ -456,6 +462,7 @@ def set_config(
         timeout=timeout,
         end_on_error=end_on_error,
         broadcast_callback=broadcast_callback,
+        stream_callback=stream_callback,
         prompt_injection=prompt_injection,
         save_state=save_state,
     )

--- a/packages/railtracks/src/railtracks/context/internal.py
+++ b/packages/railtracks/src/railtracks/context/internal.py
@@ -23,12 +23,16 @@ class InternalContext:
         publisher: RTPublisher | None = None,
         parent_id: str | None = None,
         executor_config: ExecutorConfig,
+        stream_enabled: bool = False,
+        stream_id: str | None = None,
     ):
         self._parent_id: str | None = parent_id
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
         self._executor_config: ExecutorConfig = executor_config
+        self._stream_enabled: bool = stream_enabled
+        self._stream_id: str | None = stream_id
 
     @property
     def executor_config(self) -> ExecutorConfig:
@@ -83,14 +87,43 @@ class InternalContext:
     def run_id(self) -> str | None:
         return self._run_id
 
+    @property
+    def stream_enabled(self) -> bool:
+        """True when the frame attached to this context should stream its LLM responses.
+
+        This flag is frame-local: it is set only on the entry frame of a streamed invocation
+        (see `rt.astream`) and is never inherited by child frames.
+        """
+        return self._stream_enabled
+
+    @property
+    def stream_id(self) -> str | None:
+        """The stream scope this frame belongs to (the entry request id of a streamed run).
+
+        Unlike `stream_enabled`, this id is inherited by child frames so their explicit
+        broadcasts can be routed back to the consumer attached to the entry frame.
+        """
+        return self._stream_id
+
     def prepare_new(
-        self, new_parent_id: str, run_id: str | None = None
+        self,
+        new_parent_id: str,
+        run_id: str | None = None,
+        stream: bool = False,
+        stream_id: str | None = None,
     ) -> InternalContext:
         """
         Prepares a new InternalContext with a new parent ID. If `run_id` or `session_id` are not provided, they will default to the current context's values.
 
         Note: the previous publisher will copied by reference into the next object.
 
+        Args:
+            new_parent_id: The parent id of the new frame.
+            run_id: The run id of the new frame. Defaults to the current context's run id.
+            stream: Whether the new frame should have streaming enabled. Note this is
+                deliberately NOT inherited from the current context (streaming is frame-local).
+            stream_id: The stream scope id of the new frame. If None, the current context's
+                stream id is inherited (so nested broadcasts stay routed to the entry consumer).
         """
 
         unwrapped_run_id: str | None
@@ -105,4 +138,6 @@ class InternalContext:
             session_id=self._session_id,
             run_id=unwrapped_run_id,
             executor_config=self._executor_config,
+            stream_enabled=stream,
+            stream_id=stream_id if stream_id is not None else self._stream_id,
         )

--- a/packages/railtracks/src/railtracks/execution/task.py
+++ b/packages/railtracks/src/railtracks/execution/task.py
@@ -18,21 +18,30 @@ class Task(Generic[_TOutput]):
         request_id: str,
         node: Node[..., _TOutput],
         arguments: tuple[tuple, dict[str, Any]],
+        stream: bool = False,
     ):
         self.request_id = request_id
         self.node = node
         self.arguments = arguments
+        # when True the node's frame will run with streaming enabled (frame-local, see rt.astream)
+        self.stream = stream
 
     async def invoke(self):
         """The callable that this task is representing."""
+        # if this frame is the entry of a streamed invocation, its request id becomes the
+        # stream scope id used to route broadcast chunks back to the consumer.
+        stream_id = self.request_id if self.stream else None
+
         # if there is no parent run_id then this is the root
         if get_run_id() is None:
             # note critically that since these variables only this tree of requests will see this run_id.
-            update_parent_id(self.node.uuid, self.node.uuid)
+            update_parent_id(
+                self.node.uuid, self.node.uuid, stream=self.stream, stream_id=stream_id
+            )
 
         # otherwise we are already in a run so we just use the previous one.
         else:
-            update_parent_id(self.node.uuid)
+            update_parent_id(self.node.uuid, stream=self.stream, stream_id=stream_id)
 
         result = await self.node.wrapped_invoke(*self.arguments[0], **self.arguments[1])
 

--- a/packages/railtracks/src/railtracks/interaction/__init__.py
+++ b/packages/railtracks/src/railtracks/interaction/__init__.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from ._astream import Stream, astream
 from ._call import call
 from .batch import call_batch
-from .broadcast_ import broadcast
+from .broadcast_ import broadcast, broadcast_stream
 from .couple import couple
 
 if TYPE_CHECKING:
@@ -13,7 +14,10 @@ if TYPE_CHECKING:
 __all__ = [
     "call",
     "call_batch",
+    "astream",
+    "Stream",
     "broadcast",
+    "broadcast_stream",
     "local_chat",
     "couple",
 ]

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncIterator,
+    Callable,
+    Generator,
+    Generic,
+    NoReturn,
+    ParamSpec,
+    TypeVar,
+    overload,
+)
+from uuid import uuid4
+
+from railtracks.context.central import (
+    activate_publisher,
+    get_local_config,
+    get_parent_id,
+    get_publisher,
+    get_run_id,
+    get_stream_id,
+    is_context_present,
+)
+from railtracks.exceptions import GlobalTimeOutError
+from railtracks.nodes.utils import extract_node_from_function
+from railtracks.pubsub.messages import (
+    FatalFailure,
+    RequestCompletionMessage,
+    RequestCreation,
+    RequestFinishedBase,
+    StreamEnd,
+    Streaming,
+)
+from railtracks.pubsub.utils import output_mapping
+from railtracks.utils.logging import get_rt_logger
+
+if TYPE_CHECKING:
+    from railtracks._session import Session
+    from railtracks.built_nodes.concrete import RTFunction
+    from railtracks.nodes.nodes import Node
+
+_P = ParamSpec("_P")
+_TOutput = TypeVar("_TOutput")
+
+logger = get_rt_logger(__name__)
+
+# sentinel used to mark "no result yet" (None is a valid node result)
+_UNSET = object()
+
+# queue-item tags used between get_stream's subscriber and its consuming generator
+_CHUNK = "chunk"
+_END = "end"
+
+
+class _Terminated:
+    """Sentinel type returned by `_next_channel_item` once `until` fired and the buffer drained."""
+
+
+_TERMINATED = _Terminated()
+
+
+async def _drain_channel(
+    queue: asyncio.Queue[tuple[str, Any]],
+    streams: int | None,
+    until: asyncio.Future[Any] | None,
+    unsubscribe: Callable[[], None],
+) -> AsyncIterator[Any]:
+    """Yields queued channel chunks until enough `StreamEnd` markers (or `until`) arrive.
+
+    This is the (lazy) generator half of `get_stream`; the eager half — subscribing to the
+    bus — must run at `get_stream()` call time, before the first iteration, which is why the
+    two are separate functions (an async generator body does not execute until first
+    `__anext__`, and chunks emitted before then would otherwise be lost).
+
+    Termination is fully event-driven — no polling:
+    - end-markers ride the same FIFO queue as the chunks, so when the `streams`-th marker is
+      dequeued every chunk of those productions has already been yielded;
+    - while idle we race `queue.get()` against the optional `until` future and wake on
+      whichever fires first.
+
+    Always unsubscribes (via `unsubscribe`) when iteration ends — on normal completion,
+    an early `break` (the async generator's `aclose`), or garbage collection.
+    """
+    ends_seen = 0
+    try:
+        while True:
+            item = await _next_channel_item(queue, until)
+            if isinstance(item, _Terminated):
+                return
+            if item is None:
+                continue  # `until` fired mid-wait; loop drains stragglers, then terminates
+            kind, payload = item
+            if kind == _CHUNK:
+                yield payload
+            else:  # _END: one production on this channel finished
+                ends_seen += 1
+                if streams is not None and ends_seen >= streams:
+                    return
+    finally:
+        unsubscribe()
+
+
+async def _next_channel_item(
+    queue: asyncio.Queue[tuple[str, Any]],
+    until: asyncio.Future[Any] | None,
+) -> tuple[str, Any] | _Terminated | None:
+    """Gets the next queued item, racing against `until` when one is provided.
+
+    Returns the item, `_TERMINATED` when `until` is done and the queue is drained, or None
+    when `until` fired while waiting (caller loops to drain any stragglers).
+    """
+    try:
+        return queue.get_nowait()
+    except asyncio.QueueEmpty:
+        pass
+
+    if until is None:
+        return await queue.get()
+
+    # queue is empty; if the terminator already fired no more chunks can arrive
+    # (bus dispatch is FIFO: everything published before it was already delivered)
+    if until.done():
+        return _TERMINATED
+
+    # race: the next item vs. the terminator, whichever happens first
+    getter = asyncio.ensure_future(queue.get())
+    try:
+        await asyncio.wait({getter, until}, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        if not getter.done():
+            # cancelling a Queue.get never loses items: items only leave the
+            # queue via get_nowait/get returning, and we re-drain on loop entry.
+            getter.cancel()
+
+    if getter.done() and not getter.cancelled():
+        return getter.result()
+    return None
+
+
+def get_stream(
+    channel: str = "default",
+    *,
+    streams: int | None = 1,
+    until: asyncio.Future[Any] | None = None,
+) -> AsyncIterator[Any]:
+    """
+    Consume a broadcast channel *from inside a run*, as its chunks arrive.
+
+    This is the intra-run counterpart to `rt.astream`: rather than launching and consuming a
+    top-level call, it taps a channel that some *other, concurrently running* part of the same
+    run is broadcasting to (via `rt.broadcast` / `rt.broadcast_stream`). The typical shape is a
+    producer node launched as a task while the current frame folds its stream in:
+
+    ```python
+    @rt.function_node
+    async def orchestrator(topic: str) -> str:
+        task = asyncio.create_task(rt.call(producer, topic=topic))  # streams on "tokens"
+        async for chunk in rt.context.get_stream("tokens"):          # ends with the stream
+            print(chunk, end="", flush=True)                         # live child tokens
+        return (await task).text
+    ```
+
+    Termination — by counting finished productions:
+        Every `rt.broadcast_stream` publishes a `StreamEnd` marker on its channel when it
+        finishes (even if the producer raised). By default (`streams=1`) iteration ends once
+        **one** production has completed — so for the common single-producer fold the loop
+        above just ends by itself, no extra signal needed.
+
+        - Several producers on one channel? `streams=N` ends after N productions.
+        - Open-ended feed (unknown producers, or bare `rt.broadcast` items, which carry no
+          markers)? `streams=None` and bound the loop yourself: `break`, or pass
+          `until=some_task` to stop when that task completes (also useful as a safety net —
+          e.g. `until=task` guards against a producer that crashes before ever reaching its
+          `broadcast_stream` call, in which case no marker is ever published).
+
+        Whichever of `streams` / `until` is satisfied first ends the iteration; buffered
+        chunks are always drained before stopping.
+
+    Scope: only chunks belonging to the current stream scope are delivered (child frames
+    inherit the scope, so a producer started with `rt.call` from here is included; unrelated
+    concurrent runs are not). In a plain non-streamed run the scope id is None, so give
+    concurrent independent folds distinct channel names.
+
+    Subscription happens eagerly when this function is called — before the first iteration —
+    so chunks emitted between launching the producer and starting to iterate are not missed.
+
+    Args:
+        channel: The channel name to consume. Defaults to `"default"`.
+        streams: How many finished productions (`StreamEnd` markers) end the iteration.
+            Defaults to 1 — one `broadcast_stream` production. Pass None for an unbounded
+            feed that you terminate yourself (`break` or `until`).
+        until: Optional future/task that also ends the iteration when done (after draining).
+
+    Returns:
+        AsyncIterator[Any]: An async iterator over the chunks broadcast on `channel` within
+            the current run.
+    """
+    stream_id = get_stream_id()
+    publisher = get_publisher()
+    queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+
+    def _subscriber(message: RequestCompletionMessage) -> None:
+        if isinstance(message, Streaming):
+            if message.stream_id == stream_id and message.channel == channel:
+                queue.put_nowait((_CHUNK, message.streamed_object))
+        elif isinstance(message, StreamEnd):
+            if message.stream_id == stream_id and message.channel == channel:
+                queue.put_nowait((_END, None))
+
+    # subscribe eagerly (synchronously) so nothing emitted before the first iteration is lost
+    sub_id = publisher.subscribe(_subscriber, name="channel stream subscriber")
+
+    def _unsubscribe() -> None:
+        try:
+            publisher.unsubscribe(sub_id)
+        except Exception:
+            logger.debug("Failed to unsubscribe channel stream.", exc_info=True)
+
+    return _drain_channel(queue, streams, until, _unsubscribe)
+
+
+class Stream(Generic[_TOutput], AsyncIterator[Any]):
+    """
+    The handle returned by `rt.astream(...)` (and `Flow.astream(...)`).
+
+    A `Stream` is an async iterator over the chunks emitted during a streamed invocation. It
+    yields *only* chunks (typically `str` tokens); the node's final return value is exposed
+    separately so there is never any ambiguity between a chunk and the final result:
+
+    ```python
+    stream = rt.astream(agent, user_input="Write a poem.")
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+    final = stream.result  # the node's complete return value (e.g. StringResponse)
+    ```
+
+    The final result may legitimately differ from the concatenation of the streamed chunks —
+    for example when output guardrails gate/correct the buffered response after the raw tokens
+    were streamed.
+
+    A `Stream` is also awaitable: `final = await stream` consumes the stream to completion
+    (discarding any unread chunks) and returns the final result. This is handy when you stop
+    iterating early (`break`) but still want the run to finish and the result to be available —
+    the underlying invocation always runs to completion; breaking out of the loop does not
+    cancel it.
+
+    To consume only a specific named channel, chain `on_channel` before iterating:
+
+    ```python
+    async for chunk in rt.astream(node, topic="x").on_channel("final"):
+        ...
+    ```
+
+    Error behavior: if the invoked node raises, the exception propagates out of the `async for`
+    loop (or the `await`), exactly like `rt.call`.
+
+    Notes:
+        - Iterate (and await) a `Stream` from a single task.
+        - The stream honors the session's `timeout` as a wall-clock limit on the whole run.
+    """
+
+    def __init__(
+        self,
+        node: type[Node[_P, _TOutput]],
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+        *,
+        channel: str | None = None,
+        owned_session: Session | None = None,
+    ):
+        """
+        Creates a new (not yet started) streamed invocation. Prefer `rt.astream(...)` /
+        `Flow.astream(...)` over constructing this directly.
+
+        Args:
+            node: The node type to invoke.
+            args: The positional arguments to pass to the node.
+            kwargs: The keyword arguments to pass to the node.
+            channel: Only yield chunks emitted on this named channel (None = all channels).
+            owned_session: A session this stream is responsible for closing once the run
+                completes (used by `Flow.astream`; `rt.astream` creates one lazily when
+                called outside any session).
+        """
+        self._node = node
+        self._args = args
+        self._kwargs = kwargs
+        # None means "receive chunks from every channel"; a name filters to that channel only.
+        self._channel = channel
+
+        # the request id doubles as the stream scope id used to tag every chunk of this run
+        self._request_id = str(uuid4())
+
+        self._queue: asyncio.Queue[tuple[str, Any]] | None = None
+        self._started = False
+        self._finished = False
+        self._result: Any = _UNSET
+        self._error: BaseException | None = None
+        self._sub_id: str | None = None
+        self._deadline: float | None = None
+        self._timeout: float | None = None
+        # a session this stream is responsible for closing once the run completes
+        self._owned_session: Session | None = owned_session
+
+    # ------------------------------------------------------------------ configuration
+
+    def on_channel(self, channel: str | None) -> Stream[_TOutput]:
+        """
+        Restricts this stream to chunks emitted on the given named channel.
+
+        Must be called before iteration starts. Returns `self` so it can be chained:
+
+        ```python
+        async for chunk in rt.astream(node, topic="x").on_channel("final"):
+            ...
+        ```
+
+        Why a method rather than a `channel=` argument on `astream`: `astream` forwards its
+        `*args`/`**kwargs` straight to the target node (like `rt.call`), so a `channel=`
+        keyword would collide with any node that declares its own `channel` parameter, and is
+        in any case disallowed by the type system after a forwarded `*args`. Selecting the
+        channel on the returned handle keeps the node's own arguments unambiguous.
+
+        Args:
+            channel: The channel name to filter on, or None to receive every channel
+                (the default behavior).
+
+        Returns:
+            Stream[_TOutput]: This stream, for chaining.
+
+        Raises:
+            RuntimeError: If the stream has already started iterating.
+        """
+        if self._started:
+            raise RuntimeError(
+                "on_channel() must be called before the stream is iterated."
+            )
+        self._channel = channel
+        return self
+
+    # ------------------------------------------------------------------ lifecycle
+
+    async def _start(self) -> None:
+        """Lazily starts the run on first iteration: subscribes to the bus, then publishes
+        the entry request with streaming enabled."""
+        if self._started:
+            return
+        self._started = True
+
+        if not is_context_present():
+            # lazy import to prevent a circular import (same pattern as rt.call)
+            from railtracks import Session
+
+            self._owned_session = Session()
+
+        await activate_publisher()
+        publisher = get_publisher()
+        queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+        self._queue = queue
+
+        request_id = self._request_id
+
+        def _subscriber(message: RequestCompletionMessage) -> None:
+            if isinstance(message, Streaming):
+                if message.stream_id != request_id:
+                    return
+                if self._channel is not None and message.channel != self._channel:
+                    return
+                queue.put_nowait(("chunk", message.streamed_object))
+            elif isinstance(message, RequestFinishedBase):
+                if message.request_id == request_id:
+                    queue.put_nowait(("done", message))
+            elif isinstance(message, FatalFailure):
+                queue.put_nowait(("done", message))
+
+        # subscribe BEFORE publishing the request so no chunk can be missed
+        self._sub_id = publisher.subscribe(_subscriber, name="astream subscriber")
+
+        self._timeout = get_local_config().timeout
+        self._deadline = (
+            None if self._timeout is None else time.monotonic() + self._timeout
+        )
+
+        await publisher.publish(
+            RequestCreation(
+                current_node_id=get_parent_id(),
+                current_run_id=get_run_id(),
+                new_request_id=request_id,
+                running_mode="async",
+                new_node_type=self._node,
+                args=self._args,
+                kwargs=self._kwargs,
+                stream=True,
+            )
+        )
+
+    def _cleanup(self) -> None:
+        """Unsubscribes from the bus and closes the owned session (if any)."""
+        if self._sub_id is not None:
+            try:
+                get_publisher().unsubscribe(self._sub_id)
+            except Exception:
+                # the publisher may already be gone (e.g. session shut down); nothing to do.
+                logger.debug("Failed to unsubscribe astream subscriber.", exc_info=True)
+            self._sub_id = None
+
+        if self._owned_session is not None:
+            session = self._owned_session
+            self._owned_session = None
+            session.__exit__(None, None, None)
+
+    # ------------------------------------------------------------------ iteration
+
+    def __aiter__(self) -> Stream[_TOutput]:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._finished:
+            raise StopAsyncIteration
+
+        await self._start()
+        assert self._queue is not None
+
+        remaining: float | None = None
+        if self._deadline is not None:
+            remaining = self._deadline - time.monotonic()
+            if remaining <= 0:
+                self._finish_with_timeout()
+
+        try:
+            kind, payload = await asyncio.wait_for(self._queue.get(), timeout=remaining)
+        except asyncio.TimeoutError:
+            self._finish_with_timeout()
+
+        if kind == "chunk":
+            return payload
+
+        # the run has finished: resolve the final result (or raise the node's error)
+        self._finished = True
+        self._cleanup()
+        try:
+            self._result = output_mapping(payload)
+        except BaseException as e:
+            self._error = e
+            raise
+        raise StopAsyncIteration
+
+    def _finish_with_timeout(self) -> NoReturn:
+        """Marks the stream as finished and raises the global timeout error."""
+        assert self._timeout is not None, "timeout can only fire when one is configured"
+        error = GlobalTimeOutError(timeout=self._timeout)
+        self._finished = True
+        self._error = error
+        self._cleanup()
+        raise error
+
+    # ------------------------------------------------------------------ result access
+
+    @property
+    def result(self) -> _TOutput:
+        """
+        The node's final return value.
+
+        Only available once the stream has been fully consumed (or awaited).
+
+        Returns:
+            _TOutput: The value the node returned (e.g. a `StringResponse` for agents).
+
+        Raises:
+            RuntimeError: If the stream has not finished yet.
+            BaseException: The node's own exception, if the run failed.
+        """
+        if self._error is not None:
+            raise self._error
+        if self._result is _UNSET:
+            raise RuntimeError(
+                "The stream has not finished yet. Iterate it to completion (or use "
+                "`final = await stream`) before accessing `.result`."
+            )
+        return self._result
+
+    async def _drain(self) -> _TOutput:
+        """Consumes the rest of the stream (discarding unread chunks) and returns the result."""
+        async for _ in self:
+            pass
+        return self.result
+
+    def __await__(self) -> Generator[Any, None, _TOutput]:
+        """Awaiting a Stream consumes it to completion and returns the final result."""
+        return self._drain().__await__()
+
+
+@overload
+def astream(
+    node_: type[Node[_P, _TOutput]],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> Stream[_TOutput]: ...
+
+
+@overload
+def astream(
+    node_: RTFunction[_P, _TOutput],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> Stream[_TOutput]: ...
+
+
+def astream(
+    node_: type[Node[_P, _TOutput]] | RTFunction[_P, _TOutput],
+    *args: _P.args,
+    **kwargs: _P.kwargs,
+) -> Stream[_TOutput]:
+    """
+    Invoke a node with streaming enabled and return a `Stream` over its emitted chunks.
+
+    This is the pull-based streaming entry point of railtracks. The same node/agent object
+    serves streaming and non-streaming runs — `rt.call` runs it buffered, `rt.astream` streams
+    it. Streaming is frame-local: only the node you invoke here streams its LLM responses;
+    nested `rt.call` children run buffered (their explicit `rt.broadcast` chunks are still
+    delivered).
+
+    Usage:
+    ```python
+    stream = rt.astream(agent, user_input="Write a short poem about rain.")
+    async for chunk in stream:
+        print(chunk, end="", flush=True)   # str token chunks
+    final = stream.result                  # the complete StringResponse
+    ```
+
+    When you only care about the final result of the streamed run:
+    ```python
+    final = await rt.astream(agent, user_input="...")
+    ```
+
+    To consume a single named channel, chain `on_channel` on the returned handle (channel
+    selection is a method, not a keyword argument, because `astream` forwards its keywords to
+    the node — see `Stream.on_channel`):
+    ```python
+    async for chunk in rt.astream(node, topic="x").on_channel("final"):
+        ...
+    ```
+
+    Args:
+        node_: The node to invoke. This can be a node class or a function decorated with
+            `@function_node` (same as `rt.call`).
+        *args: The positional arguments to pass to the node.
+        **kwargs: The keyword arguments to pass to the node.
+
+    Returns:
+        Stream[_TOutput]: An async iterator over the chunks, with the final result available
+            via `.result` (or by awaiting the stream).
+    """
+    node: type[Node[_P, _TOutput]]
+
+    # local import to prevent circular import issues (mirrors rt.call)
+    from railtracks.built_nodes.concrete import RTFunction
+
+    if isinstance(node_, RTFunction):
+        node = extract_node_from_function(node_)
+    else:
+        node = node_
+
+    return Stream(node, args, kwargs)

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -473,9 +474,9 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         Consumes this stream push-style, dispatching each chunk to handler(s) by channel, and
         returns the node's final result.
 
-        This is the per-call push consumer: unlike a session-level `broadcast_callback`
-        (which passively observes *every* run in the session), `route` receives only this
-        stream's own chunks and is what actually enables the streaming.
+        This is the per-call push consumer: unlike a session-level `stream_callback`
+        (which passively observes streamed chunks from *every* run in the session), `route`
+        receives only this stream's own chunks and is what actually enables the streaming.
 
         ```python
         final = await flow.astream("Write a poem.").route(
@@ -497,8 +498,8 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         Note:
             Only chunks in *this* stream's scope are routed. A nested `rt.astream` inside the
             invoked node creates its own scope — consume those with a session-level
-            `broadcast_callback` instead. If some registered channels never receive a chunk, a
-            warning is logged when the stream ends.
+            `stream_callback` instead. If some registered channels never receive a chunk, a
+            `UserWarning` is emitted when the stream ends.
         """
         registered = set(handlers.keys()) if isinstance(handlers, Mapping) else None
         fired: set[str] = set()
@@ -526,12 +527,17 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         if registered is not None:
             unused = registered - fired
             if unused:
-                logger.warning(
-                    "route(): handler channels %s never received any chunks%s.",
-                    sorted(unused),
+                detail = (
                     f"; observed channels were {sorted(seen)}"
                     if seen
-                    else " — the stream produced no chunks",
+                    else " — the stream produced no chunks"
+                )
+                # a UserWarning (not a log record) so it is visible by default
+                warnings.warn(
+                    f"route(): handler channels {sorted(unused)} never received any "
+                    f"chunks{detail}.",
+                    UserWarning,
+                    stacklevel=2,
                 )
 
         return self.result

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Generator,
     Generic,
+    Mapping,
     NoReturn,
     ParamSpec,
     TypeVar,
@@ -36,6 +37,7 @@ from railtracks.pubsub.messages import (
     Streaming,
 )
 from railtracks.pubsub.utils import output_mapping
+from railtracks.utils.config import BroadcastCallback
 from railtracks.utils.logging import get_rt_logger
 
 if TYPE_CHECKING:
@@ -255,6 +257,13 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         ...
     ```
 
+    For push-style consumption, `route` dispatches chunks to handlers by channel and returns
+    the final result:
+
+    ```python
+    final = await rt.astream(node, topic="x").route({"draft": fn1, "final": fn2})
+    ```
+
     Error behavior: if the invoked node raises, the exception propagates out of the `async for`
     loop (or the `await`), exactly like `rt.call`.
 
@@ -369,7 +378,8 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
                     return
                 if self._channel is not None and message.channel != self._channel:
                     return
-                queue.put_nowait(("chunk", message.streamed_object))
+                # keep the channel alongside the payload so route() can dispatch by it
+                queue.put_nowait(("chunk", (message.channel, message.streamed_object)))
             elif isinstance(message, RequestFinishedBase):
                 if message.request_id == request_id:
                     queue.put_nowait(("done", message))
@@ -418,6 +428,16 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         return self
 
     async def __anext__(self) -> Any:
+        _, chunk = await self._next_tagged()
+        return chunk
+
+    async def _next_tagged(self) -> tuple[str, Any]:
+        """Core iteration step: returns the next `(channel, chunk)` pair.
+
+        Raises `StopAsyncIteration` once the run finishes (resolving `.result`), or the
+        node's error / `GlobalTimeOutError` like `__anext__` does. `route()` uses the channel;
+        `__anext__` discards it (public iteration yields chunks only).
+        """
         if self._finished:
             raise StopAsyncIteration
 
@@ -436,7 +456,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
             self._finish_with_timeout()
 
         if kind == "chunk":
-            return payload
+            return payload  # (channel, chunk)
 
         # the run has finished: resolve the final result (or raise the node's error)
         self._finished = True
@@ -447,6 +467,74 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
             self._error = e
             raise
         raise StopAsyncIteration
+
+    async def route(self, handlers: BroadcastCallback) -> _TOutput:
+        """
+        Consumes this stream push-style, dispatching each chunk to handler(s) by channel, and
+        returns the node's final result.
+
+        This is the per-call push consumer: unlike a session-level `broadcast_callback`
+        (which passively observes *every* run in the session), `route` receives only this
+        stream's own chunks and is what actually enables the streaming.
+
+        ```python
+        final = await flow.astream("Write a poem.").route(
+            {"draft": to_editor_pane, "final": to_chat_pane}
+        )
+        ```
+
+        Args:
+            handlers: A single callable (receives every chunk of this stream), or a mapping of
+                channel name -> callable (chunks on unregistered channels are skipped).
+                Callables may be sync or async.
+
+        Returns:
+            _TOutput: The node's final return value (same as `stream.result`).
+
+        Raises:
+            BaseException: The node's own exception, if the run failed.
+
+        Note:
+            Only chunks in *this* stream's scope are routed. A nested `rt.astream` inside the
+            invoked node creates its own scope — consume those with a session-level
+            `broadcast_callback` instead. If some registered channels never receive a chunk, a
+            warning is logged when the stream ends.
+        """
+        registered = set(handlers.keys()) if isinstance(handlers, Mapping) else None
+        fired: set[str] = set()
+        seen: set[str] = set()
+
+        while True:
+            try:
+                channel, chunk = await self._next_tagged()
+            except StopAsyncIteration:
+                break
+
+            seen.add(channel)
+            if isinstance(handlers, Mapping):
+                fn = handlers.get(channel)
+                if fn is None:
+                    continue
+                fired.add(channel)
+            else:
+                fn = handlers
+
+            result = fn(chunk)
+            if asyncio.iscoroutine(result):
+                await result
+
+        if registered is not None:
+            unused = registered - fired
+            if unused:
+                logger.warning(
+                    "route(): handler channels %s never received any chunks%s.",
+                    sorted(unused),
+                    f"; observed channels were {sorted(seen)}"
+                    if seen
+                    else " — the stream produced no chunks",
+                )
+
+        return self.result
 
     def _finish_with_timeout(self) -> NoReturn:
         """Marks the stream as finished and raises the global timeout error."""

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -17,6 +17,7 @@ from railtracks.context.central import (
     get_parent_id,
     get_publisher,
     get_run_id,
+    get_stream_id,
     is_context_active,
     is_context_present,
 )
@@ -200,6 +201,13 @@ async def _execute(
     # filter for its completion
     request_id = str(uuid4())
 
+    # Streaming is opt-in and frame-local. A regular `rt.call` never streams, with one
+    # exception: a top-level call (no parent frame) made while a `stream_callback` is
+    # configured streams in "push" mode so the callback receives token chunks.
+    stream = (
+        get_parent_id() is None and get_local_config().stream_subscriber is not None
+    )
+
     # note we set the listener before we publish the messages ensure that we do not miss any messages
     # I am actually a bit worried about this logic and I think there is a chance of a bug popping up here.
     f = publisher.listener(message_filter(request_id), output_mapping)
@@ -213,6 +221,8 @@ async def _execute(
             new_node_type=node,
             args=args,
             kwargs=kwargs,
+            stream=stream,
+            current_stream_id=get_stream_id(),
         )
     )
 

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -201,12 +201,9 @@ async def _execute(
     # filter for its completion
     request_id = str(uuid4())
 
-    # Streaming is opt-in and frame-local. A regular `rt.call` never streams, with one
-    # exception: a top-level call (no parent frame) made while a `stream_callback` is
-    # configured streams in "push" mode so the callback receives token chunks.
-    stream = (
-        get_parent_id() is None and get_local_config().stream_subscriber is not None
-    )
+    # Streaming is opt-in and frame-local: a regular `rt.call` NEVER streams. The only
+    # enabler is `rt.astream` / `Flow.astream`, which publishes its own RequestCreation with
+    # stream=True (callbacks are passive listeners and do not enable streaming).
 
     # note we set the listener before we publish the messages ensure that we do not miss any messages
     # I am actually a bit worried about this logic and I think there is a chance of a bug popping up here.
@@ -221,7 +218,6 @@ async def _execute(
             new_node_type=node,
             args=args,
             kwargs=kwargs,
-            stream=stream,
             current_stream_id=get_stream_id(),
         )
     )

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -1,16 +1,136 @@
-from railtracks.context.central import get_parent_id, get_publisher
-from railtracks.pubsub.messages import Streaming
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, AsyncIterable, Iterable, Union, overload
+from uuid import uuid4
+
+from railtracks.context.central import get_parent_id, get_publisher, get_stream_id
+from railtracks.pubsub.messages import StreamEnd, Streaming
+
+if TYPE_CHECKING:
+    from railtracks.llm.response import Response
 
 
-async def broadcast(item: str):
+async def broadcast(item: Any, channel: str = "default"):
     """
-    Streams the given message
+    Streams the given item to the session's broadcast bus.
 
-    This will trigger the broadcast_callback callback you have already provided.
+    Consumers attached to the run will receive it:
+
+    - `rt.astream(...)` (pull mode) yields the item from its async iterator.
+    - A configured `stream_callback` (push mode) is invoked with the item; when the callback
+      is a dict, the item is routed to the callable registered under `channel` (a single
+      callable receives every item on every channel).
+    - `rt.context.get_stream(channel, ...)` (pull mode, from inside the run) yields it.
+
+    If nothing is listening, the item is simply dropped — broadcasting is always safe.
 
     Args:
-        item (str): The item you want to stream.
+        item: The item you want to stream (typically a `str` chunk).
+        channel: The named channel to emit on. Defaults to `"default"`.
     """
     publisher = get_publisher()
 
-    await publisher.publish(Streaming(node_id=get_parent_id(), streamed_object=item))
+    await publisher.publish(
+        Streaming(
+            node_id=get_parent_id(),
+            streamed_object=item,
+            channel=channel,
+            stream_id=get_stream_id(),
+        )
+    )
+
+
+@overload
+async def broadcast_stream(
+    stream: Union[AsyncIterable[str], Iterable[str]],
+    channel: str = "default",
+) -> str:
+    """A stream of plain `str` chunks (no terminal item) resolves to the accumulated text."""
+
+
+@overload
+async def broadcast_stream(
+    stream: Union[AsyncIterable[Union[str, Response]], Iterable[Union[str, Response]]],
+    channel: str = "default",
+) -> Response:
+    """A model stream (`str` chunks followed by a final `Response`) resolves to that `Response`."""
+
+
+async def broadcast_stream(
+    stream: Union[AsyncIterable[Any], Iterable[Any]],
+    channel: str = "default",
+) -> Union[Response, str]:
+    """
+    Consumes a (sync or async) stream of chunks, broadcasting each `str` chunk on the given
+    channel, and returns the final result once the stream is exhausted.
+
+    This is the bridge between a raw model stream and the railtracks streaming system: inside a
+    custom node you can forward a `model.astream_chat(...)` stream to whoever is consuming the
+    run (`rt.astream` or a `stream_callback`) while still receiving the complete final response
+    to build your node's return value:
+
+    ```python
+    @rt.function_node
+    async def poem(topic: str) -> str:
+        model = rt.llm.OpenAILLM("gpt-4o-mini")
+        response = await rt.broadcast_stream(
+            model.astream_chat([UserMessage(f"Write a poem about {topic}.")])
+        )
+        return response.message.content
+    ```
+
+    If no consumer is attached to the run, the chunks are simply dropped and this behaves like
+    a buffered call — so the same node works with and without streaming.
+
+    Behavior:
+    - Every `str` item is broadcast on `channel` (see `rt.broadcast`) and accumulated.
+    - The first non-`str` item is treated as the stream's final result (model streams such as
+      `astream_chat` yield a final `Response` after the chunks).
+    - When the stream is exhausted — or the producer raises — a `StreamEnd` marker is
+      published on the channel (after all chunks; dispatch is FIFO). Channel consumers
+      (`rt.context.get_stream`) use these markers to know when a production has finished.
+
+    Args:
+        stream: An async iterable (e.g. `model.astream_chat(...)`) or sync iterable yielding
+            `str` chunks, optionally terminated by a final non-`str` result.
+        channel: The named channel to emit chunks on. Defaults to `"default"`.
+
+    Returns:
+        The final non-`str` item yielded by the stream (a `Response` for model streams), or the
+        concatenation of all `str` chunks if the stream never yielded a final item.
+    """
+    final: Any = None
+    parts: list[str] = []
+    publisher = get_publisher()
+
+    try:
+        if hasattr(stream, "__aiter__"):
+            async for item in stream:  # type: ignore[union-attr]
+                if isinstance(item, str):
+                    parts.append(item)
+                    await broadcast(item, channel=channel)
+                else:
+                    final = item
+        else:
+            for item in stream:  # type: ignore[union-attr]
+                if isinstance(item, str):
+                    parts.append(item)
+                    await broadcast(item, channel=channel)
+                else:
+                    final = item
+    finally:
+        # always mark this production as finished — even when the producer raised — so
+        # channel consumers counting productions are released rather than left hanging.
+        await publisher.publish(
+            StreamEnd(
+                channel=channel,
+                node_id=get_parent_id(),
+                stream_id=get_stream_id(),
+                source_id=str(uuid4()),
+            )
+        )
+
+    if final is not None:
+        return final
+
+    return "".join(parts)

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -17,9 +17,10 @@ async def broadcast(item: Any, channel: str = "default"):
     Consumers attached to the run will receive it:
 
     - `rt.astream(...)` (pull mode) yields the item from its async iterator.
-    - A configured `stream_callback` (push mode) is invoked with the item; when the callback
-      is a dict, the item is routed to the callable registered under `channel` (a single
-      callable receives every item on every channel).
+    - A configured `broadcast_callback` (passive listener) is invoked with the item; when
+      the callback is a dict, the item is routed to the callable registered under `channel`
+      (a single callable receives every item on every channel). Registering one never
+      enables streaming.
     - `rt.context.get_stream(channel, ...)` (pull mode, from inside the run) yields it.
 
     If nothing is listening, the item is simply dropped — broadcasting is always safe.
@@ -66,7 +67,7 @@ async def broadcast_stream(
 
     This is the bridge between a raw model stream and the railtracks streaming system: inside a
     custom node you can forward a `model.astream_chat(...)` stream to whoever is consuming the
-    run (`rt.astream` or a `stream_callback`) while still receiving the complete final response
+    run (`rt.astream`, `Stream.route()`, or a `broadcast_callback`) while still receiving the complete final response
     to build your node's return value:
 
     ```python

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -4,30 +4,18 @@ from typing import TYPE_CHECKING, Any, AsyncIterable, Iterable, Union, overload
 from uuid import uuid4
 
 from railtracks.context.central import get_parent_id, get_publisher, get_stream_id
-from railtracks.pubsub.messages import StreamEnd, Streaming
+from railtracks.pubsub.messages import StreamEnd, Streaming, StreamingKind
 
 if TYPE_CHECKING:
     from railtracks.llm.response import Response
 
 
-async def broadcast(item: Any, channel: str = "default"):
-    """
-    Streams the given item to the session's broadcast bus.
+async def _publish_item(item: Any, channel: str, kind: StreamingKind) -> None:
+    """Publishes one item on the broadcast bus, tagged with its traffic kind.
 
-    Consumers attached to the run will receive it:
-
-    - `rt.astream(...)` (pull mode) yields the item from its async iterator.
-    - A configured `broadcast_callback` (passive listener) is invoked with the item; when
-      the callback is a dict, the item is routed to the callable registered under `channel`
-      (a single callable receives every item on every channel). Registering one never
-      enables streaming.
-    - `rt.context.get_stream(channel, ...)` (pull mode, from inside the run) yields it.
-
-    If nothing is listening, the item is simply dropped — broadcasting is always safe.
-
-    Args:
-        item: The item you want to stream (typically a `str` chunk).
-        channel: The named channel to emit on. Defaults to `"default"`.
+    The kind separates the two callback lanes: `"event"` items go to `broadcast_callback`,
+    `"stream"` chunks go to `stream_callback`. Scoped consumers (`rt.astream`,
+    `rt.context.get_stream`) receive both kinds and separate traffic by channel instead.
     """
     publisher = get_publisher()
 
@@ -37,8 +25,36 @@ async def broadcast(item: Any, channel: str = "default"):
             streamed_object=item,
             channel=channel,
             stream_id=get_stream_id(),
+            kind=kind,
         )
     )
+
+
+async def broadcast(item: Any, channel: str = "default"):
+    """
+    Broadcasts a one-off **event** to the session's broadcast bus.
+
+    Consumers attached to the run will receive it:
+
+    - A configured `broadcast_callback` (passive event listener) is invoked with the item;
+      when the callback is a dict, the item is routed to the callable registered under
+      `channel` (a single callable receives every event on every channel). Events do NOT
+      reach `stream_callback` — that lane carries `rt.broadcast_stream` chunks only.
+    - `rt.astream(...)` / `Stream.route(...)` yield/route it (scoped consumers see both
+      events and stream chunks; use channels to separate them).
+    - `rt.context.get_stream(channel, ...)` (pull mode, from inside the run) yields it.
+
+    If nothing is listening, the item is simply dropped — broadcasting is always safe.
+
+    For a *continuous* production (an LLM token stream, a chunked file read), use
+    `rt.broadcast_stream` instead: its chunks are tagged as stream traffic and it publishes
+    a completion marker consumers can count.
+
+    Args:
+        item: The item you want to broadcast.
+        channel: The named channel to emit on. Defaults to `"default"`.
+    """
+    await _publish_item(item, channel, "event")
 
 
 @overload
@@ -67,8 +83,8 @@ async def broadcast_stream(
 
     This is the bridge between a raw model stream and the railtracks streaming system: inside a
     custom node you can forward a `model.astream_chat(...)` stream to whoever is consuming the
-    run (`rt.astream`, `Stream.route()`, or a `broadcast_callback`) while still receiving the complete final response
-    to build your node's return value:
+    run (`rt.astream`, `Stream.route()`, or a `stream_callback`) while still receiving the
+    complete final response to build your node's return value:
 
     ```python
     @rt.function_node
@@ -84,7 +100,9 @@ async def broadcast_stream(
     a buffered call — so the same node works with and without streaming.
 
     Behavior:
-    - Every `str` item is broadcast on `channel` (see `rt.broadcast`) and accumulated.
+    - Every `str` item is published on `channel` as **stream** traffic (it reaches
+      `stream_callback`, not `broadcast_callback` — use `rt.broadcast` for one-off events)
+      and accumulated.
     - The first non-`str` item is treated as the stream's final result (model streams such as
       `astream_chat` yield a final `Response` after the chunks).
     - When the stream is exhausted — or the producer raises — a `StreamEnd` marker is
@@ -109,14 +127,14 @@ async def broadcast_stream(
             async for item in stream:  # type: ignore[union-attr]
                 if isinstance(item, str):
                     parts.append(item)
-                    await broadcast(item, channel=channel)
+                    await _publish_item(item, channel, "stream")
                 else:
                     final = item
         else:
             for item in stream:  # type: ignore[union-attr]
                 if isinstance(item, str):
                     parts.append(item)
-                    await broadcast(item, channel=channel)
+                    await _publish_item(item, channel, "stream")
                 else:
                     final = item
     finally:

--- a/packages/railtracks/src/railtracks/interaction/interactive.py
+++ b/packages/railtracks/src/railtracks/interaction/interactive.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Type, TypeVar
+from typing import TYPE_CHECKING, Type, TypeVar
 
 from railtracks.built_nodes.concrete.response import LLMResponse
 
@@ -39,7 +39,7 @@ def _process_attachment(attachments: list[UserMessageAttachment]) -> list[str]:
 
 async def _chat_ui_interactive(
     chat_ui,
-    node: Type[LLMBase[_TOutput, _TOutput, Literal[False]]],
+    node: Type[LLMBase[_TOutput]],
     initial_message_to_user: str | None,
     initial_message_to_agent: str | None,
     turns: int | None,
@@ -100,7 +100,7 @@ async def _chat_ui_interactive(
 
 
 async def local_chat(
-    node: type[LLMBase[_TOutput, _TOutput, Literal[False]]],
+    node: type[LLMBase[_TOutput]],
     initial_message_to_user: str | None = None,
     initial_message_to_agent: str | None = None,
     turns: int | None = None,

--- a/packages/railtracks/src/railtracks/llm/message.py
+++ b/packages/railtracks/src/railtracks/llm/message.py
@@ -4,7 +4,7 @@ import logging
 import os
 from copy import deepcopy
 from enum import Enum
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from .content import Content, ToolCall, ToolResponse
 from .encoding import detect_source, encode, ensure_data_uri
@@ -242,7 +242,7 @@ class AssistantMessage(Message[_T, Role.assistant], Generic[_T]):
         # Optionally stores the raw litellm message object so providers that
         # attach extra metadata (e.g. Gemini thought_signature) can round-trip
         # it back without any manual reconstruction.
-        self.raw_litellm_message = None
+        self.raw_litellm_message: Any | None = None
 
 
 # TODO further constrict the possible return type of a ToolMessage.

--- a/packages/railtracks/src/railtracks/llm/model.py
+++ b/packages/railtracks/src/railtracks/llm/model.py
@@ -69,9 +69,9 @@ class ModelBase(ABC, Generic[_TStream]):
         if stream:
             warnings.warn(
                 "Constructing a model with stream=True is deprecated. Streaming is now "
-                "requested at the call site: use `rt.astream(...)` (or a `stream_callback` "
-                "on your Session/Flow) instead, or call `model.astream_chat(...)` directly "
-                "for a one-off streamed model request.",
+                "requested at the call site: use `rt.astream(...)` / `Flow.astream(...)` "
+                "instead, or call `model.astream_chat(...)` directly for a one-off streamed "
+                "model request.",
                 DeprecationWarning,
                 stacklevel=3,
             )

--- a/packages/railtracks/src/railtracks/llm/model.py
+++ b/packages/railtracks/src/railtracks/llm/model.py
@@ -4,6 +4,7 @@
 ###
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import (
     AsyncGenerator,
@@ -12,6 +13,7 @@ from typing import (
     Generic,
     List,
     Literal,
+    Sequence,
     Type,
     TypeVar,
     overload,
@@ -20,6 +22,7 @@ from typing import (
 from pydantic import BaseModel
 
 from .history import MessageHistory
+from .message import Message
 from .providers import ModelProvider
 from .response import Response
 from .retries.base import RetryApproach
@@ -62,6 +65,16 @@ class ModelBase(ABC, Generic[_TStream]):
             exception_hooks: List[Callable[[MessageHistory, Exception], None]] = []
         else:
             exception_hooks = __exception_hooks
+
+        if stream:
+            warnings.warn(
+                "Constructing a model with stream=True is deprecated. Streaming is now "
+                "requested at the call site: use `rt.astream(...)` (or a `stream_callback` "
+                "on your Session/Flow) instead, or call `model.astream_chat(...)` directly "
+                "for a one-off streamed model request.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
         self._pre_hooks = pre_hooks
         self._post_hooks = post_hooks
@@ -215,6 +228,9 @@ class ModelBase(ABC, Generic[_TStream]):
 
         if isinstance(response, Generator):
             return self.generator_wrapper(response, messages)
+        if isinstance(response, AsyncGenerator):
+            # deprecated constructor-level stream=True path: pass the stream through untouched
+            return response
 
         response = self._run_post_hooks(messages, response)
 
@@ -281,6 +297,9 @@ class ModelBase(ABC, Generic[_TStream]):
 
         if isinstance(response, Generator):
             return self.generator_wrapper(response, messages)
+        if isinstance(response, AsyncGenerator):
+            # deprecated constructor-level stream=True path: pass the stream through untouched
+            return response
 
         response = self._run_post_hooks(messages, response)
 
@@ -338,10 +357,133 @@ class ModelBase(ABC, Generic[_TStream]):
 
         if isinstance(response, Generator):
             return self.generator_wrapper(response, messages)
+        if isinstance(response, AsyncGenerator):
+            # deprecated constructor-level stream=True path: pass the stream through untouched
+            return response
 
         response = self._run_post_hooks(messages, response)
 
         return response
+
+    # ================ START Streaming (per-call) LLM calls ===============
+    # These methods request a streamed response for a single call, regardless of how the model
+    # was constructed. They are the model-level building blocks of railtracks streaming (see
+    # `rt.astream` and `rt.broadcast_stream`).
+
+    @staticmethod
+    def _coerce_message_history(
+        messages: MessageHistory | Sequence[Message],
+    ) -> MessageHistory:
+        """Normalizes a plain sequence of messages into a MessageHistory."""
+        if isinstance(messages, MessageHistory):
+            return messages
+        return MessageHistory(list(messages))
+
+    async def astream_chat(
+        self, messages: MessageHistory | Sequence[Message]
+    ) -> AsyncGenerator[str | Response, None]:
+        """
+        Chat with the model, streaming the response.
+
+        Returns an async generator that yields `str` token chunks as they arrive, followed by a
+        single final `Response` object containing the complete message (and usage info).
+
+        ```python
+        async for item in model.astream_chat([UserMessage("hi")]):
+            if isinstance(item, str):
+                ...  # token chunk
+            else:
+                final = item  # the terminal Response
+        ```
+
+        Tip: inside a node, prefer `await rt.broadcast_stream(model.astream_chat(...))`, which
+        forwards the chunks to whoever is consuming the run and returns the final `Response`.
+
+        Args:
+            messages: The conversation so far — a `MessageHistory` or any sequence of
+                `Message` objects (e.g. a plain list of `UserMessage`s).
+
+        Yields:
+            str | Response: `str` token chunks, then one final complete `Response`.
+        """
+        history = self._coerce_message_history(messages)
+        history = self._run_pre_hooks(history)
+        try:
+            agen = self._astream_chat(history)
+            async for item in agen:
+                if isinstance(item, Response):
+                    yield self._run_post_hooks(history, item)
+                else:
+                    yield item
+        except Exception as e:
+            self._run_exception_hooks(history, e)
+            raise e
+
+    async def astream_chat_with_tools(
+        self, messages: MessageHistory | Sequence[Message], tools: List[Tool]
+    ) -> AsyncGenerator[str | Response, None]:
+        """
+        Chat with the model using tools, streaming the response.
+
+        Yields `str` content chunks as they arrive, followed by a single final `Response`. The
+        final `Response` contains either the complete assistant text or the requested tool
+        calls (tool-call deltas are accumulated internally and are not yielded as chunks).
+
+        Args:
+            messages: The conversation so far — a `MessageHistory` or any sequence of
+                `Message` objects.
+            tools: The tools to make available to the model.
+
+        Yields:
+            str | Response: `str` content chunks, then one final complete `Response`.
+        """
+        history = self._coerce_message_history(messages)
+        history = self._run_pre_hooks(history)
+        try:
+            agen = self._astream_chat_with_tools(history, tools)
+            async for item in agen:
+                if isinstance(item, Response):
+                    yield self._run_post_hooks(history, item)
+                else:
+                    yield item
+        except Exception as e:
+            self._run_exception_hooks(history, e)
+            raise e
+
+    async def astream_structured(
+        self, messages: MessageHistory | Sequence[Message], schema: Type[BaseModel]
+    ) -> AsyncGenerator[str | Response, None]:
+        """
+        Structured interaction with the model, streaming the response.
+
+        Yields the raw (JSON) `str` chunks as they arrive, followed by a single final
+        `Response` whose message content is the parsed `schema` instance.
+
+        Note the chunks are unvalidated JSON fragments; validation only happens once the stream
+        completes, so a schema mismatch surfaces at the end of the stream.
+
+        Args:
+            messages: The conversation so far — a `MessageHistory` or any sequence of
+                `Message` objects.
+            schema: The pydantic model the response must conform to.
+
+        Yields:
+            str | Response: raw JSON `str` chunks, then one final complete `Response`.
+        """
+        history = self._coerce_message_history(messages)
+        history = self._run_pre_hooks(history)
+        try:
+            agen = self._astream_structured(history, schema)
+            async for item in agen:
+                if isinstance(item, Response):
+                    yield self._run_post_hooks(history, item)
+                else:
+                    yield item
+        except Exception as e:
+            self._run_exception_hooks(history, e)
+            raise e
+
+    # ================ END Streaming (per-call) LLM calls ===============
 
     @abstractmethod
     def _chat(
@@ -360,6 +502,31 @@ class ModelBase(ABC, Generic[_TStream]):
         self, messages: MessageHistory, tools: List[Tool]
     ) -> Response | Generator[str | Response, None, Response]:
         pass
+
+    # Note: the _astream_* methods are deliberately NOT abstract so that existing ModelBase
+    # subclasses keep working; subclasses that support streaming should override them with
+    # async generator implementations yielding `str` chunks followed by a final `Response`.
+
+    def _astream_chat(
+        self, messages: MessageHistory
+    ) -> AsyncGenerator[str | Response, None]:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support streamed chat calls."
+        )
+
+    def _astream_chat_with_tools(
+        self, messages: MessageHistory, tools: List[Tool]
+    ) -> AsyncGenerator[str | Response, None]:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support streamed tool-calling calls."
+        )
+
+    def _astream_structured(
+        self, messages: MessageHistory, schema: Type[BaseModel]
+    ) -> AsyncGenerator[str | Response, None]:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support streamed structured calls."
+        )
 
     @abstractmethod
     async def _achat(

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 import time
 import warnings
 from abc import ABC
 from json import JSONDecodeError
 from typing import (
     Any,
+    AsyncGenerator,
     Callable,
     Dict,
     Generator,
@@ -18,12 +21,17 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    overload,
+    cast,
 )
 
 import litellm
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Function,
+    ModelResponse,
+    ModelResponseStream,
+)
 from pydantic import BaseModel, Field
 
 from ...exceptions.errors import LLMError, NodeInvocationError
@@ -37,6 +45,11 @@ from ..tools import Tool
 from ..tools.parameters import Parameter
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
+
+# Sentinel marking normal end-of-stream on the sync→async bridge queue (see
+# `_bridge_sync_stream` / `_pump_sync_stream`). A dedicated object avoids colliding with any
+# legitimate streamed value.
+_STREAM_DONE = object()
 
 # Dropped unsupported parameters from the request to the model.
 litellm.drop_params = True
@@ -167,38 +180,36 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
         self.api_key = api_key
         self.temperature = temperature
 
-    @overload
-    def _invoke(
-        self: LiteLLMWrapper[Literal[False]],
-        messages: MessageHistory,
-        *,
-        response_format: Optional[Any] = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[ModelResponse, float]:
-        pass
-
-    @overload
-    def _invoke(
-        self: LiteLLMWrapper[Literal[True]],
-        messages: MessageHistory,
-        *,
-        response_format: Optional[Any] = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[CustomStreamWrapper, float]:
-        pass
-
     def _invoke(
         self,
         messages: MessageHistory,
         *,
         response_format: Optional[Any] = None,
         tools: Optional[list[Tool]] = None,
+        stream: Optional[bool] = None,
     ) -> Tuple[CustomStreamWrapper | ModelResponse, float]:
         """
         Internal helper that:
           1. Converts MessageHistory
           2. Merges default kwargs
           3. Calls litellm.completion
+
+        This is a *blocking* call. Streaming rides litellm's synchronous
+        `completion(stream=True)` API (bridged onto the event loop by `_bridge_sync_stream`);
+        run it in a worker thread (e.g. `asyncio.to_thread`) from async contexts.
+
+        Args:
+            messages: The message history to send to the model.
+            response_format: An optional response format (e.g. a pydantic schema).
+            tools: The tools to make available to the model, if any.
+            stream: Overrides the (deprecated) constructor-level stream flag for this single
+                request; when None the constructor flag is used.
+
+        Returns:
+            A `(completion, time)` tuple where completion is a `CustomStreamWrapper` for
+            streamed requests (and `time` is the request start time) or a `ModelResponse` for
+            buffered ones (and `time` is the completion latency); callers narrow with
+            `isinstance`.
         """
         start_time = time.time()
         litellm_messages = [self._to_litellm_message(m) for m in messages]
@@ -220,11 +231,17 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
         if self.temperature is not None:
             merged["temperature"] = self.temperature
 
+        warnings.filterwarnings(
+            "ignore", category=UserWarning, module="pydantic.*"
+        )  # Supress pydantic warnings. See issue #204 for more deatils.
+
+        resolved_stream = self.stream if stream is None else stream
+
         def completion_function():
             return litellm.completion(
                 model=self._model_name,
                 messages=litellm_messages,
-                stream=self.stream,
+                stream=resolved_stream,
                 **merged,
             )
 
@@ -239,141 +256,86 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
             completion_time = time.time() - start_time
             return completion, completion_time
 
-    @overload
-    async def _ainvoke(
-        self: LiteLLMWrapper[Literal[False]],
-        messages: MessageHistory,
-        *,
-        response_format: Any | None = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[ModelResponse, float]:
-        pass
-
-    @overload
-    async def _ainvoke(
-        self: LiteLLMWrapper[Literal[True]],
-        messages: MessageHistory,
-        *,
-        response_format: Any | None = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[CustomStreamWrapper, float]:
-        pass
-
-    async def _ainvoke(
-        self,
-        messages: MessageHistory,
-        *,
-        response_format: Optional[Any] = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[CustomStreamWrapper | ModelResponse, float]:
-        """
-        Internal helper that:
-          1. Converts MessageHistory
-          2. Merges default kwargs
-          3. Calls litellm.completion
-        """
-        start_time = time.time()
-        litellm_messages = [self._to_litellm_message(m) for m in messages]
-        merged = {}
-        if response_format is not None:
-            merged["response_format"] = response_format
-        if tools is not None:
-            litellm_tools = [_to_litellm_tool(t) for t in tools]
-            merged["tools"] = litellm_tools
-        if self.api_base is not None:
-            merged["api_base"] = self.api_base
-        if self.api_key is not None:
-            merged["api_key"] = self.api_key
-        if self.temperature is not None:
-            merged["temperature"] = self.temperature
-        warnings.filterwarnings(
-            "ignore", category=UserWarning, module="pydantic.*"
-        )  # Supress pydantic warnings. See issue #204 for more deatils.
-
-        def completion_function():
-            return litellm.acompletion(
-                model=self._model_name,
-                messages=litellm_messages,
-                stream=self.stream,
-                **merged,
-            )
-
-        if self.retry_approach is not None:
-            completion = await self.retry_approach.acall_with_retry(completion_function)
-        else:
-            completion = await completion_function()
-
-        if isinstance(completion, CustomStreamWrapper):
-            return completion, start_time
-        else:
-            completion_time = time.time() - start_time
-            return completion, completion_time
-
     # ================ START Streaming Handlers ===============
-    async def _astream_handler_base(
+    async def _bridge_sync_stream(
         self,
-        raw: CustomStreamWrapper,
-        start_time: float,
-        output_schema: Type[BaseModel] | None = None,
-    ):
+        make_stream: Callable[[], Generator[str | Response, None, Response]],
+    ) -> AsyncGenerator[str | Response, None]:
         """
-        Add handler to the streamed response so that we preoperly construct the response object at the end of the stream.
+        Run a *blocking* sync stream on a dedicated worker thread and surface its items as an
+        async generator, without blocking the event loop.
+
+        litellm's synchronous `completion(stream=True)` is better maintained than its async
+        counterpart (the async path is prone to leaking noisy logs/warnings), so railtracks
+        streams on the sync API and bridges the blocking iterator here. A single worker thread
+        owns the underlying network stream for its whole lifetime — it is created, iterated,
+        and closed on that one thread, so the stream object is never touched from more than one
+        thread — while items are handed to the event loop through a thread-safe queue.
+
+        Args:
+            make_stream: A zero-arg factory (run *on the worker thread*) that opens the request
+                and returns the sync `_stream_handler_base` generator of `str` chunks followed
+                by a final `Response`.
+
+        Yields:
+            str | Response: `str` chunks as they arrive, then the terminal `Response`.
         """
-        tools: List[ToolCall] = []
-        accumulated_content = ""
-        structured_response: BaseModel | None = None
-        # fall back on empty message info if we don't get one from the stream.
-        message_info = MessageInfo()
-        active_tool_calls: Dict[int, StreamedToolCall] = {}
-        stream_finished = False
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[Any] = asyncio.Queue()
+        stop = threading.Event()
 
-        async for chunk in raw.completion_stream:
-            if stream_finished:
-                # the last chunk will contain the full message info
-                message_info = self.extract_message_info(
-                    chunk, time.time() - start_time
-                )
-
-                if output_schema is not None:
-                    structured_response = output_schema(
-                        **json.loads(accumulated_content)
-                    )
-                break
-
-            choice = chunk.choices[0]
-
-            if self._is_stream_finished(choice):
-                stream_finished = True
-                tools = self._finalize_remaining_tool_calls(active_tool_calls)
-                continue
-
-            if choice.delta.tool_calls:
-                # TODO: determine if it would be useful to stream tools
-                self._handle_tool_call_delta(
-                    choice.delta.tool_calls[0], active_tool_calls
-                )
-
-            elif choice.delta.content:
-                content = self._handle_content_delta(choice.delta.content)
-                accumulated_content += content
-                yield content
-
-        if structured_response is not None:
-            r = Response(
-                message=AssistantMessage(content=structured_response),
-                message_info=message_info,
+        worker = asyncio.ensure_future(
+            asyncio.to_thread(
+                self._pump_sync_stream, make_stream, loop, queue, stop
             )
-        elif len(tools) > 0:
-            r = Response(
-                message=AssistantMessage(content=tools), message_info=message_info
-            )
+        )
+        try:
+            while True:
+                item = await queue.get()
+                if item is _STREAM_DONE:
+                    break
+                if isinstance(item, BaseException):
+                    raise item
+                yield cast("str | Response", item)
+        finally:
+            # On early break, signal the worker to stop; it observes `stop` at the next chunk
+            # boundary, closes the stream on its own thread, and exits. Retrieve its result so
+            # a late failure isn't reported as "exception never retrieved".
+            stop.set()
+            if worker.done():
+                worker.exception()
+            else:
+                worker.add_done_callback(lambda t: t.exception())
+
+    @staticmethod
+    def _pump_sync_stream(
+        make_stream: Callable[[], Generator[str | Response, None, Response]],
+        loop: asyncio.AbstractEventLoop,
+        queue: asyncio.Queue[Any],
+        stop: threading.Event,
+    ) -> None:
+        """Worker-thread half of `_bridge_sync_stream`.
+
+        Opens, iterates, and closes the blocking stream entirely on the calling thread (so the
+        network stream object is never touched from more than one thread), marshaling each item
+        — or a terminal `_STREAM_DONE` / exception — back to the loop thread via `queue`.
+        """
+        try:
+            gen = make_stream()
+        except BaseException as exc:  # noqa: BLE001 - marshaled to the consumer
+            loop.call_soon_threadsafe(queue.put_nowait, exc)
+            return
+        try:
+            for item in gen:
+                loop.call_soon_threadsafe(queue.put_nowait, item)
+                if stop.is_set():
+                    break
+        except BaseException as exc:  # noqa: BLE001 - marshaled to the consumer
+            loop.call_soon_threadsafe(queue.put_nowait, exc)
         else:
-            r = Response(
-                message=AssistantMessage(content=accumulated_content),
-                message_info=message_info,
-            )
-
-        yield r
+            loop.call_soon_threadsafe(queue.put_nowait, _STREAM_DONE)
+        finally:
+            gen.close()
 
     def _stream_handler_base(
         self,
@@ -466,10 +428,6 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
 
         return r
 
-    async def _aconsume_stream(self, raw: CustomStreamWrapper, start_time: float):
-        """Consume the entire async stream and extract chunks, content, and metadata."""
-        return self._stream_handler_base(raw, start_time)
-
     def _is_stream_finished(self, choice) -> bool:
         """Check if the stream has finished."""
         return choice.finish_reason in ("stop", "tool_calls")
@@ -531,6 +489,48 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
 
     # ================ END Streaming Handlers ===============
 
+    # ================ START Per-call Streaming LLM calls ===============
+    # These implement the ModelBase._astream_* extension points. Each one forces a streamed
+    # request (regardless of the deprecated constructor-level stream flag) and returns an async
+    # generator yielding `str` chunks followed by a single final `Response`. They ride litellm's
+    # synchronous `completion(stream=True)` API, bridged onto the event loop by
+    # `_bridge_sync_stream` (a dedicated worker thread), so the loop never blocks.
+
+    async def _astream_chat(self, messages: MessageHistory):
+        def _open() -> Generator[str | Response, None, Response]:
+            raw, start_time = self._invoke(messages, stream=True)
+            assert isinstance(raw, CustomStreamWrapper)
+            return self._stream_handler_base(raw, start_time)
+
+        async for item in self._bridge_sync_stream(_open):
+            yield item
+
+    async def _astream_chat_with_tools(
+        self, messages: MessageHistory, tools: List[Tool]
+    ):
+        def _open() -> Generator[str | Response, None, Response]:
+            raw, start_time = self._invoke(messages, tools=tools, stream=True)
+            assert isinstance(raw, CustomStreamWrapper)
+            return self._stream_handler_base(raw, start_time)
+
+        async for item in self._bridge_sync_stream(_open):
+            yield item
+
+    async def _astream_structured(
+        self, messages: MessageHistory, schema: Type[BaseModel]
+    ):
+        def _open() -> Generator[str | Response, None, Response]:
+            raw, start_time = self._invoke(
+                messages, response_format=schema, stream=True
+            )
+            assert isinstance(raw, CustomStreamWrapper)
+            return self._stream_handler_base(raw, start_time, schema)
+
+        async for item in self._bridge_sync_stream(_open):
+            yield item
+
+    # ================ END Per-call Streaming LLM calls ===============
+
     # ================ START Base Handlers ==================
 
     def _chat_handle_base(self, raw: ModelResponse, info: MessageInfo):
@@ -556,16 +556,18 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
         choice = raw.choices[0]
 
         if choice.finish_reason == "stop" and not choice.message.tool_calls:
+            # litellm types content as str | None, but a plain "stop" completion always
+            # carries (possibly empty) text content.
             return Response(
-                message=AssistantMessage(content=choice.message.content),
+                message=AssistantMessage(content=cast(str, choice.message.content)),
                 message_info=info,
             )
 
         calls: List[ToolCall] = []
-        for tc in choice.message.tool_calls:
+        for tc in choice.message.tool_calls or []:
             args = json.loads(tc.function.arguments)
             calls.append(
-                ToolCall(identifier=tc.id, name=tc.function.name, arguments=args)
+                ToolCall(identifier=tc.id, name=tc.function.name or "", arguments=args)
             )
 
         assistant_msg = AssistantMessage(content=calls)
@@ -637,48 +639,52 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
     # ================ END Sync LLM calls ===============
 
     # ================ START Async LLM calls ===============
+    # litellm's async API (`acompletion`) is intentionally not used: its sync counterpart is
+    # better maintained and does not leak the noisy logs/warnings the async path is prone to.
+    # The async surface is preserved by running the blocking sync calls on a worker thread
+    # (`asyncio.to_thread`), exactly as the framework's buffered node path already does.
+
     async def _achat(self, messages: MessageHistory):
-        response, time = await self._ainvoke(messages=messages)
-        if isinstance(response, CustomStreamWrapper):
-            return self._astream_handler_base(response, time)
-        elif isinstance(response, ModelResponse):
-            return self._chat_handle_base(
-                response, self.extract_message_info(response, time)
-            )
-        else:
-            raise ValueError("Unexpected response type")
+        if not self.stream:
+            # Buffered path: `_chat` returns a Response (it only yields a Generator under the
+            # deprecated stream=True flag, excluded by the guard above).
+            return cast(Response, await asyncio.to_thread(self._chat, messages))
+
+        # Deprecated constructor-level stream=True: `_chat` returns a sync stream generator;
+        # bridge it back to an async generator so the async surface is unchanged.
+        def _open() -> Generator[str | Response, None, Response]:
+            result = self._chat(messages)
+            assert isinstance(result, Generator)
+            return result
+
+        return self._bridge_sync_stream(_open)
 
     async def _astructured(self, messages: MessageHistory, schema: Type[BaseModel]):
-        try:
-            model_resp, time = await self._ainvoke(messages, response_format=schema)
-            if isinstance(model_resp, CustomStreamWrapper):
-                return self._astream_handler_base(model_resp, time, schema)
-            elif isinstance(model_resp, ModelResponse):
-                return self._structured_handle_base(
-                    model_resp,
-                    self.extract_message_info(model_resp, time),
-                    schema,
-                )
-            else:
-                raise ValueError("Unexpected response type")
-        except JSONDecodeError as jde:
-            raise jde
-        except Exception as e:
-            raise LLMError(
-                reason="Structured LLM call failed",
-                message_history=messages,
-            ) from e
+        if not self.stream:
+            return cast(
+                Response, await asyncio.to_thread(self._structured, messages, schema)
+            )
+
+        def _open() -> Generator[str | Response, None, Response]:
+            result = self._structured(messages, schema)
+            assert isinstance(result, Generator)
+            return result
+
+        return self._bridge_sync_stream(_open)
 
     async def _achat_with_tools(self, messages: MessageHistory, tools: List[Tool]):
-        resp, time = await self._ainvoke(messages, tools=tools)
-        if isinstance(resp, CustomStreamWrapper):
-            return self._astream_handler_base(resp, time)
-        elif isinstance(resp, ModelResponse):
-            return self._chat_with_tools_handler_base(
-                resp, self.extract_message_info(resp, time)
+        if not self.stream:
+            return cast(
+                Response,
+                await asyncio.to_thread(self._chat_with_tools, messages, tools),
             )
-        else:
-            raise ValueError("Unexpected response type")
+
+        def _open() -> Generator[str | Response, None, Response]:
+            result = self._chat_with_tools(messages, tools)
+            assert isinstance(result, Generator)
+            return result
+
+        return self._bridge_sync_stream(_open)
 
     # ================ END Async LLM calls ===============
 
@@ -729,8 +735,8 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
             assert all(isinstance(t_c, ToolCall) for t_c in msg.content)
             base["content"] = ""
             base["tool_calls"] = [
-                litellm.utils.ChatCompletionMessageToolCall(
-                    function=litellm.utils.Function(
+                ChatCompletionMessageToolCall(
+                    function=Function(
                         arguments=tool_call.arguments, name=tool_call.name
                     ),
                     id=tool_call.identifier,
@@ -767,7 +773,7 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
 
     @classmethod
     def extract_message_info(
-        cls, model_response: ModelResponse, latency: float
+        cls, model_response: ModelResponse | ModelResponseStream, latency: float
     ) -> MessageInfo:
         """
         Create a Response object from a ModelResponse.
@@ -779,16 +785,15 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
         Returns:
             MessageInfo: An object containing the details about the message info.
         """
-        input_tokens = _return_none_on_error(lambda: model_response.usage.prompt_tokens)
-        output_tokens = _return_none_on_error(
-            lambda: model_response.usage.completion_tokens
-        )
-        model_name = _return_none_on_error(lambda: model_response.model)
-        system_fingerprint = _return_none_on_error(
-            lambda: model_response.system_fingerprint
-        )
+        # litellm does not statically type these attributes (usage/_hidden_params are set
+        # dynamically), so we go through Any; _return_none_on_error absorbs absent fields.
+        raw: Any = model_response
+        input_tokens = _return_none_on_error(lambda: raw.usage.prompt_tokens)
+        output_tokens = _return_none_on_error(lambda: raw.usage.completion_tokens)
+        model_name = _return_none_on_error(lambda: raw.model)
+        system_fingerprint = _return_none_on_error(lambda: raw.system_fingerprint)
         total_cost = _return_none_on_error(
-            lambda: model_response._hidden_params["response_cost"]
+            lambda: raw._hidden_params["response_cost"]
         )
 
         return MessageInfo(

--- a/packages/railtracks/src/railtracks/llm/providers.py
+++ b/packages/railtracks/src/railtracks/llm/providers.py
@@ -33,3 +33,18 @@ class ModelProvider(str, Enum):
     TELUS = "Telus"
     PORTKEY = "PortKey"
     UNKNOWN = "Unknown"
+
+
+# Providers we do not support token streaming for when tool calling is involved. A streamed
+# invocation that reaches one of these providers with tools attached falls back to a buffered
+# model call (with a warning) — the final response is unaffected, only incremental chunks are
+# skipped.
+TOOL_CALLING_STREAMING_BLACKLIST = frozenset(
+    {
+        ModelProvider.ANTHROPIC,
+        ModelProvider.AZUREAI,
+        ModelProvider.GEMINI,
+        ModelProvider.OLLAMA,
+        ModelProvider.HUGGINGFACE,
+    }
+)

--- a/packages/railtracks/src/railtracks/llm/response.py
+++ b/packages/railtracks/src/railtracks/llm/response.py
@@ -102,6 +102,29 @@ class Response:
         """
         return self._message_info
 
+    @property
+    def text(self) -> str:
+        """
+        The plain-text content of the response message.
+
+        This is a typed convenience accessor for the common case where the model returned
+        text (e.g. the final `Response` of `astream_chat` / `broadcast_stream`).
+
+        Returns:
+            str: The message's text content.
+
+        Raises:
+            TypeError: If the message content is not a string (e.g. tool calls or a
+                structured/pydantic output). Access `message.content` directly for those.
+        """
+        content = self._message.content
+        if not isinstance(content, str):
+            raise TypeError(
+                f"Response content is not text; it is {type(content).__name__}. "
+                "Access `response.message.content` directly for non-text content."
+            )
+        return content
+
     def __str__(self):
         if self._message is not None:
             return str(self._message)

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -10,7 +10,7 @@ from railtracks._session import Session
 from railtracks.built_nodes.concrete.function_base import RTFunction
 from railtracks.interaction._astream import Stream
 from railtracks.interaction._call import call
-from railtracks.utils.config import StreamCallback
+from railtracks.utils.config import BroadcastCallback
 
 from ..nodes.nodes import Node
 
@@ -30,10 +30,12 @@ class Flow(Generic[_P, _TOutput]):
         context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        stream_callback (Callable or dict[str, Callable], optional): A callback that receives every
-            streamed/broadcast item (push-mode streaming). Providing it enables token streaming for
-            the entry point on every invocation of this flow. Pass a dict mapping channel name ->
-            callback to route items per channel. Callbacks may be sync or async.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on the
+            broadcast bus for this flow's runs. Pass a dict mapping channel name -> callback to
+            route items per channel (preferred); a single callable receives every item on every
+            channel. It never enables streaming — use `flow.astream(...)` (optionally with
+            `.route(...)`) to stream. If it never fires during a run, a warning is logged at
+            session close. Callbacks may be sync or async.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
@@ -47,7 +49,7 @@ class Flow(Generic[_P, _TOutput]):
         context: dict[str, Any] | None = None,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        stream_callback: StreamCallback | None = None,
+        broadcast_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], Any] | None = None,
@@ -63,7 +65,7 @@ class Flow(Generic[_P, _TOutput]):
         self._context: dict[str, Any] = context or {}
         self._timeout = timeout
         self._end_on_error = end_on_error
-        self._stream_callback = stream_callback
+        self._broadcast_callback = broadcast_callback
         self._prompt_injection = prompt_injection
         self._save_state = save_state
         self._payload_callback = payload_callback
@@ -85,7 +87,7 @@ class Flow(Generic[_P, _TOutput]):
             name=None,
             timeout=self._timeout,
             end_on_error=self._end_on_error,
-            stream_callback=self._stream_callback,
+            broadcast_callback=self._broadcast_callback,
             prompt_injection=self._prompt_injection,
             save_state=self._save_state,
             payload_callback=self._payload_callback,
@@ -122,7 +124,9 @@ class Flow(Generic[_P, _TOutput]):
         ```
 
         To consume a single named channel, chain `on_channel` before iterating:
-        `flow.astream("prompt").on_channel("final")`.
+        `flow.astream("prompt").on_channel("final")`. For push-style consumption, route the
+        chunks to handlers by channel instead of iterating:
+        `final = await flow.astream("prompt").route({"default": on_chunk})`.
 
         Args:
             *args: The positional arguments to pass to the entry point.

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -30,12 +30,19 @@ class Flow(Generic[_P, _TOutput]):
         context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener on the
-            broadcast bus for this flow's runs. Pass a dict mapping channel name -> callback to
-            route items per channel (preferred); a single callable receives every item on every
-            channel. It never enables streaming — use `flow.astream(...)` (optionally with
-            `.route(...)`) to stream. If it never fires during a run, a warning is logged at
-            session close. Callbacks may be sync or async.
+        broadcast_callback (Callable or dict[str, Callable], optional): A passive listener for
+            one-off **events** published with `rt.broadcast` during this flow's runs. Pass a
+            dict mapping channel name -> callback to route events per channel (preferred); a
+            single callable receives every event on every channel. Streamed chunks go to
+            `stream_callback` instead. If it never fires during a run, a `UserWarning` is
+            emitted at session close. Callbacks may be sync or async.
+        stream_callback (Callable or dict[str, Callable], optional): A passive listener for
+            **stream chunks** published through `rt.broadcast_stream` (LLM token streams
+            included). Same shapes as `broadcast_callback`. It never enables streaming — use
+            `flow.astream(...)` (optionally with `.route(...)`) to stream; its niche over
+            `route` is observing every streaming scope in the run (e.g. nested `astream`s in
+            multi-agent flows). If it never fires during a run, a `UserWarning` is emitted at
+            session close.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
@@ -50,6 +57,7 @@ class Flow(Generic[_P, _TOutput]):
         timeout: float | None = None,
         end_on_error: bool | None = None,
         broadcast_callback: BroadcastCallback | None = None,
+        stream_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], Any] | None = None,
@@ -66,6 +74,7 @@ class Flow(Generic[_P, _TOutput]):
         self._timeout = timeout
         self._end_on_error = end_on_error
         self._broadcast_callback = broadcast_callback
+        self._stream_callback = stream_callback
         self._prompt_injection = prompt_injection
         self._save_state = save_state
         self._payload_callback = payload_callback
@@ -88,6 +97,7 @@ class Flow(Generic[_P, _TOutput]):
             timeout=self._timeout,
             end_on_error=self._end_on_error,
             broadcast_callback=self._broadcast_callback,
+            stream_callback=self._stream_callback,
             prompt_injection=self._prompt_injection,
             save_state=self._save_state,
             payload_callback=self._payload_callback,

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -4,11 +4,13 @@ import asyncio
 import hashlib
 import json
 from copy import deepcopy
-from typing import Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
+from typing import Any, Callable, Generic, ParamSpec, TypeVar
 
 from railtracks._session import Session
 from railtracks.built_nodes.concrete.function_base import RTFunction
+from railtracks.interaction._astream import Stream
 from railtracks.interaction._call import call
+from railtracks.utils.config import StreamCallback
 
 from ..nodes.nodes import Node
 
@@ -28,7 +30,10 @@ class Flow(Generic[_P, _TOutput]):
         context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
+        stream_callback (Callable or dict[str, Callable], optional): A callback that receives every
+            streamed/broadcast item (push-mode streaming). Providing it enables token streaming for
+            the entry point on every invocation of this flow. Pass a dict mapping channel name ->
+            callback to route items per channel. Callbacks may be sync or async.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
@@ -42,16 +47,14 @@ class Flow(Generic[_P, _TOutput]):
         context: dict[str, Any] | None = None,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
+        stream_callback: StreamCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], Any] | None = None,
     ) -> None:
         self.entry_point: type[Node[_P, _TOutput]]
 
-        if hasattr(entry_point, "node_type"):
+        if isinstance(entry_point, RTFunction):
             self.entry_point = entry_point.node_type
         else:
             self.entry_point = entry_point
@@ -60,7 +63,7 @@ class Flow(Generic[_P, _TOutput]):
         self._context: dict[str, Any] = context or {}
         self._timeout = timeout
         self._end_on_error = end_on_error
-        self._broadcast_callback = broadcast_callback
+        self._stream_callback = stream_callback
         self._prompt_injection = prompt_injection
         self._save_state = save_state
         self._payload_callback = payload_callback
@@ -73,19 +76,23 @@ class Flow(Generic[_P, _TOutput]):
         new_obj._context.update(context)
         return new_obj
 
-    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
-        with Session(
+    def _create_session(self) -> Session:
+        """Creates a fresh Session configured from this flow."""
+        return Session(
             context=deepcopy(self._context),
             flow_name=self.name,
             flow_id=self.equality_hash(),
             name=None,
             timeout=self._timeout,
             end_on_error=self._end_on_error,
-            broadcast_callback=self._broadcast_callback,
+            stream_callback=self._stream_callback,
             prompt_injection=self._prompt_injection,
             save_state=self._save_state,
             payload_callback=self._payload_callback,
-        ):
+        )
+
+    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        with self._create_session():
             result = await call(self.entry_point, *args, **kwargs)
 
         return result
@@ -98,6 +105,39 @@ class Flow(Generic[_P, _TOutput]):
             raise RuntimeError(
                 "Cannot invoke flow synchronously within an active event loop. Use 'ainvoke' instead."
             )
+
+    def astream(self, *args: _P.args, **kwargs: _P.kwargs) -> Stream[_TOutput]:
+        """
+        Invoke this flow with streaming enabled and return a `Stream` over the emitted chunks.
+
+        The entry point streams its LLM responses token-by-token; nested `rt.call` children run
+        buffered (streaming is frame-local). The flow's session is created for this run and is
+        closed automatically once the stream completes.
+
+        ```python
+        stream = flow.astream("Write a short poem about rain.")
+        async for chunk in stream:
+            print(chunk, end="", flush=True)
+        final = stream.result  # the entry point's complete return value
+        ```
+
+        To consume a single named channel, chain `on_channel` before iterating:
+        `flow.astream("prompt").on_channel("final")`.
+
+        Args:
+            *args: The positional arguments to pass to the entry point.
+            **kwargs: The keyword arguments to pass to the entry point.
+
+        Returns:
+            Stream[_TOutput]: An async iterator over chunks with `.result` for the final value.
+        """
+        session = self._create_session()
+        return Stream(
+            self.entry_point,
+            args,
+            kwargs,
+            owned_session=session,
+        )
 
     def equality_hash(self) -> str:
         """

--- a/packages/railtracks/src/railtracks/pubsub/__init__.py
+++ b/packages/railtracks/src/railtracks/pubsub/__init__.py
@@ -21,10 +21,10 @@ __all__ = [
     "Streaming",
     "output_mapping",
     "RTPublisher",
-    "stream_chunk_subscriber",
+    "BroadcastCallbackSubscriber",
     "StreamEnd",
 ]
 
-from ._subscriber import stream_chunk_subscriber
+from ._subscriber import BroadcastCallbackSubscriber
 from .publisher import RTPublisher
 from .utils import output_mapping

--- a/packages/railtracks/src/railtracks/pubsub/__init__.py
+++ b/packages/railtracks/src/railtracks/pubsub/__init__.py
@@ -6,6 +6,7 @@ from .messages import (
     RequestFailure,
     RequestFinishedBase,
     RequestSuccess,
+    StreamEnd,
     Streaming,
 )
 
@@ -20,9 +21,10 @@ __all__ = [
     "Streaming",
     "output_mapping",
     "RTPublisher",
-    "stream_subscriber",
+    "stream_chunk_subscriber",
+    "StreamEnd",
 ]
 
-from ._subscriber import stream_subscriber
+from ._subscriber import stream_chunk_subscriber
 from .publisher import RTPublisher
 from .utils import output_mapping

--- a/packages/railtracks/src/railtracks/pubsub/_subscriber.py
+++ b/packages/railtracks/src/railtracks/pubsub/_subscriber.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from typing import Any, Callable, Mapping, Union
 
-from railtracks.utils.logging import get_rt_logger
-
-from .messages import RequestCompletionMessage, Streaming
-
-logger = get_rt_logger(__name__)
+from .messages import RequestCompletionMessage, Streaming, StreamingKind
 
 
 class BroadcastCallbackSubscriber:
     """
-    Bus subscriber that drives a user `broadcast_callback`.
+    Bus subscriber that drives a user callback (`broadcast_callback` or `stream_callback`).
 
-    - A single callable receives every streamed/broadcast item regardless of channel (the
-      "firehose" form — note this includes token chunks whenever something in the session
-      streams; prefer the mapping form to listen selectively).
+    The two session-level callback lanes are separated by the traffic `kind` on each
+    `Streaming` message:
+
+    - `kind="event"`: one-off items published with `rt.broadcast` -> `broadcast_callback`.
+    - `kind="stream"`: chunks of an `rt.broadcast_stream` production (LLM token streams
+      included) -> `stream_callback`.
+
+    Each subscriber instance filters to its own kind (or observes everything when
+    `kind=None`). The callback itself takes one of two forms:
+
+    - A single callable receives every matching item regardless of channel (the "firehose"
+      form; prefer the mapping form to listen selectively).
     - A mapping routes each item to the callable registered under the item's channel name;
       items on channels without a registered callable are skipped silently.
 
@@ -24,8 +30,9 @@ class BroadcastCallbackSubscriber:
 
     The subscriber tracks what it observed and delivered so `warn_if_unused()` can flag, at
     session close, a callback that never fired — the most common causes being a channel-name
-    typo, or expecting LLM tokens from a run that never streamed (callbacks are passive; only
-    `rt.astream` / `Flow.astream` enable streaming).
+    typo, listening on the wrong lane (events vs. stream chunks), or expecting LLM tokens
+    from a run that never streamed (callbacks are passive; only `rt.astream` /
+    `Flow.astream` enable streaming).
     """
 
     def __init__(
@@ -34,16 +41,35 @@ class BroadcastCallbackSubscriber:
             Callable[[Any], Any],
             Mapping[str, Callable[[Any], Any]],
         ],
+        *,
+        kind: StreamingKind | None = None,
+        param_name: str = "broadcast_callback",
     ):
+        """
+        Args:
+            callback: The user callback (single callable or channel-name -> callable mapping).
+            kind: The traffic kind this subscriber listens to (`"event"` / `"stream"`), or
+                None to receive every `Streaming` item regardless of kind.
+            param_name: The user-facing parameter this callback was registered as; used in
+                `warn_if_unused` messages.
+        """
         self._callback = callback
+        self._kind = kind
+        self._param_name = param_name
         self._items_seen = 0
         self._channels_seen: set[str] = set()
+        # channels observed carrying the OTHER kind of traffic — used to hint at lane mix-ups
+        self._offkind_channels: set[str] = set()
         self._fired_channels: set[str] = set()
         self._fired = False
 
     async def __call__(self, item: RequestCompletionMessage) -> None:
-        """Handles one bus message: routes `Streaming` items to the user callback."""
+        """Handles one bus message: routes matching `Streaming` items to the user callback."""
         if not isinstance(item, Streaming):
+            return
+
+        if self._kind is not None and item.kind != self._kind:
+            self._offkind_channels.add(item.channel)
             return
 
         self._items_seen += 1
@@ -62,14 +88,42 @@ class BroadcastCallbackSubscriber:
         if asyncio.iscoroutine(result):
             await result
 
+    def _never_fired_hint(self) -> str:
+        """The likely cause when zero matching items were observed, per lane."""
+        if self._kind == "stream":
+            hint = (
+                "— nothing streamed during this session. Note that callbacks do not "
+                "enable streaming; invoke with rt.astream / Flow.astream (optionally "
+                ".route(...))."
+            )
+        elif self._kind == "event":
+            hint = "— nothing was broadcast (rt.broadcast) during this session."
+        else:
+            hint = "— nothing was broadcast during this session."
+
+        if self._offkind_channels:
+            other = "event" if self._kind == "stream" else "stream"
+            other_param = (
+                "broadcast_callback" if other == "event" else "stream_callback"
+            )
+            hint += (
+                f" However, channels {sorted(self._offkind_channels)} carried {other} "
+                f"traffic — did you mean to register a {other_param}?"
+            )
+        return hint
+
     def warn_if_unused(self) -> None:
         """
-        Logs a warning when the callback (or some of its channel entries) never received an
-        item over the subscriber's lifetime. Called by the session at close.
+        Emits a `UserWarning` when the callback (or some of its channel entries) never
+        received an item over the subscriber's lifetime. Called by the session at close.
+        (A `UserWarning` — not a log record — so it is visible by default, without
+        `enable_logging()`.)
 
-        The message distinguishes the two failure modes:
-        - nothing was broadcast at all (likely: expected tokens but nothing streamed), vs.
-        - traffic existed but none matched the registered channels (likely: a channel typo).
+        The message distinguishes the failure modes:
+        - nothing matching was broadcast at all (likely: expected tokens without streaming,
+          or the traffic went down the other callback lane), vs.
+        - matching traffic existed but none was on the registered channels (likely: a
+          channel-name typo).
         """
         if isinstance(self._callback, Mapping):
             registered = set(self._callback.keys())
@@ -77,24 +131,24 @@ class BroadcastCallbackSubscriber:
             if not unused:
                 return
             if self._items_seen == 0:
-                logger.warning(
-                    "broadcast_callback channels %s never received any items — nothing was "
-                    "broadcast during this session. If you expected LLM tokens, note that "
-                    "callbacks do not enable streaming; invoke with rt.astream / Flow.astream "
-                    "(optionally .route(...)).",
-                    sorted(unused),
+                warnings.warn(
+                    f"{self._param_name} channels {sorted(unused)} never received any "
+                    f"items {self._never_fired_hint()}",
+                    UserWarning,
+                    stacklevel=2,
                 )
             else:
-                logger.warning(
-                    "broadcast_callback channels %s never received any items; observed "
-                    "channels were %s (check for channel-name typos).",
-                    sorted(unused),
-                    sorted(self._channels_seen),
+                warnings.warn(
+                    f"{self._param_name} channels {sorted(unused)} never received any "
+                    f"items; observed channels were {sorted(self._channels_seen)} (check "
+                    "for channel-name typos).",
+                    UserWarning,
+                    stacklevel=2,
                 )
         elif not self._fired:
-            logger.warning(
-                "broadcast_callback was registered but never received any items — nothing "
-                "was broadcast during this session. If you expected LLM tokens, note that "
-                "callbacks do not enable streaming; invoke with rt.astream / Flow.astream "
-                "(optionally .route(...))."
+            warnings.warn(
+                f"{self._param_name} was registered but never received any items "
+                f"{self._never_fired_hint()}",
+                UserWarning,
+                stacklevel=2,
             )

--- a/packages/railtracks/src/railtracks/pubsub/_subscriber.py
+++ b/packages/railtracks/src/railtracks/pubsub/_subscriber.py
@@ -1,39 +1,100 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Callable, Coroutine, Mapping, Union
+from typing import Any, Callable, Mapping, Union
+
+from railtracks.utils.logging import get_rt_logger
 
 from .messages import RequestCompletionMessage, Streaming
 
+logger = get_rt_logger(__name__)
 
-def stream_chunk_subscriber(
-    callback: Union[
-        Callable[[Any], Any],
-        Mapping[str, Callable[[Any], Any]],
-    ],
-) -> Callable[[RequestCompletionMessage], Coroutine[None, None, None]]:
+
+class BroadcastCallbackSubscriber:
     """
-    Converts a `stream_callback` (a single callable, or a mapping of channel name -> callable)
-    into a subscriber handler for `Streaming` messages.
+    Bus subscriber that drives a user `broadcast_callback`.
 
-    - A single callable receives every streamed/broadcast item regardless of channel.
+    - A single callable receives every streamed/broadcast item regardless of channel (the
+      "firehose" form — note this includes token chunks whenever something in the session
+      streams; prefer the mapping form to listen selectively).
     - A mapping routes each item to the callable registered under the item's channel name;
-      items on channels without a registered callable are dropped silently.
+      items on channels without a registered callable are skipped silently.
 
     Callables may be sync or async.
+
+    The subscriber tracks what it observed and delivered so `warn_if_unused()` can flag, at
+    session close, a callback that never fired — the most common causes being a channel-name
+    typo, or expecting LLM tokens from a run that never streamed (callbacks are passive; only
+    `rt.astream` / `Flow.astream` enable streaming).
     """
 
-    async def subscriber_handler(item: RequestCompletionMessage):
+    def __init__(
+        self,
+        callback: Union[
+            Callable[[Any], Any],
+            Mapping[str, Callable[[Any], Any]],
+        ],
+    ):
+        self._callback = callback
+        self._items_seen = 0
+        self._channels_seen: set[str] = set()
+        self._fired_channels: set[str] = set()
+        self._fired = False
+
+    async def __call__(self, item: RequestCompletionMessage) -> None:
+        """Handles one bus message: routes `Streaming` items to the user callback."""
         if not isinstance(item, Streaming):
             return
 
-        if isinstance(callback, Mapping):
-            fn = callback.get(item.channel)
+        self._items_seen += 1
+        self._channels_seen.add(item.channel)
+
+        if isinstance(self._callback, Mapping):
+            fn = self._callback.get(item.channel)
             if fn is None:
                 return
+            self._fired_channels.add(item.channel)
         else:
-            fn = callback
+            fn = self._callback
+        self._fired = True
 
         result = fn(item.streamed_object)
         if asyncio.iscoroutine(result):
             await result
 
-    return subscriber_handler
+    def warn_if_unused(self) -> None:
+        """
+        Logs a warning when the callback (or some of its channel entries) never received an
+        item over the subscriber's lifetime. Called by the session at close.
+
+        The message distinguishes the two failure modes:
+        - nothing was broadcast at all (likely: expected tokens but nothing streamed), vs.
+        - traffic existed but none matched the registered channels (likely: a channel typo).
+        """
+        if isinstance(self._callback, Mapping):
+            registered = set(self._callback.keys())
+            unused = registered - self._fired_channels
+            if not unused:
+                return
+            if self._items_seen == 0:
+                logger.warning(
+                    "broadcast_callback channels %s never received any items — nothing was "
+                    "broadcast during this session. If you expected LLM tokens, note that "
+                    "callbacks do not enable streaming; invoke with rt.astream / Flow.astream "
+                    "(optionally .route(...)).",
+                    sorted(unused),
+                )
+            else:
+                logger.warning(
+                    "broadcast_callback channels %s never received any items; observed "
+                    "channels were %s (check for channel-name typos).",
+                    sorted(unused),
+                    sorted(self._channels_seen),
+                )
+        elif not self._fired:
+            logger.warning(
+                "broadcast_callback was registered but never received any items — nothing "
+                "was broadcast during this session. If you expected LLM tokens, note that "
+                "callbacks do not enable streaming; invoke with rt.astream / Flow.astream "
+                "(optionally .route(...))."
+            )

--- a/packages/railtracks/src/railtracks/pubsub/_subscriber.py
+++ b/packages/railtracks/src/railtracks/pubsub/_subscriber.py
@@ -1,20 +1,39 @@
 import asyncio
-from typing import Any, Callable, Coroutine, Union
+from typing import Any, Callable, Coroutine, Mapping, Union
 
 from .messages import RequestCompletionMessage, Streaming
 
 
-def stream_subscriber(
-    sub_callback: Callable[[Any], Union[None, Coroutine[None, None, None]]],
+def stream_chunk_subscriber(
+    callback: Union[
+        Callable[[Any], Any],
+        Mapping[str, Callable[[Any], Any]],
+    ],
 ) -> Callable[[RequestCompletionMessage], Coroutine[None, None, None]]:
     """
-    Converts the basic streamer callback into a broadcast_callback handler designed to take in `RequestCompletionMessage`
+    Converts a `stream_callback` (a single callable, or a mapping of channel name -> callable)
+    into a subscriber handler for `Streaming` messages.
+
+    - A single callable receives every streamed/broadcast item regardless of channel.
+    - A mapping routes each item to the callable registered under the item's channel name;
+      items on channels without a registered callable are dropped silently.
+
+    Callables may be sync or async.
     """
 
     async def subscriber_handler(item: RequestCompletionMessage):
-        if isinstance(item, Streaming):
-            result = sub_callback(item.streamed_object)
-            if asyncio.iscoroutine(result):
-                await result
+        if not isinstance(item, Streaming):
+            return
+
+        if isinstance(callback, Mapping):
+            fn = callback.get(item.channel)
+            if fn is None:
+                return
+        else:
+            fn = callback
+
+        result = fn(item.streamed_object)
+        if asyncio.iscoroutine(result):
+            await result
 
     return subscriber_handler

--- a/packages/railtracks/src/railtracks/pubsub/messages.py
+++ b/packages/railtracks/src/railtracks/pubsub/messages.py
@@ -204,7 +204,7 @@ class Streaming(RequestCompletionMessage):
         streamed_object: The item being streamed (typically a `str` chunk).
         node_id: The id of the node that emitted the item.
         channel: The named channel this item was emitted on. Consumers (`rt.astream`,
-            `stream_callback`) can filter/route on this name. Defaults to `"default"`.
+            `broadcast_callback`) can filter/route on this name. Defaults to `"default"`.
         stream_id: The stream scope this item belongs to. This is the request id of the entry
             frame that was invoked with streaming enabled (see `rt.astream`), or None if the
             item was broadcast outside any streaming scope.

--- a/packages/railtracks/src/railtracks/pubsub/messages.py
+++ b/packages/railtracks/src/railtracks/pubsub/messages.py
@@ -106,7 +106,10 @@ class RequestFailure(RequestFinishedBase):
         )
 
     def log_message(self) -> str:
-        return f"{self.node_state.node.name()} FAILED with error {self.error}"
+        node_name = (
+            self.node_state.node.name() if self.node_state is not None else "<unknown>"
+        )
+        return f"{node_name} FAILED with error {self.error}"
 
 
 class RequestCreationFailure(RequestFinishedBase):
@@ -131,6 +134,20 @@ class RequestCreationFailure(RequestFinishedBase):
 class RequestCreation(RequestCompletionMessage):
     """
     A message that describes the creation of a new request in the system.
+
+    Args:
+        current_node_id: The id of the node creating this request (None for a top level request).
+        current_run_id: The run id of the tree this request belongs to (None for a top level request).
+        new_request_id: The unique identifier of the request being created.
+        running_mode: The execution mode used to run this request.
+        new_node_type: The node type to instantiate for this request.
+        args: The positional arguments to pass to the node.
+        kwargs: The keyword arguments to pass to the node.
+        stream: If True, the created node's frame will have streaming enabled (see `rt.astream`).
+            Note this flag is frame-local: it applies only to the node created by this request,
+            never to its children.
+        current_stream_id: The stream scope id of the *creating* frame. Children inherit this id so
+            their explicit broadcasts can be routed to the consumer attached to the entry frame.
     """
 
     def __init__(
@@ -143,6 +160,8 @@ class RequestCreation(RequestCompletionMessage):
         new_node_type: Type[Node],
         args,
         kwargs,
+        stream: bool = False,
+        current_stream_id: str | None = None,
     ):
         self.current_node_id = current_node_id
         self.current_run_id = current_run_id
@@ -151,6 +170,8 @@ class RequestCreation(RequestCompletionMessage):
         self.new_node_type = new_node_type
         self.args = args
         self.kwargs = kwargs
+        self.stream = stream
+        self.current_stream_id = current_stream_id
 
     def __repr__(self):
         return (
@@ -177,12 +198,73 @@ class FatalFailure(RequestCompletionMessage):
 
 class Streaming(RequestCompletionMessage):
     """
-    A message that indicates a streaming operation in the request completion system.
+    A message carrying a single streamed item (e.g. an LLM token chunk or a user broadcast).
+
+    Args:
+        streamed_object: The item being streamed (typically a `str` chunk).
+        node_id: The id of the node that emitted the item.
+        channel: The named channel this item was emitted on. Consumers (`rt.astream`,
+            `stream_callback`) can filter/route on this name. Defaults to `"default"`.
+        stream_id: The stream scope this item belongs to. This is the request id of the entry
+            frame that was invoked with streaming enabled (see `rt.astream`), or None if the
+            item was broadcast outside any streaming scope.
     """
 
-    def __init__(self, *, streamed_object: Any, node_id: str):
+    def __init__(
+        self,
+        *,
+        streamed_object: Any,
+        node_id: str | None,
+        channel: str = "default",
+        stream_id: str | None = None,
+    ):
         self.streamed_object = streamed_object
         self.node_id = node_id
+        self.channel = channel
+        self.stream_id = stream_id
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(streamed_object={self.streamed_object}, node_id={self.node_id})"
+        return (
+            f"{self.__class__.__name__}(streamed_object={self.streamed_object}, "
+            f"node_id={self.node_id}, channel={self.channel}, stream_id={self.stream_id})"
+        )
+
+
+class StreamEnd(RequestCompletionMessage):
+    """
+    Marks the completion of one `rt.broadcast_stream` production on a channel.
+
+    `broadcast_stream` publishes this exactly once when its source stream is exhausted (or
+    fails), *after* all of its chunks — bus dispatch is FIFO, so a consumer that has seen this
+    marker has already received every chunk of that production. Channel consumers
+    (`rt.context.get_stream`) use these markers to know when the expected number of
+    productions has finished, without needing an external termination signal.
+
+    Note a channel itself never "closes": this marks the end of ONE production; other
+    producers may still write to the same channel.
+
+    Args:
+        channel: The channel the finished production was broadcast on.
+        node_id: The id of the node that ran the production.
+        stream_id: The stream scope the production belonged to (see `Streaming.stream_id`).
+        source_id: A unique id of this particular production (one per `broadcast_stream` call).
+    """
+
+    def __init__(
+        self,
+        *,
+        channel: str,
+        node_id: str | None,
+        stream_id: str | None,
+        source_id: str,
+    ):
+        self.channel = channel
+        self.node_id = node_id
+        self.stream_id = stream_id
+        self.source_id = source_id
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(channel={self.channel}, node_id={self.node_id}, "
+            f"stream_id={self.stream_id}, source_id={self.source_id})"
+        )

--- a/packages/railtracks/src/railtracks/pubsub/messages.py
+++ b/packages/railtracks/src/railtracks/pubsub/messages.py
@@ -196,6 +196,14 @@ class FatalFailure(RequestCompletionMessage):
         return f"{self.__class__.__name__}(error={self.error})"
 
 
+# The two kinds of broadcast traffic. "event": a one-off item published with `rt.broadcast`
+# (progress notes, tool events, ...). "stream": one chunk of a continuous production published
+# through `rt.broadcast_stream` — which includes all LLM token streaming. Session-level
+# callbacks are split along this line: `broadcast_callback` observes events, `stream_callback`
+# observes stream chunks.
+StreamingKind = Literal["event", "stream"]
+
+
 class Streaming(RequestCompletionMessage):
     """
     A message carrying a single streamed item (e.g. an LLM token chunk or a user broadcast).
@@ -204,10 +212,15 @@ class Streaming(RequestCompletionMessage):
         streamed_object: The item being streamed (typically a `str` chunk).
         node_id: The id of the node that emitted the item.
         channel: The named channel this item was emitted on. Consumers (`rt.astream`,
-            `broadcast_callback`) can filter/route on this name. Defaults to `"default"`.
+            `broadcast_callback` / `stream_callback`) can filter/route on this name.
+            Defaults to `"default"`.
         stream_id: The stream scope this item belongs to. This is the request id of the entry
             frame that was invoked with streaming enabled (see `rt.astream`), or None if the
             item was broadcast outside any streaming scope.
+        kind: What produced this item: `"event"` for a one-off `rt.broadcast`, `"stream"` for
+            a chunk of an `rt.broadcast_stream` production (LLM token streams included).
+            Session-level callbacks filter on this; scoped consumers (`rt.astream`,
+            `rt.context.get_stream`) do not — they separate traffic by channel instead.
     """
 
     def __init__(
@@ -217,16 +230,19 @@ class Streaming(RequestCompletionMessage):
         node_id: str | None,
         channel: str = "default",
         stream_id: str | None = None,
+        kind: StreamingKind = "event",
     ):
         self.streamed_object = streamed_object
         self.node_id = node_id
         self.channel = channel
         self.stream_id = stream_id
+        self.kind = kind
 
     def __repr__(self):
         return (
             f"{self.__class__.__name__}(streamed_object={self.streamed_object}, "
-            f"node_id={self.node_id}, channel={self.channel}, stream_id={self.stream_id})"
+            f"node_id={self.node_id}, channel={self.channel}, stream_id={self.stream_id}, "
+            f"kind={self.kind})"
         )
 
 

--- a/packages/railtracks/src/railtracks/state/state.py
+++ b/packages/railtracks/src/railtracks/state/state.py
@@ -90,7 +90,13 @@ class RTState:
         if isinstance(item, RequestCreation):
             previous_context = safe_get_runner_context()
             if item.current_node_id is not None:
-                update_parent_id(item.current_node_id, item.current_run_id)
+                # restore the creating frame's context (including its stream scope) so the
+                # task created below inherits the correct lineage.
+                update_parent_id(
+                    item.current_node_id,
+                    item.current_run_id,
+                    stream_id=item.current_stream_id,
+                )
 
             try:
                 assert item.new_request_id not in self._request_heap.heap().keys()
@@ -101,6 +107,7 @@ class RTState:
                     node=item.new_node_type,
                     args=item.args,
                     kwargs=item.kwargs,
+                    stream=item.stream,
                 )
             finally:
                 # restore publisher context after dispatching child tasks so root calls don't inherit stale run IDs
@@ -210,6 +217,7 @@ class RTState:
         node: type[Node[_P, _TOutput]],
         args,
         kwargs,
+        stream: bool = False,
     ):
         """
         This function will handle the creation of the node and the subsequent running of the node returning the result.
@@ -223,6 +231,7 @@ class RTState:
             node: The node you would like to create.
             args: The arguments to pass to the node.
             kwargs: The keyword arguments to pass to the node.
+            stream: If True, the created node's frame will have streaming enabled (frame-local).
 
         Returns:
             The output of the node that was run. It will match the output type of the child node that was run.
@@ -252,7 +261,7 @@ class RTState:
             logger.exception(rfa.to_logging_msg())
             raise e
         # you have to run this in a task so it isn't blocking other completions
-        outputs = asyncio.create_task(self._run_request(request_id))
+        outputs = asyncio.create_task(self._run_request(request_id, stream=stream))
 
         return outputs
 
@@ -306,7 +315,7 @@ class RTState:
 
         return request_ids
 
-    async def _run_request(self, request_id: str):
+    async def _run_request(self, request_id: str, stream: bool = False):
         """
         Runs the request for the given request id.
 
@@ -317,6 +326,7 @@ class RTState:
 
         Args:
             request_id: The identifier for the request you would like to run
+            stream: If True, the node's frame will have streaming enabled (frame-local).
 
 
         """
@@ -327,6 +337,7 @@ class RTState:
                 request_id=request_id,
                 node=node,
                 arguments=self._request_heap[request_id].input,
+                stream=stream,
             ),
             mode="async",
         )

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Mapping
 
-# A stream callback is either a single callable invoked for every chunk, or a mapping of
-# channel name -> callable used to route chunks per channel. Callables may be sync or async.
-StreamCallback = Callable[[Any], Any] | Mapping[str, Callable[[Any], Any]]
+# A broadcast callback is either a single callable invoked for every broadcast item (the
+# "firehose" form), or a mapping of channel name -> callable used to route items per channel
+# (preferred; unregistered channels are skipped). Callables may be sync or async. It is a
+# PASSIVE listener: registering one never enables streaming (only rt.astream does).
+BroadcastCallback = Callable[[Any], Any] | Mapping[str, Callable[[Any], Any]]
 
 
 class ExecutorConfig:
@@ -14,7 +16,7 @@ class ExecutorConfig:
         *,
         timeout: float | None = None,
         end_on_error: bool = False,
-        stream_callback: StreamCallback | None = None,
+        broadcast_callback: BroadcastCallback | None = None,
         prompt_injection: bool = True,
         save_state: bool = True,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -25,10 +27,11 @@ class ExecutorConfig:
         Args:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
-            stream_callback (Callable or Mapping[str, Callable]): A callback (or mapping of channel
-                name -> callback) that receives every streamed/broadcast item. Providing it also
-                enables token streaming for top-level calls (push-mode streaming; see `rt.astream`
-                for pull-mode).
+            broadcast_callback (Callable or Mapping[str, Callable]): A passive listener on the
+                broadcast bus. A mapping routes items per channel; a single callable receives
+                every item on every channel. It never enables streaming — only `rt.astream` /
+                `Flow.astream` do; use `Stream.route(...)` for push-style consumption of a
+                single streamed call.
             prompt_injection (bool): If true, prompts can be injected with global context
             save_state (bool): If true, the state of the executor will be saved to disk.
             payload_callback (Callable): A callback invoked once at session end with the full
@@ -36,7 +39,7 @@ class ExecutorConfig:
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
-        self.stream_subscriber = stream_callback
+        self.broadcast_callback = broadcast_callback
         self.prompt_injection = prompt_injection
         # During test runs, disable save_state by default unless RAILTRACKS_ALLOW_PERSISTENCE is set
         self._user_save_state = save_state
@@ -58,7 +61,7 @@ class ExecutorConfig:
         *,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        stream_subscriber: StreamCallback | None = None,
+        broadcast_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -71,9 +74,9 @@ class ExecutorConfig:
             end_on_error=end_on_error
             if end_on_error is not None
             else self.end_on_error,
-            stream_callback=stream_subscriber
-            if stream_subscriber is not None
-            else self.stream_subscriber,
+            broadcast_callback=broadcast_callback
+            if broadcast_callback is not None
+            else self.broadcast_callback,
             prompt_injection=prompt_injection
             if prompt_injection is not None
             else self.prompt_injection,

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import os
 from typing import Any, Callable, Mapping
 
-# A broadcast callback is either a single callable invoked for every broadcast item (the
-# "firehose" form), or a mapping of channel name -> callable used to route items per channel
-# (preferred; unregistered channels are skipped). Callables may be sync or async. It is a
-# PASSIVE listener: registering one never enables streaming (only rt.astream does).
+# A bus callback is either a single callable invoked for every item (the "firehose" form), or
+# a mapping of channel name -> callable used to route items per channel (preferred;
+# unregistered channels are skipped). Callables may be sync or async. Both callback lanes are
+# PASSIVE listeners: registering one never enables streaming (only rt.astream does).
+#
+# The two lanes carry different traffic:
+# - `broadcast_callback` receives one-off EVENTS published with `rt.broadcast`.
+# - `stream_callback` receives STREAM chunks published through `rt.broadcast_stream`
+#   (which includes all LLM token streaming during `rt.astream` runs).
 BroadcastCallback = Callable[[Any], Any] | Mapping[str, Callable[[Any], Any]]
 
 
@@ -17,6 +22,7 @@ class ExecutorConfig:
         timeout: float | None = None,
         end_on_error: bool = False,
         broadcast_callback: BroadcastCallback | None = None,
+        stream_callback: BroadcastCallback | None = None,
         prompt_injection: bool = True,
         save_state: bool = True,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -27,11 +33,16 @@ class ExecutorConfig:
         Args:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
-            broadcast_callback (Callable or Mapping[str, Callable]): A passive listener on the
-                broadcast bus. A mapping routes items per channel; a single callable receives
-                every item on every channel. It never enables streaming — only `rt.astream` /
-                `Flow.astream` do; use `Stream.route(...)` for push-style consumption of a
-                single streamed call.
+            broadcast_callback (Callable or Mapping[str, Callable]): A passive listener for
+                one-off **events** published with `rt.broadcast`. A mapping routes events per
+                channel; a single callable receives every event on every channel. It does not
+                receive streamed chunks — see `stream_callback`.
+            stream_callback (Callable or Mapping[str, Callable]): A passive listener for
+                **stream chunks** published through `rt.broadcast_stream` (LLM token streams
+                included). It never enables streaming — only `rt.astream` / `Flow.astream`
+                do; use `Stream.route(...)` for push-style consumption of a single streamed
+                call. Its niche over `route` is observing streams session-wide (e.g. nested
+                `astream` scopes in multi-agent runs).
             prompt_injection (bool): If true, prompts can be injected with global context
             save_state (bool): If true, the state of the executor will be saved to disk.
             payload_callback (Callable): A callback invoked once at session end with the full
@@ -40,6 +51,7 @@ class ExecutorConfig:
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.broadcast_callback = broadcast_callback
+        self.stream_callback = stream_callback
         self.prompt_injection = prompt_injection
         # During test runs, disable save_state by default unless RAILTRACKS_ALLOW_PERSISTENCE is set
         self._user_save_state = save_state
@@ -62,6 +74,7 @@ class ExecutorConfig:
         timeout: float | None = None,
         end_on_error: bool | None = None,
         broadcast_callback: BroadcastCallback | None = None,
+        stream_callback: BroadcastCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -77,6 +90,9 @@ class ExecutorConfig:
             broadcast_callback=broadcast_callback
             if broadcast_callback is not None
             else self.broadcast_callback,
+            stream_callback=stream_callback
+            if stream_callback is not None
+            else self.stream_callback,
             prompt_injection=prompt_injection
             if prompt_injection is not None
             else self.prompt_injection,

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Coroutine
+from typing import Any, Callable, Mapping
+
+# A stream callback is either a single callable invoked for every chunk, or a mapping of
+# channel name -> callable used to route chunks per channel. Callables may be sync or async.
+StreamCallback = Callable[[Any], Any] | Mapping[str, Callable[[Any], Any]]
 
 
 class ExecutorConfig:
@@ -10,9 +14,7 @@ class ExecutorConfig:
         *,
         timeout: float | None = None,
         end_on_error: bool = False,
-        broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
+        stream_callback: StreamCallback | None = None,
         prompt_injection: bool = True,
         save_state: bool = True,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -23,13 +25,18 @@ class ExecutorConfig:
         Args:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
-            broadcast_callback (Callable or Coroutine): A function or coroutine that will handle streaming messages.
+            stream_callback (Callable or Mapping[str, Callable]): A callback (or mapping of channel
+                name -> callback) that receives every streamed/broadcast item. Providing it also
+                enables token streaming for top-level calls (push-mode streaming; see `rt.astream`
+                for pull-mode).
             prompt_injection (bool): If true, prompts can be injected with global context
             save_state (bool): If true, the state of the executor will be saved to disk.
+            payload_callback (Callable): A callback invoked once at session end with the full
+                serialized session payload.
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
-        self.subscriber = broadcast_callback
+        self.stream_subscriber = stream_callback
         self.prompt_injection = prompt_injection
         # During test runs, disable save_state by default unless RAILTRACKS_ALLOW_PERSISTENCE is set
         self._user_save_state = save_state
@@ -51,9 +58,7 @@ class ExecutorConfig:
         *,
         timeout: float | None = None,
         end_on_error: bool | None = None,
-        subscriber: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
+        stream_subscriber: StreamCallback | None = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -66,9 +71,9 @@ class ExecutorConfig:
             end_on_error=end_on_error
             if end_on_error is not None
             else self.end_on_error,
-            broadcast_callback=subscriber
-            if subscriber is not None
-            else self.subscriber,
+            stream_callback=stream_subscriber
+            if stream_subscriber is not None
+            else self.stream_subscriber,
             prompt_injection=prompt_injection
             if prompt_injection is not None
             else self.prompt_injection,

--- a/packages/railtracks/src/railtracks/utils/publisher.py
+++ b/packages/railtracks/src/railtracks/utils/publisher.py
@@ -26,7 +26,7 @@ class Subscriber(Generic[_T]):
         self.id = str(uuid.uuid4())
 
     async def trigger(self, message: _T):
-        """Trigger this broadcast_callback with the given message."""
+        """Trigger this subscriber with the given message."""
         try:
             result = self.callback(message)
             if asyncio.iscoroutine(result):
@@ -41,7 +41,7 @@ class Publisher(Generic[_T]):
 
     Note a couple of things:
     - Message will be handled in the order they came in (no jumping the line)
-    - If you add a broadcast_callback during the operation it will handle any new messages that come in after the subscription
+    - If you add a subscriber during the operation it will handle any new messages that come in after the subscription
         took place
     - Calling the shutdown method will kill the publisher forever. You will have to make a new one after.
     """
@@ -128,10 +128,10 @@ class Publisher(Generic[_T]):
 
         Args:
             callback: The callback function that will be triggered when a message is published.
-            name: Optional name for the broadcast_callback, mainly used for debugging.
+            name: Optional name for the subscriber, mainly used for debugging.
 
         Returns:
-            str: A unique identifier for the broadcast_callback. You can use this key to unsubscribe later.
+            str: A unique identifier for the subscriber. You can use this key to unsubscribe later.
 
         """
         sub = Subscriber(callback, name)
@@ -140,19 +140,19 @@ class Publisher(Generic[_T]):
 
     def unsubscribe(self, identifier: str):
         """
-        Unsubscribe the publisher so the given broadcast_callback will no longer receive messages.
+        Unsubscribe the publisher so the given subscriber will no longer receive messages.
 
         Args:
-            identifier: The unique identifier of the broadcast_callback to remove.
+            identifier: The unique identifier of the subscriber to remove.
 
         Raises:
-            KeyError: If no broadcast_callback with the given identifier exists.
+            KeyError: If no subscriber with the given identifier exists.
         """
         index_to_remove = [
             index for index, sub in enumerate(self._subscribers) if sub.id == identifier
         ]
         if not index_to_remove:
-            raise KeyError(f"No broadcast_callback with identifier {identifier} found.")
+            raise KeyError(f"No subscriber with identifier {identifier} found.")
 
         index_to_remove = index_to_remove[0]
         self._subscribers.pop(index_to_remove)
@@ -167,7 +167,7 @@ class Publisher(Generic[_T]):
         Creates a special listener object that will wait for the first message that matches the given filter.
 
         After receiving the message it will run the result_mapping function on the message and return the result, and
-        kill the broadcast_callback.
+        kill the subscriber.
 
         Args:
             message_filter: A function that takes a message and returns True if the message should be returned.

--- a/packages/railtracks/src/railtracks/validation/node_invocation/validation.py
+++ b/packages/railtracks/src/railtracks/validation/node_invocation/validation.py
@@ -3,7 +3,7 @@ from railtracks.exceptions.messages.exception_messages import (
     get_message,
     get_notes,
 )
-from railtracks.llm import Message, MessageHistory, ModelBase
+from railtracks.llm import Message, MessageHistory, ModelBase, SystemMessage
 from railtracks.utils.logging import get_rt_logger
 
 # Global logger for validation
@@ -11,8 +11,19 @@ logger = get_rt_logger(__name__)
 
 
 def check_message_history(
-    message_history: MessageHistory, system_message: str | None = None
+    message_history: MessageHistory,
+    system_message: SystemMessage | str | None = None,
 ) -> None:
+    """Validates a message history (and optional system message) before an LLM node runs.
+
+    Args:
+        message_history: The history to validate.
+        system_message: The node-level system message (if any); only its presence is used.
+
+    Raises:
+        NodeInvocationError: If the history contains non-Message items or is empty while no
+            system message is configured.
+    """
     if any(not isinstance(m, Message) for m in message_history):
         raise NodeInvocationError(
             message=get_message("MESSAGE_HISTORY_TYPE_MSG"),

--- a/packages/railtracks/tests/conftest.py
+++ b/packages/railtracks/tests/conftest.py
@@ -180,8 +180,32 @@ class MockLLM(rt.llm.ModelBase):
     async def _achat_with_tools(self, messages, tools, **kwargs):
         return self._base_chat_with_tools(messages, **kwargs)
 
+    # ---- per-call streaming (rt.astream / model.astream_*): async generators yielding
+    # str chunks followed by a final Response ----
     async def _astream_chat(self, messages, **kwargs):
-        return self._base_chat()
+        text = self.custom_response or "mocked Message"
+        for char in text:
+            yield char
+        yield Response(
+            message=AssistantMessage(content=text),
+            message_info=self.mocked_message_info,
+        )
+
+    async def _astream_structured(self, messages, schema, **kwargs):
+        response = self._base_structured(messages, schema)
+        assert isinstance(response, Response)
+        content = response.message.content
+        for char in content.model_dump_json():
+            yield char
+        yield response
+
+    async def _astream_chat_with_tools(self, messages, tools, **kwargs):
+        response = self._base_chat_with_tools(messages)
+        assert isinstance(response, Response)
+        if isinstance(response.message.content, str):
+            for char in response.message.content:
+                yield char
+        yield response
 
     def _chat(self, messages, **kwargs):
         return self._base_chat()

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -7,9 +7,6 @@ import railtracks as rt
 from pydantic import BaseModel, Field
 
 from railtracks.built_nodes.concrete import (
-    GuardedStreamingStructuredLLM,
-    GuardedStreamingTerminalLLM,
-    GuardedStreamingToolCallLLM,
     GuardedStructuredLLM,
     GuardedStructuredToolCallLLM,
     GuardedTerminalLLM,
@@ -87,7 +84,6 @@ async def test_terminal_agent_uses_guarded_base_when_guardrails_set(
         guardrails=Guard(input=[allow_input]),
     )
     assert issubclass(Agent, GuardedTerminalLLM)
-    assert not issubclass(Agent, GuardedStreamingTerminalLLM)
 
 
 @pytest.mark.asyncio
@@ -124,6 +120,8 @@ async def test_terminal_input_allow_calls_llm(mock_llm, allow_input):
 @pytest.mark.parametrize("stream", [False, True])
 @pytest.mark.asyncio
 async def test_streaming_terminal_guardrails(mock_llm, allow_input, stream):
+    # streaming is now decided at the call site (rt.astream); a model constructed with the
+    # deprecated stream=True flag maps to the same guarded class and a complete response.
     llm = mock_llm(custom_response="streamed", stream=stream)
     counts = _counting_chat(llm)
     Agent = rt.agent_node(
@@ -131,22 +129,14 @@ async def test_streaming_terminal_guardrails(mock_llm, allow_input, stream):
         llm=llm,
         guardrails=Guard(input=[allow_input]),
     )
-    assert issubclass(Agent, GuardedStreamingTerminalLLM if stream else GuardedTerminalLLM)
+    assert issubclass(Agent, GuardedTerminalLLM)
 
     with rt.Session():
         result = await rt.call(Agent, user_input="hi")
 
     assert counts["n"] == 1
-    if stream:
-        collected: StringResponse | None = None
-        for chunk in result:
-            if isinstance(chunk, StringResponse):
-                collected = chunk
-        assert collected is not None
-        assert "streamed" in collected.text
-    else:
-        assert isinstance(result, StringResponse)
-        assert "streamed" in result.text
+    assert isinstance(result, StringResponse)
+    assert "streamed" in result.text
 
 
 @pytest.mark.asyncio
@@ -217,6 +207,8 @@ async def test_structured_output_block_after_llm(mock_llm, allow_input):
 @pytest.mark.parametrize("stream", [False, True])
 @pytest.mark.asyncio
 async def test_structured_streaming_guardrails(mock_llm, allow_input, stream):
+    # streaming is now decided at the call site (rt.astream); a model constructed with the
+    # deprecated stream=True flag maps to the same guarded class and a complete response.
     llm = mock_llm(custom_response='{"text":"s"}', stream=stream)
     counts = _counting_structured(llm)
     Agent = rt.agent_node(
@@ -225,25 +217,14 @@ async def test_structured_streaming_guardrails(mock_llm, allow_input, stream):
         llm=llm,
         guardrails=Guard(input=[allow_input]),
     )
-    assert issubclass(
-        Agent,
-        GuardedStreamingStructuredLLM if stream else GuardedStructuredLLM,
-    )
+    assert issubclass(Agent, GuardedStructuredLLM)
 
     with rt.Session():
         result = await rt.call(Agent, user_input="hi")
 
     assert counts["n"] == 1
-    if stream:
-        final: StructuredResponse[_Answer] | None = None
-        for chunk in result:
-            if isinstance(chunk, StructuredResponse):
-                final = chunk
-        assert final is not None
-        assert final.structured.text == "s"
-    else:
-        assert isinstance(result, StructuredResponse)
-        assert result.structured.text == "s"
+    assert isinstance(result, StructuredResponse)
+    assert result.structured.text == "s"
 
 
 
@@ -419,7 +400,7 @@ async def test_tool_call_no_guardrails_produces_unguarded_node(mock_llm):
 
 
 # ============================================================
-# StreamingToolCallLLM guardrail tests
+# Tool-call guardrail tests with (deprecated) stream=True models
 # ============================================================
 
 
@@ -434,7 +415,7 @@ async def test_streaming_tool_call_uses_guarded_base(mock_llm, allow_input):
         llm=mock_llm(stream=True),
         guardrails=Guard(input=[allow_input]),
     )
-    assert issubclass(Agent, GuardedStreamingToolCallLLM)
+    assert issubclass(Agent, GuardedToolCallLLM)
 
 
 @pytest.mark.asyncio

--- a/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
@@ -56,8 +56,9 @@ async def test_structured_llm_run_with_different_inputs(mock_llm, simple_output_
         assert isinstance(response.content.number, int)
 
 @pytest.mark.asyncio
-async def test_terminal_llm_streaming(mock_llm):
-    """Test that the terminal LLM can stream responses."""
+async def test_terminal_llm_legacy_stream_flag_is_buffered(mock_llm):
+    """A model constructed with the deprecated stream=True flag still yields a complete
+    response from rt.call (streaming is now requested at the call site via rt.astream)."""
     llm = mock_llm(stream=True, custom_response="hello world")
 
     agent = rt.agent_node(
@@ -68,21 +69,13 @@ async def test_terminal_llm_streaming(mock_llm):
 
     with rt.Session():
         response = await rt.call(agent, user_input=rt.llm.MessageHistory([rt.llm.UserMessage("hello world")]))
-        accumulated_text = ""
-        for chunk in response:
-            assert isinstance(chunk, (str, StringResponse))
-            if isinstance(chunk, StringResponse):
-                assert isinstance(chunk.text, str)
-                assert chunk.text == "hello world"
-            if isinstance(chunk, str):
-                accumulated_text += chunk
-            
-        assert accumulated_text == "hello world"
+        assert isinstance(response, StringResponse)
+        assert response.text == "hello world"
 
 
 @pytest.mark.asyncio
-async def test_structured_llm_streaming(mock_llm, simple_output_model):
-    """Test Structured LLM streaming."""
+async def test_structured_llm_legacy_stream_flag_is_buffered(mock_llm, simple_output_model):
+    """Same as above, for structured output."""
     llm = mock_llm(stream=True, custom_response='{"text":"hello world", "number":"42"}')
 
     agent = rt.agent_node(
@@ -94,19 +87,10 @@ async def test_structured_llm_streaming(mock_llm, simple_output_model):
 
     with rt.Session():
         response = await rt.call(agent, user_input=rt.llm.MessageHistory([rt.llm.UserMessage("hello world")]))
-        accumulated_text = ""
-        for chunk in response:
-            assert isinstance(chunk, (str, StructuredResponse))
-
-            if isinstance(chunk, StructuredResponse):
-                assert isinstance(chunk.structured, simple_output_model)
-                assert chunk.structured.text == "hello world"
-                assert chunk.structured.number == 42
-
-            if isinstance(chunk, str):
-                accumulated_text += chunk
-
-        assert accumulated_text == '{"text":"hello world","number":42}'
+        assert isinstance(response, StructuredResponse)
+        assert isinstance(response.structured, simple_output_model)
+        assert response.structured.text == "hello world"
+        assert response.structured.number == 42
 
 
 

--- a/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
@@ -48,14 +48,9 @@ class TestSimpleToolCalling:
                 agent,
                 user_input="What is the secret phrase? Only return the secret phrase, no other text.",
             )
-            collected_response: StringResponse | None = None
-            if stream:
-                for chunk in response:
-                    assert isinstance(chunk, (str, StringResponse))
-                    if isinstance(chunk, StringResponse):
-                        collected_response = chunk
-            else:
-                collected_response = response
+            # streaming is now decided at the call site (rt.astream); the deprecated
+            # stream=True model flag still yields a complete response from rt.call.
+            collected_response: StringResponse | None = response
             assert collected_response is not None
             assert "Constantinople" in collected_response.text
             assert rt.context.get("secret_phrase_called")

--- a/packages/railtracks/tests/integration_tests/run/test_broadcast.py
+++ b/packages/railtracks/tests/integration_tests/run/test_broadcast.py
@@ -25,7 +25,7 @@ async def test_simple_streamer():
 
     sub = SubObject()
     with rt.Session(
-        broadcast_callback=sub.handle,
+        stream_callback=sub.handle,
     ):
         finished_result = await rt.call(StreamingRNGNode)
 
@@ -49,7 +49,7 @@ async def test_slow_streamer():
             self.finished_message = item
 
     sub = Sub()
-    with rt.Session(broadcast_callback=sub.handle):
+    with rt.Session(stream_callback=sub.handle):
         finished_result = await rt.call(StreamingRNGNode)
 
     assert isinstance(finished_result, float)
@@ -88,7 +88,7 @@ async def rng_stream_tester(
                 self.total_streams.append(item)
 
     sub = Sub()
-    with rt.Session(broadcast_callback=sub.handle):
+    with rt.Session(stream_callback=sub.handle):
         finished_result = await rt.call(
             RNGTreeStreamer, num_calls, parallel_call_nums, multiplier
         )

--- a/packages/railtracks/tests/integration_tests/run/test_broadcast.py
+++ b/packages/railtracks/tests/integration_tests/run/test_broadcast.py
@@ -25,7 +25,7 @@ async def test_simple_streamer():
 
     sub = SubObject()
     with rt.Session(
-        stream_callback=sub.handle,
+        broadcast_callback=sub.handle,
     ):
         finished_result = await rt.call(StreamingRNGNode)
 
@@ -49,7 +49,7 @@ async def test_slow_streamer():
             self.finished_message = item
 
     sub = Sub()
-    with rt.Session(stream_callback=sub.handle):
+    with rt.Session(broadcast_callback=sub.handle):
         finished_result = await rt.call(StreamingRNGNode)
 
     assert isinstance(finished_result, float)
@@ -88,7 +88,7 @@ async def rng_stream_tester(
                 self.total_streams.append(item)
 
     sub = Sub()
-    with rt.Session(stream_callback=sub.handle):
+    with rt.Session(broadcast_callback=sub.handle):
         finished_result = await rt.call(
             RNGTreeStreamer, num_calls, parallel_call_nums, multiplier
         )

--- a/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
+++ b/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
@@ -144,7 +144,7 @@ StreamingNode = rt.function_node(streaming_func)
 async def test_streaming_inserted_globally():
     handler = StreamHandler()
 
-    railtracks.context.central.set_config(stream_callback=handler.handle)
+    railtracks.context.central.set_config(broadcast_callback=handler.handle)
     with rt.Session():
         result = await rt.call(StreamingNode)
         assert result is None
@@ -157,7 +157,7 @@ async def test_streaming_inserted_globally():
 async def test_streaming_inserted_locally():
     handler = StreamHandler()
 
-    with rt.Session(stream_callback=handler.handle):
+    with rt.Session(broadcast_callback=handler.handle):
         result = await rt.call(StreamingNode)
         assert result is None
 
@@ -173,8 +173,8 @@ def fake_handler(item: str) -> None:
 async def test_streaming_overwrite():
     handler = StreamHandler()
 
-    railtracks.context.central.set_config(stream_callback=fake_handler)
-    with rt.Session(stream_callback=handler.handle):
+    railtracks.context.central.set_config(broadcast_callback=fake_handler)
+    with rt.Session(broadcast_callback=handler.handle):
         result = await rt.call(StreamingNode)
         assert result is None
 

--- a/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
+++ b/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
@@ -144,7 +144,7 @@ StreamingNode = rt.function_node(streaming_func)
 async def test_streaming_inserted_globally():
     handler = StreamHandler()
 
-    railtracks.context.central.set_config(broadcast_callback=handler.handle)
+    railtracks.context.central.set_config(stream_callback=handler.handle)
     with rt.Session():
         result = await rt.call(StreamingNode)
         assert result is None
@@ -157,7 +157,7 @@ async def test_streaming_inserted_globally():
 async def test_streaming_inserted_locally():
     handler = StreamHandler()
 
-    with rt.Session(broadcast_callback=handler.handle):
+    with rt.Session(stream_callback=handler.handle):
         result = await rt.call(StreamingNode)
         assert result is None
 
@@ -173,8 +173,8 @@ def fake_handler(item: str) -> None:
 async def test_streaming_overwrite():
     handler = StreamHandler()
 
-    railtracks.context.central.set_config(broadcast_callback=fake_handler)
-    with rt.Session(broadcast_callback=handler.handle):
+    railtracks.context.central.set_config(stream_callback=fake_handler)
+    with rt.Session(stream_callback=handler.handle):
         result = await rt.call(StreamingNode)
         assert result is None
 

--- a/packages/railtracks/tests/llm_live_tests/llm_map.py
+++ b/packages/railtracks/tests/llm_live_tests/llm_map.py
@@ -1,15 +1,18 @@
 import railtracks as rt
 
+# Streaming is now requested at the call site (rt.astream) rather than at model construction,
+# so the map only contains regular models. `streaming_llm_map` selects the models used for the
+# rt.astream live tests.
 llm_map = {
     "openai": rt.llm.OpenAILLM("gpt-4o"),
-    "openai_stream": rt.llm.OpenAILLM("gpt-4o", stream=True),
     "anthropic": rt.llm.AnthropicLLM("claude-sonnet-4-5-20250929"),
     "huggingface": rt.llm.HuggingFaceLLM("together/deepseek-ai/DeepSeek-R1"),        # this model is a little dumb, see test_function_as_tool test case
     "gemini": rt.llm.GeminiLLM("gemini-2.5-flash"),
-    "anthropic_stream": rt.llm.AnthropicLLM("claude-sonnet-4-5-20250929", stream=True),
     # "cohere": rt.llm.CohereLLM("command-a-03-2025"), # TODO: #uncomment after https://github.com/RailtownAI/railtracks/issues/775
-    "huggingface_stream": rt.llm.HuggingFaceLLM("together/deepseek-ai/DeepSeek-R1", stream=True),        # this model is a little dumb, see test_function_as_tool test case
-    "gemini_stream": rt.llm.GeminiLLM("gemini-2.5-flash", stream=True),
-    # "cohere_stream": rt.llm.CohereLLM("command-a-03-2025", stream=True), #TODO: #uncomment after https://github.com/RailtownAI/railtracks/issues/775
 }
 
+streaming_llm_map = {
+    "openai": llm_map["openai"],
+    "anthropic": llm_map["anthropic"],
+    "gemini": llm_map["gemini"],
+}

--- a/packages/railtracks/tests/llm_live_tests/test_basic.py
+++ b/packages/railtracks/tests/llm_live_tests/test_basic.py
@@ -3,7 +3,7 @@ import railtracks as rt
 from pydantic import BaseModel, Field
 from railtracks.built_nodes.concrete.response import StringResponse, StructuredResponse
 
-from .llm_map import llm_map
+from .llm_map import llm_map, streaming_llm_map
 
 # Filter out Cohere LLMs for these tests
 llm_map_filtered = {k: v for k, v in llm_map.items() if "cohere" not in k.lower()}
@@ -61,17 +61,32 @@ async def test_terminal_llm(llm):
         response = await rt.call(
             terminal_node, user_input="Please reverse '12345'."
         )
-        final_resp: StringResponse | None = None
-        if llm.stream:
-            for chunk in response:
-                assert isinstance(chunk, (str, StringResponse)), "The response should be either string or the final response"
-                if isinstance(chunk, StringResponse):
-                    final_resp = chunk
-        else:
-            final_resp = response
-        
+        assert isinstance(response, StringResponse)
+        assert '54321' in response.content
 
-        assert final_resp is not None and '54321' in final_resp.content
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm", streaming_llm_map.values(), ids=streaming_llm_map.keys())
+async def test_terminal_llm_astream(llm):
+    """Test pull-based streaming (rt.astream) against live providers."""
+
+    terminal_node = rt.agent_node(
+        name="Terminal Node",
+        system_message="You are a helpful assistant reverses the input string.",
+        llm=llm,
+    )
+
+    with rt.Session():
+        stream = rt.astream(terminal_node, user_input="Please reverse '12345'.")
+        accumulated = ""
+        async for chunk in stream:
+            assert isinstance(chunk, str), "astream should only yield str chunks"
+            accumulated += chunk
+
+        final_resp = stream.result
+        assert isinstance(final_resp, StringResponse)
+        assert "54321" in final_resp.content
+        assert "54321" in accumulated
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map_filtered.values(), ids=llm_map_filtered.keys())
@@ -92,15 +107,7 @@ async def test_structured_llm(llm, test_case):
             user_input=test_case["user_input"]
         )
 
-        final_resp = None
-
-        if llm.stream:
-            for chunk in response:
-                assert isinstance(chunk, (str, StructuredResponse)), "The response should be either string or the final response"
-                if isinstance(chunk, StructuredResponse):
-                    final_resp = chunk
-        else:
-            final_resp = response
+        final_resp = response
 
         # Basic type check
         assert final_resp is not None

--- a/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
+++ b/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
@@ -1,8 +1,6 @@
 import pytest
 from railtracks.built_nodes.concrete.response import StringResponse
-from railtracks.exceptions.errors import NodeCreationError
-from railtracks.llm.providers import ModelProvider
-from .llm_map import llm_map
+from .llm_map import llm_map, streaming_llm_map
 import railtracks as rt
 from pydantic import BaseModel, Field
 from typing import Optional, final
@@ -37,27 +35,49 @@ async def test_function_as_tool(llm):
     )
 
     with rt.Session():
-        if llm.stream and llm.model_provider() != ModelProvider.OPENAI:
-            with pytest.raises(NodeCreationError):
-                response = await rt.call(agent, user_input="First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.")
+        response = await rt.call(agent, user_input="First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.")
 
-            return
-        else:
-            response = await rt.call(agent, user_input="First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.")
-
-        final_resp = None
-        if llm.stream:
-            for chunk in response:
-                assert isinstance(chunk, (str, StringResponse))
-                if isinstance(chunk, StringResponse):
-                    final_resp = chunk
-        else:
-            final_resp = response
+        final_resp = response
 
         assert final_resp is not None
         assert '15' in final_resp.content
         assert rt.context.get("magic_number_called")
         assert rt.context.get("magic_operator_called")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("llm", streaming_llm_map.values(), ids=streaming_llm_map.keys())
+async def test_function_as_tool_astream(llm):
+    """Tool-calling agents streamed via rt.astream: text chunks stream, tools still run.
+
+    Non-OpenAI providers are on the tool-calling streaming blacklist and fall back to a
+    buffered call (no chunks) — the final result must be identical either way.
+    """
+
+    def magic_number(input_num: int):
+        """
+        Args:
+            input_num (int): The input number to test.
+        """
+        rt.context.put("magic_number_called", True)
+        return input_num + 2
+
+    agent = rt.agent_node(
+        tool_nodes={rt.function_node(magic_number)},
+        name="Magic Number Agent",
+        system_message="You are a helpful assistant that can call the tools available to you to answer user queries",
+        llm=llm,
+    )
+
+    with rt.Session():
+        stream = rt.astream(agent, user_input="Find the magic number for 4 and return it.")
+        async for chunk in stream:
+            assert isinstance(chunk, str), "astream should only yield str chunks"
+
+        final_resp = stream.result
+        assert isinstance(final_resp, StringResponse)
+        assert '6' in final_resp.content
+        assert rt.context.get("magic_number_called")
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
@@ -100,19 +120,10 @@ async def test_realistic_scenario(llm):
     )
 
     with rt.Session():
-        if llm.stream and llm.model_provider() != ModelProvider.OPENAI:
-            return
-        else:
-            response = await rt.call(
-                agent, rt.llm.MessageHistory([rt.llm.UserMessage(usr_prompt)])
-            )
+        await rt.call(
+            agent, rt.llm.MessageHistory([rt.llm.UserMessage(usr_prompt)])
+        )
         assert rt.context.get("staff_directory_updated")
-
-        if llm.stream:
-            for chunk in response:
-                assert isinstance(chunk, (str, StringResponse))
-                pass
-
 
     assert DB["John"]["role"] == "Senior Manager"
     assert DB["John"]["phone"] == "5555"
@@ -169,22 +180,12 @@ async def test_agents_as_tools(llm):
 
     # Run the parent tool
     with rt.Session(timeout=100):
-        if llm.stream:
-            return
-        
         response = await rt.call(
             parent_tool, user_input="Get me the secret phrase for id `1`."
         )
 
-        final_resp = None
-        if llm.stream:
-            for chunk in response:
-                assert isinstance(chunk, (str, StringResponse))
-                if isinstance(chunk, StringResponse):
-                    final_resp = chunk
-        else:
-            final_resp = response
-            
+        final_resp = response
+
         assert final_resp is not None
         assert rt.context.get("secret_phrase_called")
 

--- a/packages/railtracks/tests/unit_tests/context/test_central.py
+++ b/packages/railtracks/tests/unit_tests/context/test_central.py
@@ -117,7 +117,9 @@ def test_update_parent_id(monkeypatch, make_runner_context_vars):
     monkeypatch.setattr(central, "safe_get_runner_context", mock.Mock(return_value=rt))
     monkeypatch.setattr(central, "runner_context", mock.Mock(set=mock.Mock()))
     central.update_parent_id("new-parent")
-    rt.prepare_new.assert_called_with("new-parent", new_run_id=None)
+    rt.prepare_new.assert_called_with(
+        "new-parent", new_run_id=None, stream=False, stream_id=None
+    )
     central.runner_context.set.assert_called_with("new_ctx")
 
 def test_runner_context_vars_prepare_new(make_external_context_mock, make_internal_context_mock):

--- a/packages/railtracks/tests/unit_tests/execution/test_task.py
+++ b/packages/railtracks/tests/unit_tests/execution/test_task.py
@@ -11,7 +11,9 @@ from railtracks.execution.task import Task
 async def test_invoke_calls_update_and_node_invoke(mock_get_run_id, mock_update_parent_id, mock_node):
     task = Task(request_id="req-1", node=mock_node, arguments=((), {}))
     result = await task.invoke()
-    mock_update_parent_id.assert_called_once_with("mock-uuid")
+    mock_update_parent_id.assert_called_once_with(
+        "mock-uuid", stream=False, stream_id=None
+    )
     mock_node.wrapped_invoke.assert_awaited_once()
     assert result == "result"
 
@@ -23,7 +25,9 @@ async def test_invoke_propagates_exception(mock_update_parent_id, mock_get_run_i
     task = Task(request_id="req-2", node=mock_node, arguments=((), {}))
     with pytest.raises(RuntimeError, match="fail!"):
         await task.invoke()
-    mock_update_parent_id.assert_called_once_with("mock-uuid")
+    mock_update_parent_id.assert_called_once_with(
+        "mock-uuid", stream=False, stream_id=None
+    )
     mock_node.wrapped_invoke.assert_awaited_once()
 
 

--- a/packages/railtracks/tests/unit_tests/llm/models/conftest.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/conftest.py
@@ -1,15 +1,14 @@
-import pytest
-from pydantic import BaseModel, Field
-from railtracks.llm.message import UserMessage, AssistantMessage, ToolMessage
-from railtracks.llm.history import MessageHistory
-from railtracks.llm.content import ToolCall, ToolResponse
-from railtracks.llm.providers import ModelProvider
-from railtracks.llm.tools import Tool, Parameter
-from railtracks.llm.models._litellm_wrapper import LiteLLMWrapper
-
-from typing import Any, Optional, Tuple, Union
-from litellm.utils import CustomStreamWrapper, ModelResponse  # type: ignore
 import logging
+from typing import Any, Optional, Tuple, Union
+
+import pytest
+from litellm.utils import CustomStreamWrapper, ModelResponse  # type: ignore
+from pydantic import BaseModel
+from railtracks.llm.content import ToolCall, ToolResponse
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.message import AssistantMessage, ToolMessage, UserMessage
+from railtracks.llm.models._litellm_wrapper import LiteLLMWrapper
+from railtracks.llm.tools import Parameter, Tool
 
 
 # ====================================== START Tool Fixtures ======================================
@@ -202,8 +201,10 @@ class MockLiteLLMWrapper(LiteLLMWrapper):
         *,
         response_format: Optional[Any] = None,
         tools: Optional[list[Tool]] = None,
+        stream: Optional[bool] = None,
     ) -> Tuple[Union[CustomStreamWrapper, ModelResponse], float]:
-        if self.stream:
+        resolved_stream = self.stream if stream is None else stream
+        if resolved_stream:
 
             def _stream_gen():
                 for i, char in enumerate(self.content):
@@ -241,48 +242,6 @@ class MockLiteLLMWrapper(LiteLLMWrapper):
             return (
                 CustomStreamWrapper(
                     completion_stream=_stream_gen(),
-                    model=self.model_name(),
-                    logging_obj=MockLogger(),
-                ),
-                0.0,
-            )
-        else:
-            return self._invoke_content()
-
-    async def _ainvoke(
-        self,
-        messages: MessageHistory,
-        *,
-        response_format: Optional[Any] = None,
-        tools: Optional[list[Tool]] = None,
-    ) -> Tuple[Union[CustomStreamWrapper, ModelResponse], float]:
-        if self.stream:
-
-            async def _astream_gen():
-                for i, char in enumerate(self.content):
-                    yield ChatCompletionChunk(
-                        id=str(i),
-                        choices=[
-                            MockChoice(
-                                delta=MockDelta(
-                                    content=char,
-                                    tool_calls=self.tool_calls,
-                                ),
-                                finish_reason=(
-                                    "stop" if i == len(self.content) else ""
-                                ),
-                            )
-                        ],
-                    )
-                
-                yield ChatCompletionChunk(
-                    id=str(len(self.content) + 1),
-                    choices=[],
-                )
-
-            return (
-                CustomStreamWrapper(
-                    completion_stream=_astream_gen(),
                     model=self.model_name(),
                     logging_obj=MockLogger(),
                 ),

--- a/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
@@ -1,20 +1,21 @@
+import json
+from json import JSONDecodeError
 from typing import Generator, Literal
 from unittest.mock import patch
+
+import litellm
 import pytest
+from pydantic import BaseModel
+from railtracks.exceptions import LLMError, NodeInvocationError
+from railtracks.llm import AssistantMessage, UserMessage
+from railtracks.llm.history import MessageHistory
 from railtracks.llm.models._litellm_wrapper import (
     LiteLLMWrapper,
     _parameters_to_json_schema,
     _to_litellm_tool,
 )
-from railtracks.exceptions import NodeInvocationError, LLMError
-from railtracks.llm import AssistantMessage, UserMessage
 from railtracks.llm.providers import ModelProvider
-from pydantic import BaseModel
 from railtracks.llm.response import Response
-from json import JSONDecodeError
-import litellm
-from railtracks.llm.content import Stream
-import json
 
 
 class _ConcreteLiteLLMWrapperForTest(LiteLLMWrapper[Literal[False]]):
@@ -324,7 +325,7 @@ class TestCompletionMethods:
                         assert calls[0]["name"] == "tool_x"
                         assert calls[0]["arguments"] == {"foo": 1}
                         assert calls[0]["identifier"] == "id123"
-                    except Exception as e:
+                    except Exception:
                         pytest.fail("Structured response did not match schema")
                 elif not isinstance(chunk, str):
                     pytest.fail("Stream yielded non-string, non-Response chunk")
@@ -336,6 +337,79 @@ class TestCompletionMethods:
             assert calls[0].name == "tool_x"
             assert calls[0].arguments == {"foo": 1}
             assert calls[0].identifier == "id123"
+
+
+# ================= START async streaming (sync bridge) tests =========================
+class TestAsyncStreaming:
+    """Exercise the per-call `astream_*` surface, which rides the synchronous
+    `litellm.completion(stream=True)` bridged onto the event loop by `_bridge_sync_stream`.
+
+    The model is constructed with `stream=False` on purpose: per-call streaming forces the
+    streamed request itself, independent of the (deprecated) constructor flag."""
+
+    @pytest.mark.asyncio
+    async def test_astream_chat_yields_chunks_then_response(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper(content="Hello", stream=False)
+
+        chunks: list[str] = []
+        final: Response | None = None
+        async for item in wrapper.astream_chat(MessageHistory([UserMessage("hi")])):
+            if isinstance(item, Response):
+                final = item
+            else:
+                chunks.append(item)
+
+        assert "".join(chunks) == "Hello"
+        assert final is not None
+        assert isinstance(final.message, AssistantMessage)
+        assert final.message.content == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_astream_structured_final_is_parsed(self, mock_litellm_wrapper):
+        class ExampleSchema(BaseModel):
+            field: str
+
+        wrapper = mock_litellm_wrapper(content='{"field": "VAL"}', stream=False)
+
+        final: Response | None = None
+        async for item in wrapper.astream_structured(
+            MessageHistory([UserMessage("hi")]), schema=ExampleSchema
+        ):
+            if isinstance(item, Response):
+                final = item
+
+        assert final is not None
+        assert isinstance(final.message.content, ExampleSchema)
+        assert final.message.content.field == "VAL"
+
+    @pytest.mark.asyncio
+    async def test_astream_chat_early_break_is_clean(self, mock_litellm_wrapper):
+        """Breaking out early must not raise or hang (the worker is signalled to stop and the
+        underlying stream is closed on its own thread)."""
+        wrapper = mock_litellm_wrapper(content="abcdef", stream=False)
+
+        got = None
+        async for item in wrapper.astream_chat(MessageHistory([UserMessage("hi")])):
+            if isinstance(item, str):
+                got = item
+                break
+
+        assert got is not None
+
+    @pytest.mark.asyncio
+    async def test_astream_chat_propagates_errors(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper(content="Hello", stream=False)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("stream open failed")
+
+        with patch.object(wrapper, "_invoke", side_effect=_boom):
+            with pytest.raises(RuntimeError, match="stream open failed"):
+                async for _ in wrapper.astream_chat(MessageHistory([UserMessage("hi")])):
+                    pass
+
+
+# ================= END async streaming (sync bridge) tests =========================
 
 
 def test_temperature_passed_to_litellm_completion(message_history):
@@ -353,18 +427,19 @@ def test_temperature_passed_to_litellm_completion(message_history):
 
 
 @pytest.mark.asyncio
-async def test_temperature_passed_to_litellm_acompletion(message_history):
-    """Assert that when a LiteLLMWrapper is created with temperature, it is passed to litellm.acompletion."""
-    with patch.object(litellm, "acompletion") as mock_acompletion:
-        mock_acompletion.return_value = litellm.utils.ModelResponse(
+async def test_temperature_passed_through_async_chat(message_history):
+    """The async surface (`achat`) runs the sync `litellm.completion` on a worker thread, so
+    temperature must still reach litellm."""
+    with patch.object(litellm, "completion") as mock_completion:
+        mock_completion.return_value = litellm.utils.ModelResponse(
             choices=[{"message": {"content": "ok"}}]
         )
         wrapper = _ConcreteLiteLLMWrapperForTest(
             model_name="test-model", stream=False, temperature=0.7
         )
         await wrapper.achat(message_history)
-        mock_acompletion.assert_called_once()
-        assert mock_acompletion.call_args.kwargs.get("temperature") == 0.7
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs.get("temperature") == 0.7
 
 
 # ================= END completion methods tests =========================

--- a/packages/railtracks/tests/unit_tests/llm/test_retry_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/test_retry_wrapper.py
@@ -1,10 +1,9 @@
 """Tests for retry_approach wiring inside LiteLLMWrapper via real provider classes."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import litellm
 import pytest
 from litellm.utils import ModelResponse
-
 from railtracks.llm._exceptions import RetryError
 from railtracks.llm.models.api_providers import AnthropicLLM, OpenAILLM
 from railtracks.llm.retries import ExponentialRetry, FixedRetry
@@ -105,7 +104,10 @@ class TestSyncRetryInWrapper:
 
 
 # ---------------------------------------------------------------------------
-# Async _ainvoke retry tests — OpenAILLM
+# Async surface retry tests — OpenAILLM
+#
+# `achat` runs the synchronous `litellm.completion` (with the sync retry loop) on a worker
+# thread, so retries are driven by `completion` + `time.sleep`, not the async path.
 # ---------------------------------------------------------------------------
 
 class TestAsyncRetryInWrapper:
@@ -113,7 +115,7 @@ class TestAsyncRetryInWrapper:
     async def test_retries_on_rate_limit_error(self, message_history):
         call_count = {"n": 0}
 
-        async def _side_effect(*args, **kwargs):
+        def _side_effect(*args, **kwargs):
             call_count["n"] += 1
             if call_count["n"] < 3:
                 raise litellm.exceptions.RateLimitError(
@@ -125,8 +127,8 @@ class TestAsyncRetryInWrapper:
             "gpt-4o-mini",
             retry_approach=FixedRetry(max_tries=5, delay=0.0),
         )
-        with patch.object(litellm, "acompletion", side_effect=_side_effect):
-            with patch("railtracks.llm.retries.base.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(litellm, "completion", side_effect=_side_effect):
+            with patch("railtracks.llm.retries.base.time.sleep"):
                 response = await llm.achat(message_history)
 
         assert call_count["n"] == 3
@@ -134,7 +136,7 @@ class TestAsyncRetryInWrapper:
 
     @pytest.mark.asyncio
     async def test_raises_retry_error_after_max_tries(self, message_history):
-        async def _always_fails(*args, **kwargs):
+        def _always_fails(*args, **kwargs):
             raise litellm.exceptions.RateLimitError(
                 message="rate limited", llm_provider="openai", model="gpt-4o-mini"
             )
@@ -143,8 +145,8 @@ class TestAsyncRetryInWrapper:
             "gpt-4o-mini",
             retry_approach=FixedRetry(max_tries=3, delay=0.0),
         )
-        with patch.object(litellm, "acompletion", side_effect=_always_fails):
-            with patch("railtracks.llm.retries.base.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(litellm, "completion", side_effect=_always_fails):
+            with patch("railtracks.llm.retries.base.time.sleep"):
                 with pytest.raises(RetryError):
                     await llm.achat(message_history)
 
@@ -152,7 +154,7 @@ class TestAsyncRetryInWrapper:
     async def test_non_retryable_error_propagates_without_retry(self, message_history):
         call_count = {"n": 0}
 
-        async def _bad_request(*args, **kwargs):
+        def _bad_request(*args, **kwargs):
             call_count["n"] += 1
             raise litellm.exceptions.BadRequestError(
                 message="bad", model="gpt-4o-mini", llm_provider="openai"
@@ -162,8 +164,8 @@ class TestAsyncRetryInWrapper:
             "gpt-4o-mini",
             retry_approach=FixedRetry(max_tries=5, delay=0.0),
         )
-        with patch.object(litellm, "acompletion", side_effect=_bad_request):
-            with patch("railtracks.llm.retries.base.asyncio.sleep", new_callable=AsyncMock):
+        with patch.object(litellm, "completion", side_effect=_bad_request):
+            with patch("railtracks.llm.retries.base.time.sleep"):
                 with pytest.raises(litellm.exceptions.BadRequestError):
                     await llm.achat(message_history)
 

--- a/packages/railtracks/tests/unit_tests/pubsub/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/pubsub/test_publisher.py
@@ -6,7 +6,7 @@ from railtracks.pubsub.messages import RequestCompletionMessage
 
 @pytest.mark.asyncio
 async def test_rcpublisher_logging_sub(dummy_publisher):
-    # Should have one default broadcast_callback (logging_sub)
+    # Should have one default subscriber (logging_sub)
     assert len(dummy_publisher._subscribers) >= 1
     msg = RequestCompletionMessage()
     dummy_publisher._running = True

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -86,23 +86,23 @@ def test_session_name_is_taken_from_executor_config():
 
 def test_setup_subscriber_adds_subscriber_if_present():
     sub_subscriber = Mock()
-    runner = Session(stream_callback=sub_subscriber)
+    runner = Session(broadcast_callback=sub_subscriber)
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_chunk_subscriber', return_value="fake_stream_sub") as m_stream:
+    with patch('railtracks._session.BroadcastCallbackSubscriber', return_value="fake_sub") as m_sub:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_called_once_with(
-            "fake_stream_sub", name="Stream Callback Subscriber"
+            "fake_sub", name="Broadcast Callback Subscriber"
         )
-        m_stream.assert_called_once_with(sub_subscriber)
+        m_sub.assert_called_once_with(sub_subscriber)
 
 def test_setup_subscriber_noop_if_no_subscriber(mock_dependencies):
     runner = Session()
-    runner.executor_config.stream_subscriber = None
+    runner.executor_config.broadcast_callback = None
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_chunk_subscriber') as m_stream:
+    with patch('railtracks._session.BroadcastCallbackSubscriber') as m_sub:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_not_called()
-        m_stream.assert_not_called()
+        m_sub.assert_not_called()
 
 # ================ END Session: setup_subscriber ===============
 

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -86,20 +86,20 @@ def test_session_name_is_taken_from_executor_config():
 
 def test_setup_subscriber_adds_subscriber_if_present():
     sub_subscriber = Mock()
-    runner = Session(broadcast_callback=sub_subscriber)
+    runner = Session(stream_callback=sub_subscriber)
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_subscriber', return_value="fake_stream_sub") as m_stream:
+    with patch('railtracks._session.stream_chunk_subscriber', return_value="fake_stream_sub") as m_stream:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_called_once_with(
-            "fake_stream_sub", name="Streaming Subscriber"
+            "fake_stream_sub", name="Stream Callback Subscriber"
         )
         m_stream.assert_called_once_with(sub_subscriber)
 
 def test_setup_subscriber_noop_if_no_subscriber(mock_dependencies):
     runner = Session()
-    runner.executor_config.subscriber = None
+    runner.executor_config.stream_subscriber = None
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_subscriber') as m_stream:
+    with patch('railtracks._session.stream_chunk_subscriber') as m_stream:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_not_called()
         m_stream.assert_not_called()

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -93,11 +93,27 @@ def test_setup_subscriber_adds_subscriber_if_present():
         runner.publisher.subscribe.assert_called_once_with(
             "fake_sub", name="Broadcast Callback Subscriber"
         )
-        m_sub.assert_called_once_with(sub_subscriber)
+        m_sub.assert_called_once_with(
+            sub_subscriber, kind="event", param_name="broadcast_callback"
+        )
+
+def test_setup_subscriber_adds_stream_subscriber_if_present():
+    stream_subscriber = Mock()
+    runner = Session(stream_callback=stream_subscriber)
+    runner.publisher = MagicMock()
+    with patch('railtracks._session.BroadcastCallbackSubscriber', return_value="fake_sub") as m_sub:
+        runner._setup_subscriber()
+        runner.publisher.subscribe.assert_called_once_with(
+            "fake_sub", name="Stream Callback Subscriber"
+        )
+        m_sub.assert_called_once_with(
+            stream_subscriber, kind="stream", param_name="stream_callback"
+        )
 
 def test_setup_subscriber_noop_if_no_subscriber(mock_dependencies):
     runner = Session()
     runner.executor_config.broadcast_callback = None
+    runner.executor_config.stream_callback = None
     runner.publisher = MagicMock()
     with patch('railtracks._session.BroadcastCallbackSubscriber') as m_sub:
         runner._setup_subscriber()

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -12,18 +12,22 @@ def test_instantiation_with_all_defaults():
     assert config.end_on_error is False
     assert config.prompt_injection is True
     assert config.broadcast_callback is None
+    assert config.stream_callback is None
 
 def test_instantiation_with_custom_values(tmp_path):
     test_subscriber = lambda x: x
+    test_stream_subscriber = lambda x: x
     config = ExecutorConfig(
         timeout=12.0,
         end_on_error=True,
         broadcast_callback=test_subscriber,
+        stream_callback=test_stream_subscriber,
         prompt_injection=False
     )
     assert config.timeout == 12.0
     assert config.end_on_error is True
     assert config.broadcast_callback == test_subscriber
+    assert config.stream_callback == test_stream_subscriber
     assert config.prompt_injection is False
 
 # ================ END ExecutorConfig: Instantiation tests ===============
@@ -49,6 +53,13 @@ async def test_subscriber_accepts_coroutine_function():
 def test_subscriber_is_none_by_default():
     config = ExecutorConfig()
     assert config.broadcast_callback is None
+
+def test_precedence_overwritten_carries_stream_callback():
+    stream_cb = lambda s: s
+    config = ExecutorConfig(stream_callback=stream_cb)
+    updated = config.precedence_overwritten(timeout=5.0)
+    assert updated.stream_callback is stream_cb
+    assert updated.broadcast_callback is None
 
 # ================ END ExecutorConfig: broadcast_callback handling tests ===============
 

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -11,19 +11,19 @@ def test_instantiation_with_all_defaults():
     assert config.timeout is None
     assert config.end_on_error is False
     assert config.prompt_injection is True
-    assert config.subscriber is None
+    assert config.stream_subscriber is None
 
 def test_instantiation_with_custom_values(tmp_path):
     test_subscriber = lambda x: x
     config = ExecutorConfig(
         timeout=12.0,
         end_on_error=True,
-        broadcast_callback=test_subscriber,
+        stream_callback=test_subscriber,
         prompt_injection=False
     )
     assert config.timeout == 12.0
     assert config.end_on_error is True
-    assert config.subscriber == test_subscriber
+    assert config.stream_subscriber == test_subscriber
     assert config.prompt_injection is False
 
 # ================ END ExecutorConfig: Instantiation tests ===============
@@ -31,26 +31,26 @@ def test_instantiation_with_custom_values(tmp_path):
 
 
 
-# ================= START ExecutorConfig: broadcast_callback handling tests ============
+# ================= START ExecutorConfig: stream_callback handling tests ============
 
 def test_subscriber_accepts_callable():
-    config = ExecutorConfig(broadcast_callback=lambda s: s)
-    assert callable(config.subscriber)
+    config = ExecutorConfig(stream_callback=lambda s: s)
+    assert callable(config.stream_subscriber)
 
 @pytest.mark.asyncio
 async def test_subscriber_accepts_coroutine_function():
     async def async_sub_fn(text):
         return text
-    config = ExecutorConfig(broadcast_callback=async_sub_fn)
+    config = ExecutorConfig(stream_callback=async_sub_fn)
     # (not invoked/executed here, just type accepted)
-    assert callable(config.subscriber)
-    assert isinstance(config.subscriber, types.FunctionType)
+    assert callable(config.stream_subscriber)
+    assert isinstance(config.stream_subscriber, types.FunctionType)
 
 def test_subscriber_is_none_by_default():
     config = ExecutorConfig()
-    assert config.subscriber is None
+    assert config.stream_subscriber is None
 
-# ================ END ExecutorConfig: broadcast_callback handling tests ===============
+# ================ END ExecutorConfig: stream_callback handling tests ===============
 
 
 # ================= START ExecutorConfig: prompt_injection tests ============

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -11,19 +11,19 @@ def test_instantiation_with_all_defaults():
     assert config.timeout is None
     assert config.end_on_error is False
     assert config.prompt_injection is True
-    assert config.stream_subscriber is None
+    assert config.broadcast_callback is None
 
 def test_instantiation_with_custom_values(tmp_path):
     test_subscriber = lambda x: x
     config = ExecutorConfig(
         timeout=12.0,
         end_on_error=True,
-        stream_callback=test_subscriber,
+        broadcast_callback=test_subscriber,
         prompt_injection=False
     )
     assert config.timeout == 12.0
     assert config.end_on_error is True
-    assert config.stream_subscriber == test_subscriber
+    assert config.broadcast_callback == test_subscriber
     assert config.prompt_injection is False
 
 # ================ END ExecutorConfig: Instantiation tests ===============
@@ -31,26 +31,26 @@ def test_instantiation_with_custom_values(tmp_path):
 
 
 
-# ================= START ExecutorConfig: stream_callback handling tests ============
+# ================= START ExecutorConfig: broadcast_callback handling tests ============
 
 def test_subscriber_accepts_callable():
-    config = ExecutorConfig(stream_callback=lambda s: s)
-    assert callable(config.stream_subscriber)
+    config = ExecutorConfig(broadcast_callback=lambda s: s)
+    assert callable(config.broadcast_callback)
 
 @pytest.mark.asyncio
 async def test_subscriber_accepts_coroutine_function():
     async def async_sub_fn(text):
         return text
-    config = ExecutorConfig(stream_callback=async_sub_fn)
+    config = ExecutorConfig(broadcast_callback=async_sub_fn)
     # (not invoked/executed here, just type accepted)
-    assert callable(config.stream_subscriber)
-    assert isinstance(config.stream_subscriber, types.FunctionType)
+    assert callable(config.broadcast_callback)
+    assert isinstance(config.broadcast_callback, types.FunctionType)
 
 def test_subscriber_is_none_by_default():
     config = ExecutorConfig()
-    assert config.stream_subscriber is None
+    assert config.broadcast_callback is None
 
-# ================ END ExecutorConfig: stream_callback handling tests ===============
+# ================ END ExecutorConfig: broadcast_callback handling tests ===============
 
 
 # ================= START ExecutorConfig: prompt_injection tests ============

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 from railtracks.utils.publisher import Publisher, Subscriber
 
-from railtracks.pubsub._subscriber import stream_subscriber
+from railtracks.pubsub._subscriber import stream_chunk_subscriber
 
 # ================= START Subscriber class tests ============
 
@@ -220,13 +220,13 @@ class TestSubscriberList:
 
         time.sleep(0.1)  # Give some time to process the message
 
-        assert _message is None, "Unsubscribed broadcast_callback should not receive messages."
+        assert _message is None, "Unsubscribed subscriber should not receive messages."
 
 
     @pytest.mark.asyncio
     async def test_bad_unsubscribe(self, started_publisher):
         with pytest.raises(KeyError):
-            # Attempting to unsubscribe a non-existent broadcast_callback should raise KeyError
+            # Attempting to unsubscribe a non-existent callback should raise KeyError
             started_publisher.unsubscribe("nonexistent_id")
 
 
@@ -379,14 +379,14 @@ class TestPublisherException:
         await asyncio.sleep(0.1)
         assert (
             _message == "another message"
-        ), "Callback should still receive messages even if one broadcast_callback throws an exception"
+        ), "Callback should still receive messages even if one subscriber throws an exception"
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_callback_exception(self, streaming_message):
+    async def test_stream_chunk_subscriber_callback_exception(self, streaming_message):
         def bad(val):
             raise Exception("fail!")  # coverage for error handling
 
-        handler = stream_subscriber(bad)
+        handler = stream_chunk_subscriber(bad)
         with pytest.raises(Exception):
             await handler(streaming_message)
 # ================ END Publisher exception tests ===============
@@ -499,10 +499,10 @@ class TestPublisherSanity:
 
 # ================ END Publisher advanced tests ===============
 
-# ================= START Subscriber (stream_subscriber) tests ============
+# ================= START Subscriber (stream_chunk_subscriber) tests ============
 class TestSubscriberStream:
     @pytest.mark.asyncio
-    async def test_stream_subscriber_handles_streaming_true(
+    async def test_stream_chunk_subscriber_handles_streaming_true(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -510,13 +510,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = stream_chunk_subscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_skips_non_streaming(self):
+    async def test_stream_chunk_subscriber_skips_non_streaming(self):
         class DummyMsg:
             pass
 
@@ -525,13 +525,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = stream_chunk_subscriber(cb)
         await handler(DummyMsg())
         assert results == []
 
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_supports_async_callbacks(
+    async def test_stream_chunk_subscriber_supports_async_callbacks(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -539,11 +539,11 @@ class TestSubscriberStream:
         async def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = stream_chunk_subscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
-# ================ END Subscriber (stream_subscriber) tests ===============
+# ================ END Subscriber (stream_chunk_subscriber) tests ===============
 
 # ================= START Miscellaneous corner cases ============
 class TestMisc:

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -543,6 +543,25 @@ class TestSubscriberStream:
         await handler(streaming_message)
         assert results == [streamed_object]
 
+    @pytest.mark.asyncio
+    async def test_broadcast_callback_subscriber_filters_by_kind(self):
+        """An event-lane subscriber ignores stream chunks, and vice versa."""
+        from railtracks.pubsub.messages import Streaming
+
+        event_msg = Streaming(streamed_object="ev", node_id="1", kind="event")
+        chunk_msg = Streaming(streamed_object="ch", node_id="1", kind="stream")
+
+        events, chunks = [], []
+        event_handler = BroadcastCallbackSubscriber(events.append, kind="event")
+        stream_handler = BroadcastCallbackSubscriber(chunks.append, kind="stream")
+
+        for msg in (event_msg, chunk_msg):
+            await event_handler(msg)
+            await stream_handler(msg)
+
+        assert events == ["ev"]
+        assert chunks == ["ch"]
+
 # ================ END Subscriber (BroadcastCallbackSubscriber) tests ===============
 
 # ================= START Miscellaneous corner cases ============

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 from railtracks.utils.publisher import Publisher, Subscriber
 
-from railtracks.pubsub._subscriber import stream_chunk_subscriber
+from railtracks.pubsub._subscriber import BroadcastCallbackSubscriber
 
 # ================= START Subscriber class tests ============
 
@@ -382,11 +382,11 @@ class TestPublisherException:
         ), "Callback should still receive messages even if one subscriber throws an exception"
 
     @pytest.mark.asyncio
-    async def test_stream_chunk_subscriber_callback_exception(self, streaming_message):
+    async def test_broadcast_callback_subscriber_callback_exception(self, streaming_message):
         def bad(val):
             raise Exception("fail!")  # coverage for error handling
 
-        handler = stream_chunk_subscriber(bad)
+        handler = BroadcastCallbackSubscriber(bad)
         with pytest.raises(Exception):
             await handler(streaming_message)
 # ================ END Publisher exception tests ===============
@@ -499,10 +499,10 @@ class TestPublisherSanity:
 
 # ================ END Publisher advanced tests ===============
 
-# ================= START Subscriber (stream_chunk_subscriber) tests ============
+# ================= START Subscriber (BroadcastCallbackSubscriber) tests ============
 class TestSubscriberStream:
     @pytest.mark.asyncio
-    async def test_stream_chunk_subscriber_handles_streaming_true(
+    async def test_broadcast_callback_subscriber_handles_streaming_true(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -510,13 +510,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_chunk_subscriber(cb)
+        handler = BroadcastCallbackSubscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
 
     @pytest.mark.asyncio
-    async def test_stream_chunk_subscriber_skips_non_streaming(self):
+    async def test_broadcast_callback_subscriber_skips_non_streaming(self):
         class DummyMsg:
             pass
 
@@ -525,13 +525,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_chunk_subscriber(cb)
+        handler = BroadcastCallbackSubscriber(cb)
         await handler(DummyMsg())
         assert results == []
 
 
     @pytest.mark.asyncio
-    async def test_stream_chunk_subscriber_supports_async_callbacks(
+    async def test_broadcast_callback_subscriber_supports_async_callbacks(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -539,11 +539,11 @@ class TestSubscriberStream:
         async def cb(val):
             results.append(val)
 
-        handler = stream_chunk_subscriber(cb)
+        handler = BroadcastCallbackSubscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
-# ================ END Subscriber (stream_chunk_subscriber) tests ===============
+# ================ END Subscriber (BroadcastCallbackSubscriber) tests ===============
 
 # ================= START Miscellaneous corner cases ============
 class TestMisc:


### PR DESCRIPTION
Work item: #1206

## Summary

Second of two stacked PRs for the call-scoped streaming work (#1206). This PR adds the **framework-level streaming feature** on top of the model primitives in #1257.

> **Base branch:** this PR targets `1206/v4_streaming-model-api` (PR #1257) so its diff shows only the framework layer. **Merge #1257 first**; GitHub will then auto-retarget this PR to `feature-branch-node-add-on`.

Streaming is redesigned from **model-scoped** (a `stream=True` flag baked into the model, forking every node into a `Streaming*` class variant returning raw generators) to **call-scoped**: the same agent object serves streaming and non-streaming runs, and the caller decides per invocation.

```python
result = await rt.call(agent, user_input="...")   # buffered — no streaming cost
stream = rt.astream(agent, user_input="...")       # streamed — tokens as they arrive
async for chunk in stream:
    print(chunk, end="")
final = stream.result                              # the complete, gated response
```

Everything rides the session's existing pubsub bus: producers broadcast chunks on named **channels**; consumers subscribe via `rt.astream` (pull), `stream_callback` (push), or `rt.context.get_stream` (pull, from inside a run). No generators are threaded through node results.

## What's included

**Public API (added)**
- `rt.astream(node, ...) -> Stream` — pull-mode streamed invocation; `Stream` iterates `str` chunks, exposes `.result`, `await stream` drains, `.on_channel(name)` filters. `Flow.astream(...)` variant owns its session.
- `stream_callback=` (Flow / `rt.set_config`) — push mode: single callable = firehose; `dict[str, Callable]` = per-channel routing. Presence enables top-level token streaming.
- `rt.broadcast(item, channel=...)` / `rt.broadcast_stream(gen, channel=...)` — put items/model-stream chunks on a named bus; `broadcast_stream` returns the final `Response` and emits a `StreamEnd` marker.
- `rt.context.get_stream(channel, *, streams=1, until=None)` — consume a channel from **inside** a run (fold a concurrent child's tokens); terminates by counting `StreamEnd` markers.
- `agent_node(..., stream_channel="writer")` — bind a prebuilt agent's tokens to a named bus at construction.

**Removed / deprecated**
- `Streaming{Terminal,ToolCall,Structured,OutputLessToolCall}LLM` + `GuardedStreaming*` — **removed**; one node class serves both modes.
- Generator-typed node results — **removed**; results are always complete `Response`s (chunks arrive via the bus).
- `broadcast_callback` (Session/Flow/`set_config`) — **merged into `stream_callback`**; `pubsub.stream_subscriber` → `stream_chunk_subscriber`.
- Tool-calling streaming blacklist moved from node construction to call time with graceful buffered fallback.

**Internals**
- `pubsub/messages.py` — `Streaming` gains `channel` + `stream_id`; `RequestCreation` gains `stream`; new `StreamEnd`.
- `context/*` — `InternalContext.stream_enabled` (frame-local) + `stream_id` (inherited); `set_config(stream_callback=...)`; fix: `set_local_config` wrote to the wrong object.
- `execution/task.py` / `state/state.py` — `Task.stream`; entry frames stamp `stream_id = request_id`.
- `built_nodes/llm/model_invoker.py` — streaming branch (chunks out via bus, complete `Response` back through middleware).
- `built_nodes/concrete/*` — legacy classes de-forked to stream via shared `_LLMBase` helpers.
- `utils/publisher.py` — handle absent publishers in `get_publisher`/`shutdown_publisher`.

## Testing

- Unit + integration tests updated (pubsub messages, config, publisher, session, broadcast, exterior call, guardrails, library LLMs).
- Live streaming tests added (`rt.astream` pull + tool-calling) — require real provider keys to run.
- Streaming/broadcast docs rewritten for the call-scoped model.

## Notes

- Design rationale (rejected alternatives, termination design, callback merge) lives in `pr.md` on the branch.
- This branch's history was rebuilt to stack cleanly on #1257; `docs/scripts/*.py` formatter-only noise from the original branch was dropped.
