### PR TITLE
1271 decorators for guardrail

### DIFF
--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -46,6 +46,8 @@ __all__ = [
     "before_llm",
     "after_llm",
     "wrap_llm",
+    "input_guard",
+    "output_guard",
 ]
 
 
@@ -68,6 +70,7 @@ from . import (
 from ._session import ExecutionInfo, Session, session
 from .built_nodes.llm.middleware import after_llm, before_llm, wrap_llm
 from .context.central import session_id, set_config
+from .guardrails import input_guard, output_guard
 from .interaction import broadcast, call, call_batch, couple
 from .middleware import after_node, wrap_node
 from .nodes.manifest import ToolManifest

--- a/packages/railtracks/src/railtracks/guardrails/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/__init__.py
@@ -9,6 +9,7 @@ from .core import (
     LLMGuardrailPhase,
     OutputGuard,
 )
+from .llm.decorators import input_guard, output_guard
 
 # Primitives only.
 __all__ = [
@@ -20,5 +21,7 @@ __all__ = [
     "OutputGuard",
     "LLMGuardrailEvent",
     "LLMGuardrailPhase",
+    "input_guard",
+    "output_guard",
     "llm",
 ]

--- a/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
@@ -7,15 +7,17 @@ that maps an event to a :class:`GuardrailDecision` and get back a ready-to-use
 Example::
 
     @rt.input_guard
-    def block_secrets(event: rt.guardrails.LLMGuardrailEvent) -> rt.guardrails.GuardrailDecision:
+    def block_secrets(
+        event: rt.guardrails.LLMGuardrailEvent,
+    ) -> rt.guardrails.GuardrailDecision:
         for msg in event.messages:
             if isinstance(msg.content, str) and "SECRET" in msg.content:
                 return rt.guardrails.GuardrailDecision.block(reason="secret leaked")
         return rt.guardrails.GuardrailDecision.allow()
 
+
     @rt.output_guard(fail_open=True)
-    def no_profanity(event) -> rt.guardrails.GuardrailDecision:
-        ...
+    def no_profanity(event) -> rt.guardrails.GuardrailDecision: ...
 
 The decorated guard is callable both with an :class:`LLMGuardrailEvent` (how the
 guard's middleware invokes it) and with a raw ``str`` / :class:`~railtracks.llm.message.Message`
@@ -91,6 +93,7 @@ def input_guard(
         @rt.input_guard
         def guard(event): ...
 
+
         @rt.input_guard(name="my_rail", fail_open=True)
         def guard(event): ...
 
@@ -135,6 +138,7 @@ def output_guard(
 
         @rt.output_guard
         def guard(event): ...
+
 
         @rt.output_guard(name="my_rail", fail_open=True)
         def guard(event): ...

--- a/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
@@ -1,0 +1,157 @@
+"""Decorators for authoring guardrails from a plain function.
+
+Mirror the ``@before_llm`` / ``@after_llm`` middleware decorators: wrap a function
+that maps an event to a :class:`GuardrailDecision` and get back a ready-to-use
+:class:`InputGuard` / :class:`OutputGuard` instance.
+
+Example::
+
+    @rt.input_guard
+    def block_secrets(event: rt.guardrails.LLMGuardrailEvent) -> rt.guardrails.GuardrailDecision:
+        for msg in event.messages:
+            if isinstance(msg.content, str) and "SECRET" in msg.content:
+                return rt.guardrails.GuardrailDecision.block(reason="secret leaked")
+        return rt.guardrails.GuardrailDecision.allow()
+
+    @rt.output_guard(fail_open=True)
+    def no_profanity(event) -> rt.guardrails.GuardrailDecision:
+        ...
+
+The decorated guard is callable both with an :class:`LLMGuardrailEvent` (how the
+guard's middleware invokes it) and with a raw ``str`` / :class:`~railtracks.llm.message.Message`
+/ :class:`~railtracks.llm.history.MessageHistory`, which is coerced to the correct
+event for the phase via :meth:`convert` before the function sees it.
+
+The wrapped function must be synchronous: a guard's ``__call__`` is invoked
+synchronously while its middleware evaluates the rail (``_eval_one_rail``), so an
+``async def`` would return an un-awaited coroutine.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, TypeVar, cast, overload
+
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent
+from railtracks.guardrails.llm.concrete import InputGuard, OutputGuard
+from railtracks.guardrails.llm.llm_guard import BaseLLMGuardrail
+
+_GuardFn = Callable[[LLMGuardrailEvent], GuardrailDecision]
+_GuardT = TypeVar("_GuardT", bound=BaseLLMGuardrail)
+
+
+def _make_guard(
+    base: type[_GuardT],
+    fn: _GuardFn,
+    *,
+    name: str | None,
+    fail_open: bool,
+) -> _GuardT:
+    """Build an ``InputGuard``/``OutputGuard`` instance that delegates to ``fn``.
+
+    The generated guard coerces any non-event input to an event via the base's
+    phase-aware :meth:`convert`, so ``fn`` always receives an
+    :class:`LLMGuardrailEvent`.
+    """
+    guard_name = name or fn.__name__
+
+    class _FunctionGuard(base):  # type: ignore[valid-type, misc]
+        def __call__(self, event) -> GuardrailDecision:
+            if not isinstance(event, LLMGuardrailEvent):
+                event = self.convert(event)
+            return fn(event)
+
+    _FunctionGuard.__name__ = f"{base.__name__}[{guard_name}]"
+    _FunctionGuard.__qualname__ = _FunctionGuard.__name__
+    _FunctionGuard.__doc__ = fn.__doc__
+
+    guard_cls = cast("type[_GuardT]", _FunctionGuard)
+    return guard_cls(name=guard_name, fail_open=fail_open)
+
+
+@overload
+def input_guard(fn: _GuardFn, /) -> InputGuard: ...
+@overload
+def input_guard(
+    *, name: str | None = ..., fail_open: bool = ...
+) -> Callable[[_GuardFn], InputGuard]: ...
+def input_guard(
+    fn: _GuardFn | None = None,
+    *,
+    name: str | None = None,
+    fail_open: bool = False,
+):
+    """Turn a function into an :class:`InputGuard` instance.
+
+    The function receives an :class:`LLMGuardrailEvent` (INPUT phase; inspect
+    ``event.messages``) and returns a :class:`GuardrailDecision`.
+
+    Usable bare or parameterized::
+
+        @rt.input_guard
+        def guard(event): ...
+
+        @rt.input_guard(name="my_rail", fail_open=True)
+        def guard(event): ...
+
+    Args:
+        fn: The guard function (supplied automatically in the bare form).
+        name: Rail name for traces; defaults to the function name.
+        fail_open: Allow the request through if the guard raises unexpectedly.
+
+    Returns:
+        An :class:`InputGuard` instance in the bare form, or a decorator in the
+        parameterized form.
+    """
+
+    def decorate(func: _GuardFn, /) -> InputGuard:
+        return _make_guard(InputGuard, func, name=name, fail_open=fail_open)
+
+    if fn is not None:
+        return decorate(fn)
+    return decorate
+
+
+@overload
+def output_guard(fn: _GuardFn, /) -> OutputGuard: ...
+@overload
+def output_guard(
+    *, name: str | None = ..., fail_open: bool = ...
+) -> Callable[[_GuardFn], OutputGuard]: ...
+def output_guard(
+    fn: _GuardFn | None = None,
+    *,
+    name: str | None = None,
+    fail_open: bool = False,
+):
+    """Turn a function into an :class:`OutputGuard` instance.
+
+    The function receives an :class:`LLMGuardrailEvent` (OUTPUT phase; inspect
+    ``event.output_message``) and returns a :class:`GuardrailDecision`.
+    Intermediate tool-call turns are skipped by :class:`OutputGuard`, so the
+    function fires only on the final reply.
+
+    Usable bare or parameterized::
+
+        @rt.output_guard
+        def guard(event): ...
+
+        @rt.output_guard(name="my_rail", fail_open=True)
+        def guard(event): ...
+
+    Args:
+        fn: The guard function (supplied automatically in the bare form).
+        name: Rail name for traces; defaults to the function name.
+        fail_open: Allow the response through if the guard raises unexpectedly.
+
+    Returns:
+        An :class:`OutputGuard` instance in the bare form, or a decorator in the
+        parameterized form.
+    """
+
+    def decorate(func: _GuardFn, /) -> OutputGuard:
+        return _make_guard(OutputGuard, func, name=name, fail_open=fail_open)
+
+    if fn is not None:
+        return decorate(fn)
+    return decorate

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guard_decorators.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guard_decorators.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import railtracks as rt
+from railtracks.guardrails.core.decision import GuardrailAction, GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm.concrete import InputGuard, OutputGuard
+from railtracks.guardrails.llm.decorators import input_guard, output_guard
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, UserMessage
+
+
+def _input_event(messages: MessageHistory) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(phase=LLMGuardrailPhase.INPUT, messages=messages)
+
+
+def _output_event(text: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.OUTPUT,
+        messages=MessageHistory(),
+        output_message=AssistantMessage(text),
+    )
+
+
+class TestReturnsGuardInstance:
+    def test_bare_input_guard_is_input_guard(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert isinstance(rail, InputGuard)
+
+    def test_bare_output_guard_is_output_guard(self) -> None:
+        @output_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert isinstance(rail, OutputGuard)
+
+    def test_parameterized_forms_return_guards(self) -> None:
+        @input_guard(name="in")
+        def in_rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        @output_guard(fail_open=True)
+        def out_rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert isinstance(in_rail, InputGuard)
+        assert isinstance(out_rail, OutputGuard)
+
+
+class TestExposedOnPublicApi:
+    def test_top_level_and_namespace(self) -> None:
+        assert rt.input_guard is input_guard
+        assert rt.output_guard is output_guard
+        assert rt.guardrails.input_guard is input_guard
+        assert rt.guardrails.output_guard is output_guard
+
+
+class TestNaming:
+    def test_name_defaults_to_function_name(self) -> None:
+        @input_guard
+        def my_rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert my_rail.name == "my_rail"
+
+    def test_explicit_name_wins(self) -> None:
+        @input_guard(name="custom")
+        def my_rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert my_rail.name == "custom"
+
+
+class TestDecisions:
+    def test_allow(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        decision = rail(_input_event(MessageHistory([UserMessage("hi")])))
+        assert decision.action == GuardrailAction.ALLOW
+
+    def test_block(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            for msg in event.messages:
+                if isinstance(msg.content, str) and "SECRET" in msg.content:
+                    return GuardrailDecision.block(reason="secret leaked")
+            return GuardrailDecision.allow()
+
+        blocked = rail(_input_event(MessageHistory([UserMessage("my SECRET key")])))
+        allowed = rail(_input_event(MessageHistory([UserMessage("hello")])))
+        assert blocked.action == GuardrailAction.BLOCK
+        assert allowed.action == GuardrailAction.ALLOW
+
+    def test_output_transform(self) -> None:
+        @output_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.transform_output(
+                AssistantMessage("[redacted]"), reason="scrubbed"
+            )
+
+        decision = rail(_output_event("sensitive"))
+        assert decision.action == GuardrailAction.TRANSFORM
+        assert decision.output_message.content == "[redacted]"
+
+
+class TestRawInputCoercion:
+    """The decorated guard coerces str/Message/MessageHistory to the phase event."""
+
+    def test_input_guard_accepts_str(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            assert isinstance(event, LLMGuardrailEvent)
+            assert event.phase == LLMGuardrailPhase.INPUT
+            text = event.messages[0].content
+            return (
+                GuardrailDecision.block(reason="nope")
+                if "SECRET" in text
+                else GuardrailDecision.allow()
+            )
+
+        assert rail("my SECRET key").action == GuardrailAction.BLOCK
+        assert rail("hello").action == GuardrailAction.ALLOW
+
+    def test_output_guard_accepts_str(self) -> None:
+        @output_guard
+        def rail(event) -> GuardrailDecision:
+            assert isinstance(event, LLMGuardrailEvent)
+            assert event.phase == LLMGuardrailPhase.OUTPUT
+            return (
+                GuardrailDecision.block(reason="nope")
+                if "bad" in event.output_message.content
+                else GuardrailDecision.allow()
+            )
+
+        assert rail("this is bad").action == GuardrailAction.BLOCK
+        assert rail("this is fine").action == GuardrailAction.ALLOW
+
+    def test_decide_helper_works(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow(reason="ok")
+
+        assert rail.decide("anything").action == GuardrailAction.ALLOW
+
+
+class TestRunIntegration:
+    """Decorated guards run via .run() like hand-written subclasses."""
+
+    def test_run_allows(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        event = _input_event(MessageHistory([UserMessage("hi")]))
+        value, traces, decision = rail.run(event=event, value=event.messages)
+        assert decision is None
+        assert len(traces) == 1
+
+    def test_run_stops_on_block(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.block(reason="blocked")
+
+        event = _input_event(MessageHistory([UserMessage("hi")]))
+        _, _, decision = rail.run(event=event, value=event.messages)
+        assert decision is not None
+        assert decision.action == GuardrailAction.BLOCK
+
+
+class TestFailOpen:
+    def test_fail_open_lets_request_continue_on_error(self) -> None:
+        @input_guard(fail_open=True)
+        def rail(event) -> GuardrailDecision:
+            raise RuntimeError("boom")
+
+        event = _input_event(MessageHistory([UserMessage("hi")]))
+        value, traces, decision = rail.run(event=event, value=event.messages)
+        assert decision is None  # continued despite the exception
+        assert traces  # the exception was recorded
+
+    def test_fail_closed_blocks_on_error(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            raise RuntimeError("boom")
+
+        event = _input_event(MessageHistory([UserMessage("hi")]))
+        _, _, decision = rail.run(event=event, value=event.messages)
+        assert decision is not None
+        assert decision.action == GuardrailAction.BLOCK
+
+
+class TestDocstringPreserved:
+    def test_docstring_carried_to_guard_class(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            """My rail docstring."""
+            return GuardrailDecision.allow()
+
+        assert type(rail).__doc__ == "My rail docstring."


### PR DESCRIPTION
## Summary

Adds `@rt.input_guard` and `@rt.output_guard` decorators so users can author a guardrail from a plain function, mirroring the existing `@rt.before_llm` / `@rt.after_llm` middleware decorators. Each wraps an `fn(event) -> GuardrailDecision` into a ready-to-use `InputGuard` / `OutputGuard` instance. Both bare (`@rt.input_guard`) and parameterized (`@rt.input_guard(name=..., fail_open=...)`) forms are supported, `name` defaults to the function name, and the generated guard coerces a raw `str` / `Message` / `MessageHistory` argument to the correct phase event via `convert()`, so it's callable ad-hoc as well as from the middleware that evaluates the rail. Exposed at both `rt.*` and `rt.guardrails.*`.

closes #1271

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes
**Usage:**

```python
from railtracks.guardrails import GuardrailDecision, LLMGuardrailEvent

@rt.input_guard
def block_secrets(event: LLMGuardrailEvent) -> GuardrailDecision:
    for msg in event.messages:
        if isinstance(msg.content, str) and "SECRET" in msg.content:
            return GuardrailDecision.block(reason="secret leaked")
    return GuardrailDecision.allow()

@rt.output_guard(fail_open=True)
def no_profanity(event: LLMGuardrailEvent) -> GuardrailDecision:
    ...

agent = rt.agent_node(..., model_middleware=[block_secrets, no_profanity])
```
