### PR TITLE
debug/output-rail-roundtrip

### DIFF
--- a/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
@@ -114,11 +114,22 @@ class InputGuard(BaseLLMGuardrail[MessageHistory]):
         return event.model_copy(update={"messages": value})
 
 
+def _is_intermediate_tool_call(response: Response) -> bool:
+    """A model round-trip is *intermediate* (not the final reply) when it requests tools.
+
+    Mirrors ``process_message`` in ``llm_helpers`` (tool calls present => "Tool").
+    """
+    return len(response.message.tool_calls) > 0
+
+
 class OutputGuard(BaseLLMGuardrail[Message]):
     """Base for guardrails that run on LLM output (e.g. model response).
 
     Inspect ``event.output_message`` for the assistant message produced this turn.
     ``event.messages`` is conversation context and may not yet include that reply.
+
+    Intermediate tool-call turns pass through untouched, so output rails fire only
+    on the final reply.
 
     Attributes:
         phase: Always :attr:`LLMGuardrailPhase.OUTPUT`.
@@ -136,8 +147,14 @@ class OutputGuard(BaseLLMGuardrail[Message]):
         schema: type[BaseModel] | None,
         tools: list[Tool] | None,
     ):
-        """Call onward for the response, then run this guard on the resulting message."""
+        """Call onward for the response, then run this guard on the final reply.
+
+        Responses that request tools are intermediate steps of the tool-calling
+        loop and pass through unguarded.
+        """
         result = await call(message_history, schema, tools)
+        if _is_intermediate_tool_call(result):
+            return result
         return self._output_wrapper(result=result)
 
     def _output_wrapper(

--- a/packages/railtracks/tests/integration_tests/guardrails/conftest.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails import GuardrailDecision, InputGuard, LLMGuardrailEvent
 
 

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-
 from railtracks.built_nodes.llm.response import StringResponse
 from railtracks.guardrails import GuardrailBlockedError
 from railtracks.guardrails.llm import BlockTextInputGuard, BlockTextOutputGuard

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import pytest
 import railtracks as rt
 from pydantic import BaseModel, Field
-
 from railtracks.built_nodes.llm.response import StringResponse, StructuredResponse
-from railtracks.guardrails import GuardrailBlockedError, GuardrailDecision, InputGuard, LLMGuardrailEvent, OutputGuard
+from railtracks.guardrails import (
+    GuardrailBlockedError,
+    GuardrailDecision,
+    InputGuard,
+    LLMGuardrailEvent,
+    OutputGuard,
+)
 from railtracks.llm import AssistantMessage
 
 
@@ -347,11 +352,10 @@ async def test_tool_call_output_transform_updates_response_and_history(mock_llm,
 
 
 @pytest.mark.asyncio
-async def test_tool_call_output_guard_fires_per_model_round_trip(mock_llm, allow_input):
-    """OutputGuard is plain model_middleware: it wraps every raw model call inside the
-    tool-calling loop (once for the tool-call turn, once for the final reply), not just
-    the final reply. The old Guarded*LLM hierarchy special-cased "final reply only"; that
-    guarantee no longer holds now that guards are ordinary model_middleware entries.
+async def test_tool_call_output_guard_fires_only_on_final_reply(mock_llm, allow_input):
+    """OutputGuard wraps every raw model call inside the tool-calling loop, but
+    intermediate tool-call turns pass through unguarded — output rails fire only on
+    the final replys.
     """
     @rt.function_node
     async def weather_tool(city: str) -> str:
@@ -381,7 +385,7 @@ async def test_tool_call_output_guard_fires_per_model_round_trip(mock_llm, allow
     with rt.Session():
         await rt.call(Agent, user_input="weather?")
 
-    assert fire_count["n"] == 2
+    assert fire_count["n"] == 1
 
 
 # ============================================================

--- a/packages/railtracks/tests/integration_tests/guardrails/test_flow_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_flow_guardrails.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-from railtracks.orchestration.flow import Flow
-
 from railtracks.guardrails import GuardrailDecision, InputGuard, LLMGuardrailEvent
+from railtracks.orchestration.flow import Flow
 
 
 class FnInputGuard(InputGuard):

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-
 from railtracks.built_nodes.llm.response import StringResponse
-from railtracks.guardrails.core import GuardrailBlockedError, GuardrailDecision, InputGuard, LLMGuardrailEvent, OutputGuard
+from railtracks.guardrails.core import (
+    GuardrailBlockedError,
+    GuardrailDecision,
+    InputGuard,
+    LLMGuardrailEvent,
+    OutputGuard,
+)
 
 
 class RaisingInputGuard(InputGuard):

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-
 from railtracks.built_nodes.llm.middleware import before_llm
-from railtracks.guardrails.core import GuardrailBlockedError, GuardrailDecision, InputGuard, LLMGuardrailEvent, OutputGuard
+from railtracks.guardrails.core import (
+    GuardrailBlockedError,
+    GuardrailDecision,
+    InputGuard,
+    LLMGuardrailEvent,
+    OutputGuard,
+)
 from railtracks.llm import UserMessage
 
 

--- a/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
@@ -567,11 +567,10 @@ class TestGuardrailsEndToEnd:
         with pytest.raises(GuardrailBlockedError):
             await rt.Flow("GuardedOutputAgent", agent).ainvoke("hi")
 
-    async def test_output_guard_fires_per_model_round_trip(self, mock_llm):
-        """OutputGuard is plain model_middleware: it wraps every raw model call inside
-        the tool-calling loop, so it fires on the intermediate tool-call turn too, not
-        only on the final content reply. (The old Guarded*LLM hierarchy special-cased
-        "final reply only"; that guarantee no longer holds under this architecture.)"""
+    async def test_output_guard_fires_only_on_final_reply(self, mock_llm):
+        """OutputGuard is plain model_middleware and wraps every raw model call inside
+        the tool-calling loop, but intermediate tool-call turns pass through unguarded —
+        output rails fire only on the final content reply."""
         fired = {"n": 0}
 
         class CountingAllowOutput(OutputGuard):
@@ -602,8 +601,8 @@ class TestGuardrailsEndToEnd:
 
         result = await rt.Flow("GuardedToolAgent", agent).ainvoke("increment 1")
 
-        # Fires once for the intermediate tool-call turn and once for the final reply.
-        assert fired["n"] == 2
+        # The intermediate tool-call turn is skipped; only the final reply is guarded.
+        assert fired["n"] == 1
         assert "2" in result.content
 
     async def test_guardrail_block_is_not_wrapped_as_llmerror(self, mock_llm):

--- a/packages/railtracks/tests/unit_tests/guardrails/conftest.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.llm import MessageHistory, UserMessage
 
 

--- a/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
@@ -5,8 +5,6 @@ exercised only indirectly through the now-deleted GuardRunner.
 
 from __future__ import annotations
 
-import pytest
-
 from railtracks.guardrails.core import (
     GuardrailAction,
     GuardrailDecision,

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_input_guard.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import re
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm import BlockTextInputGuard
 from railtracks.llm import MessageHistory
-from railtracks.llm.message import AssistantMessage, Role, SystemMessage, UserMessage
+from railtracks.llm.message import AssistantMessage, SystemMessage, UserMessage
 
 
 def _make_input_event(messages: MessageHistory) -> LLMGuardrailEvent:

--- a/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_block_text_output_guard.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm import BlockTextOutputGuard

--- a/packages/railtracks/tests/unit_tests/guardrails/test_decide.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_decide.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm import (

--- a/packages/railtracks/tests/unit_tests/guardrails/test_event.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_event.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core import LLMGuardrailEvent, LLMGuardrailPhase
 
 

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
@@ -7,7 +7,6 @@ through full agent_node integration tests; here each guard is wired directly via
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core import (
     GuardrailBlockedError,
     GuardrailDecision,
@@ -15,7 +14,7 @@ from railtracks.guardrails.core import (
     LLMGuardrailEvent,
     OutputGuard,
 )
-from railtracks.llm import AssistantMessage, MessageHistory, UserMessage
+from railtracks.llm import AssistantMessage, MessageHistory, ToolCall, UserMessage
 from railtracks.llm.response import MessageInfo, Response
 
 
@@ -155,3 +154,28 @@ async def test_output_guard_block_raises_after_call_was_made():
         await guard.wrap(fake_call)(MessageHistory([UserMessage("q")]), None, None)
 
     assert call_count["n"] == 1  # unlike InputGuard, the model call already happened
+
+
+@pytest.mark.asyncio
+async def test_output_guard_skips_intermediate_tool_call_turns():
+    tool_call_response = Response(
+        message=AssistantMessage(
+            [ToolCall(name="search", identifier="tc_1", arguments={})]
+        ),
+        message_info=MessageInfo(model_name="m"),
+    )
+
+    async def fake_call(message_history, schema, tools):
+        return tool_call_response
+
+    guard_fired = {"n": 0}
+
+    def _guard(_e):
+        guard_fired["n"] += 1
+        return GuardrailDecision.block(reason="would break the tool loop")
+
+    guard = FnOutputGuard(_guard)
+    result = await guard.wrap(fake_call)(MessageHistory([UserMessage("q")]), None, None)
+
+    assert guard_fired["n"] == 0  # tool-requesting turns are intermediate: never guarded
+    assert result is tool_call_response  # passed through untouched, tool calls intact

--- a/packages/railtracks/tests/unit_tests/guardrails/test_length_guards.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_length_guards.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm.input import InputLengthGuard
 from railtracks.guardrails.llm.output import OutputLengthGuard
 from railtracks.llm import MessageHistory, UserMessage
 from railtracks.llm.message import AssistantMessage
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_engine.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.llm._pii.config import (
     PIICustomPattern,
     PIIEntity,

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_input_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_input_guard.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm import (
@@ -15,7 +14,6 @@ from railtracks.guardrails.llm import (
 from railtracks.llm import MessageHistory
 from railtracks.llm.message import (
     AssistantMessage,
-    Role,
     SystemMessage,
     UserMessage,
 )

--- a/packages/railtracks/tests/unit_tests/guardrails/test_pii_output_guard.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_pii_output_guard.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from railtracks.guardrails.core.decision import GuardrailAction
 from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
 from railtracks.guardrails.llm import PIIRedactOutputGuard


### PR DESCRIPTION
## Summary

Restores a guardrail behavior lost in the `GuardRunner` → per-guard middleware migration (#1255): output guards must skip intermediate tool-call turns and fire only on the final reply. The old `guardrail_output_middleware` gate checked `_is_intermediate_tool_call` before running output rails; the new `OutputGuard._middleware_fn` ran on every model round-trip inside the tool-calling loop. This reinstates the check in `OutputGuard`: responses that request tools now pass through unguarded, exactly as before #1255.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

**Why the old behavior matters** — without the skip, two failure modes appear in tool-calling agents:

1. Text-oriented output guards (`BlockTextOutputGuard`, `PIIRedactOutputGuard`, …) evaluate intermediate tool-call messages whose `content` is a tool-call list rather than text — they can misfire or raise, and with the default `fail_open=False` a raised exception kills the whole request mid-loop.
2. A `TRANSFORM` rebuilds the `Response` wholesale from `decision.output_message`, which doesn't carry the original `tool_calls` — so a transforming guard on a tool-call turn silently amputates the tool calls, `process_message` reclassifies the turn as `"Content"`, and the agent terminates early with an internal step's text as its final answer.

**Changes**:
- `guardrails/llm/concrete.py`: added `_is_intermediate_tool_call` (same implementation as the deleted `guardrail_gates.py` helper, mirroring `process_message`) and an early return in `OutputGuard._middleware_fn`; class and method docstrings now state the guarantee.
- Two existing tests had codified the regression as intended behavior (asserting output guards fire twice per tool loop): `test_agent_node_guardrails.py` and `TestGuardrailsEndToEnd` in `test_middleware_integration.py`. Both renamed to `..._fires_only_on_final_reply` and now assert a single firing.
- New unit regression test `test_output_guard_skips_intermediate_tool_call_turns` in `test_guard_middleware_wiring.py`: a blocking guard never evaluates a tool-requesting response, and the response passes through by identity with tool calls intact.
- Remaining test-file churn is import-sort autofixes from `ruff check` (project config runs with fix enabled).