### PR TITLE
feat(evaluations): add runtime evaluator

### DIFF
--- a/docs/evaluations/evaluators/runtime_evaluator.md
+++ b/docs/evaluations/evaluators/runtime_evaluator.md
@@ -1,0 +1,15 @@
+The **`RuntimeEvaluator`** reports the wall-clock duration of complete agent invocations. Use it to compare end-to-end flow performance across models, tools, and agent configurations instead of measuring individual LLM or tool calls.
+
+## Usage
+
+```python
+--8<-- "docs/scripts/evaluations/runtime_evaluator.py"
+```
+
+## Metric Tracked
+
+| Metric | Description |
+|---|---|
+| `Runtime` | Wall-clock execution time per agent invocation (seconds). |
+
+Runs without a recorded runtime are omitted from the metric instead of being reported as zero. The evaluation payload includes minimum, maximum, mean, median, mode, and standard deviation across measured invocations for visualization.

--- a/docs/scripts/evaluations/evals_quickstart.py
+++ b/docs/scripts/evaluations/evals_quickstart.py
@@ -8,6 +8,7 @@ data = evals.extract_agent_data_points(".railtracks/data/sessions/")
 # Default Evaluators
 t_evaluator = evals.ToolUseEvaluator()
 llm_evaluator = evals.LLMInferenceEvaluator()
+runtime_evaluator = evals.RuntimeEvaluator()
 
 # Configurable Evaluators
 judge_evaluator = evals.JudgeEvaluator(
@@ -37,6 +38,6 @@ judge_evaluator = evals.JudgeEvaluator(
 
 results = evals.evaluate(
     data=data,
-    evaluators=[t_evaluator, llm_evaluator, judge_evaluator],
+    evaluators=[t_evaluator, llm_evaluator, runtime_evaluator, judge_evaluator],
 )
 # --8<-- [end: tutorial]

--- a/docs/scripts/evaluations/runtime_evaluator.py
+++ b/docs/scripts/evaluations/runtime_evaluator.py
@@ -1,0 +1,6 @@
+from railtracks import evaluations as evals
+
+data = evals.extract_agent_data_points(".railtracks/data/sessions/")
+
+evaluator = evals.RuntimeEvaluator()
+results = evals.evaluate(data=data, evaluators=[evaluator])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
           - Evaluator Abstraction: evaluations/evaluators/evaluators.md
           - ToolUseEvaluator: evaluations/evaluators/tool_use_evaluator.md
           - LLMInferenceEvaluator: evaluations/evaluators/llm_inference_evaluator.md
+          - RuntimeEvaluator: evaluations/evaluators/runtime_evaluator.md
           - JudgeEvaluator: evaluations/evaluators/judge_evaluator.md
 
   - Observability:

--- a/packages/railtracks/src/railtracks/evaluations/__init__.py
+++ b/packages/railtracks/src/railtracks/evaluations/__init__.py
@@ -1,4 +1,10 @@
-from .evaluators import JudgeEvaluator, LLMInferenceEvaluator, ToolUseEvaluator, metrics
+from .evaluators import (
+    JudgeEvaluator,
+    LLMInferenceEvaluator,
+    RuntimeEvaluator,
+    ToolUseEvaluator,
+    metrics,
+)
 from .point import extract_agent_data_points
 from .runners._evaluate import evaluate
 
@@ -9,4 +15,5 @@ __all__ = [
     "JudgeEvaluator",
     "ToolUseEvaluator",
     "LLMInferenceEvaluator",
+    "RuntimeEvaluator",
 ]

--- a/packages/railtracks/src/railtracks/evaluations/evaluators/__init__.py
+++ b/packages/railtracks/src/railtracks/evaluations/evaluators/__init__.py
@@ -1,6 +1,13 @@
 from .evaluator import Evaluator
 from .judge_evaluator import JudgeEvaluator
 from .llm_inference_evaluator import LLMInferenceEvaluator
+from .runtime_evaluator import RuntimeEvaluator
 from .tool_use_evaluator import ToolUseEvaluator
 
-__all__ = ["Evaluator", "JudgeEvaluator", "ToolUseEvaluator", "LLMInferenceEvaluator"]
+__all__ = [
+    "Evaluator",
+    "JudgeEvaluator",
+    "ToolUseEvaluator",
+    "LLMInferenceEvaluator",
+    "RuntimeEvaluator",
+]

--- a/packages/railtracks/src/railtracks/evaluations/evaluators/runtime_evaluator.py
+++ b/packages/railtracks/src/railtracks/evaluations/evaluators/runtime_evaluator.py
@@ -1,0 +1,60 @@
+from uuid import UUID
+
+from ..point import AgentDataPoint
+from ..result import (
+    AggregateForest,
+    EvaluatorResult,
+    MetricResult,
+    NumericalAggregateNode,
+)
+from .evaluator import Evaluator
+from .metrics import Numerical
+
+RUNTIME_METRIC = Numerical(
+    name="Runtime",
+    min_value=0.0,
+    description="Wall-clock runtime of an agent invocation in seconds.",
+)
+
+
+class RuntimeEvaluator(Evaluator):
+    """Evaluate wall-clock runtime across complete agent invocations."""
+
+    def run(
+        self, data: list[AgentDataPoint]
+    ) -> EvaluatorResult[Numerical, MetricResult, NumericalAggregateNode]:
+        agent_data_ids: set[UUID] = {datapoint.identifier for datapoint in data}
+        forest = AggregateForest[NumericalAggregateNode, MetricResult]()
+        metric_results: list[MetricResult] = []
+
+        for datapoint in data:
+            if datapoint.runtime is None:
+                continue
+
+            metric_result = MetricResult(
+                result_name=RUNTIME_METRIC.name,
+                metric_id=RUNTIME_METRIC.identifier,
+                agent_data_id=[datapoint.identifier],
+                value=datapoint.runtime,
+            )
+            metric_results.append(metric_result)
+            forest.add_node(metric_result)
+
+        if metric_results:
+            aggregate = NumericalAggregateNode(
+                name=f"Aggregate/{RUNTIME_METRIC.name}",
+                metric=RUNTIME_METRIC,
+                children=[result.identifier for result in metric_results],
+                forest=forest,
+            )
+            forest.add_node(aggregate)
+            forest.roots.append(aggregate.identifier)
+
+        return EvaluatorResult(
+            evaluator_name=self.name,
+            evaluator_id=self.identifier,
+            agent_data_ids=agent_data_ids,
+            metrics=[RUNTIME_METRIC] if metric_results else [],
+            metric_results=metric_results,
+            aggregate_results=forest,
+        )

--- a/packages/railtracks/src/railtracks/evaluations/point.py
+++ b/packages/railtracks/src/railtracks/evaluations/point.py
@@ -104,8 +104,27 @@ class AgentDataPoint(BaseModel):
     agent_name: str
     agent_input: dict | list
     agent_output: dict
+    runtime: float | None = None
     llm_details: LLMDetails
     tool_details: ToolDetails
+
+
+def extract_runtime(run: dict, session: dict) -> float | None:
+    """Extract elapsed wall-clock time from run or legacy session boundaries."""
+    if run.get("status") == Status.OPEN.value:
+        return None
+
+    timing = run if "start_time" in run or "end_time" in run else session
+    start_time = timing.get("start_time")
+    end_time = timing.get("end_time")
+
+    if not isinstance(start_time, (int, float)) or not isinstance(
+        end_time, (int, float)
+    ):
+        return None
+
+    runtime = end_time - start_time
+    return runtime if runtime >= 0 else None
 
 
 def extract_llm_details(llm_details: list[dict]) -> LLMDetails:
@@ -363,6 +382,21 @@ def _data_points_from_payload(payload: dict) -> list[AgentDataPoint]:
 
         graph, sink_list = construct_graph(edges)
 
+        agent_nodes = [
+            node for node in nodes.values() if node.node_type == NodeType.AGENT
+        ]
+        root_agent_ids = {
+            target
+            for source, target in edges
+            if source is None
+            and target in nodes
+            and nodes[target].node_type == NodeType.AGENT
+        }
+        # Legacy payloads may omit graph edges; a lone agent is still the run root.
+        if not root_agent_ids and len(agent_nodes) == 1:
+            root_agent_ids.add(agent_nodes[0].identifier)
+
+        run_runtime = extract_runtime(run, payload)
         for node in nodes.values():
             if node.node_type == NodeType.AGENT:
                 llm_details_dict = node.details.get("internals", {}).get(
@@ -389,6 +423,9 @@ def _data_points_from_payload(payload: dict) -> list[AgentDataPoint]:
                         agent_name=node.name,
                         agent_input=agent_input,
                         agent_output=agent_output,
+                        runtime=(
+                            run_runtime if node.identifier in root_agent_ids else None
+                        ),
                         llm_details=llm_details,
                         tool_details=tool_details,
                     )

--- a/packages/railtracks/tests/unit_tests/evaluations/evaluators/conftest.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/evaluators/conftest.py
@@ -1,12 +1,11 @@
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
-
 from railtracks.evaluations.point import (
+    LLMIO,
     AgentDataPoint,
     LLMCall,
     LLMDetails,
-    LLMIO,
     MessageRole,
     Status,
     ToolArguments,
@@ -15,7 +14,13 @@ from railtracks.evaluations.point import (
 )
 
 
-def make_llm_call(index: int = 0, input_tokens: int = 50, output_tokens: int = 10, total_cost: float = 0.001, latency: float = 1.2) -> LLMCall:
+def make_llm_call(
+    index: int = 0,
+    input_tokens: int = 50,
+    output_tokens: int = 10,
+    total_cost: float = 0.001,
+    latency: float = 1.2,
+) -> LLMCall:
     return LLMCall(
         model_name="gpt-4",
         model_provider="OpenAI",
@@ -29,7 +34,9 @@ def make_llm_call(index: int = 0, input_tokens: int = 50, output_tokens: int = 1
     )
 
 
-def make_tool_call(name: str = "get_price", runtime: float = 0.1, status: Status = Status.COMPLETED) -> ToolCall:
+def make_tool_call(
+    name: str = "get_price", runtime: float = 0.1, status: Status = Status.COMPLETED
+) -> ToolCall:
     return ToolCall(
         identifier=uuid4(),
         name=name,
@@ -44,6 +51,7 @@ def make_agent_data_point(
     agent_name: str = "TestAgent",
     llm_calls: list[LLMCall] | None = None,
     tool_calls: list[ToolCall] | None = None,
+    runtime: float | None = 1.2,
 ) -> AgentDataPoint:
     if llm_calls is None:
         llm_calls = [make_llm_call()]
@@ -58,6 +66,7 @@ def make_agent_data_point(
         agent_output={"answer": "$100"},
         llm_details=LLMDetails(calls=llm_calls),
         tool_details=ToolDetails(tool_names=tool_names, calls=tool_calls),
+        runtime=runtime,
     )
 
 

--- a/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_runtime_evaluator.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_runtime_evaluator.py
@@ -1,0 +1,65 @@
+import pytest
+from railtracks.evaluations import RuntimeEvaluator
+from railtracks.evaluations.result import MetricResult, NumericalAggregateNode
+
+from .conftest import make_agent_data_point
+
+
+def test_run_records_runtime_for_each_agent_invocation():
+    data = [
+        make_agent_data_point(runtime=1.25),
+        make_agent_data_point(runtime=2.75),
+    ]
+
+    result = RuntimeEvaluator().run(data)
+
+    assert {metric.name for metric in result.metrics} == {"Runtime"}
+    assert [metric_result.value for metric_result in result.metric_results] == [
+        1.25,
+        2.75,
+    ]
+    assert all(
+        isinstance(metric_result, MetricResult)
+        for metric_result in result.metric_results
+    )
+
+
+def test_run_skips_invocations_without_runtime():
+    measured = make_agent_data_point(runtime=1.5)
+    missing = make_agent_data_point(runtime=None)
+
+    result = RuntimeEvaluator().run([measured, missing])
+
+    assert [metric_result.value for metric_result in result.metric_results] == [1.5]
+    assert result.agent_data_ids == {measured.identifier, missing.identifier}
+
+
+def test_run_without_measured_invocations_returns_empty_results():
+    result = RuntimeEvaluator().run([make_agent_data_point(runtime=None)])
+
+    assert result.metrics == []
+    assert result.metric_results == []
+    assert result.aggregate_results.roots == []
+
+
+def test_run_aggregates_and_serializes_for_the_visualizer():
+    result = RuntimeEvaluator().run(
+        [
+            make_agent_data_point(runtime=1.0),
+            make_agent_data_point(runtime=3.0),
+        ]
+    )
+
+    assert len(result.aggregate_results.roots) == 1
+    aggregate = result.aggregate_results.get(result.aggregate_results.roots[0])
+    assert isinstance(aggregate, NumericalAggregateNode)
+    assert aggregate.mean == pytest.approx(2.0)
+    assert aggregate.minimum == pytest.approx(1.0)
+    assert aggregate.maximum == pytest.approx(3.0)
+
+    serialized = result.model_dump(mode="json")
+    assert serialized["evaluator_name"] == "RuntimeEvaluator"
+    assert serialized["metric_results"][0]["type"] == "Base"
+    assert {
+        node["type"] for node in serialized["aggregate_results"]["nodes"].values()
+    } == {"Base", "NumericalAggregate"}

--- a/packages/railtracks/tests/unit_tests/evaluations/test_point.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/test_point.py
@@ -1,9 +1,8 @@
 import json
 from collections import defaultdict
-
-import pytest
 from uuid import UUID
 
+import pytest
 from railtracks.evaluations.point import (
     EdgeDataPoint,
     MessageRole,
@@ -12,13 +11,13 @@ from railtracks.evaluations.point import (
     extract_agent_data_points,
     extract_agent_io,
     extract_llm_details,
+    extract_runtime,
     extract_tool_details,
     load_session,
     resolve_file_paths,
 )
 
-from .conftest import AGENT_ID, TOOL1_ID, TOOL2_ID, SESSION_ID
-
+from .conftest import AGENT_ID, SESSION_ID, TOOL1_ID, TOOL2_ID
 
 # ── load_session ──────────────────────────────────────────────────────────────
 
@@ -166,7 +165,9 @@ def test_extract_agent_io_completed_edge(agent_node, edges):
 
 
 def test_extract_agent_io_no_edges(agent_node):
-    agent_input, agent_output = extract_agent_io(defaultdict(list), agent_node, str(SESSION_ID))
+    agent_input, agent_output = extract_agent_io(
+        defaultdict(list), agent_node, str(SESSION_ID)
+    )
     assert agent_input == {}
     assert agent_output == {}
 
@@ -178,11 +179,18 @@ def test_extract_agent_io_ignores_failed_edge(agent_node):
                 identifier=UUID("eeeeeeee-0000-0000-0000-000000000001"),
                 source=None,
                 target=AGENT_ID,
-                details={"input_args": [], "input_kwargs": {}, "status": "Failed", "output": None},
+                details={
+                    "input_args": [],
+                    "input_kwargs": {},
+                    "status": "Failed",
+                    "output": None,
+                },
             )
         ]
     }
-    agent_input, agent_output = extract_agent_io(failed_sink, agent_node, str(SESSION_ID))
+    agent_input, agent_output = extract_agent_io(
+        failed_sink, agent_node, str(SESSION_ID)
+    )
     assert agent_input == {}
     assert agent_output == {}
 
@@ -237,7 +245,62 @@ def test_extract_agent_data_points_from_file(tmp_path, session_json):
     dp = data_points[0]
     assert dp.agent_name == "TestAgent"
     assert dp.session_id == SESSION_ID
+    assert dp.runtime == pytest.approx(16.0)
     assert len(dp.llm_details.calls) == 1
+
+
+def test_extract_runtime_prefers_run_boundaries():
+    run = {"start_time": 10.0, "end_time": 12.5}
+    session = {"start_time": 1.0, "end_time": 101.0}
+
+    assert extract_runtime(run, session) == pytest.approx(2.5)
+
+
+def test_extract_runtime_uses_session_boundaries_for_legacy_runs():
+    session = {"start_time": 1_000_000.0, "end_time": 1_000_016.0}
+
+    assert extract_runtime({}, session) == pytest.approx(16.0)
+
+
+def test_extract_runtime_does_not_complete_an_open_run_from_session_time():
+    run = {"start_time": 10.0, "end_time": None}
+    session = {"start_time": 1.0, "end_time": 101.0}
+
+    assert extract_runtime(run, session) is None
+
+
+def test_extract_runtime_does_not_complete_an_open_legacy_run():
+    run = {"status": "Open"}
+    session = {"start_time": 1.0, "end_time": 101.0}
+
+    assert extract_runtime(run, session) is None
+
+
+def test_extract_runtime_ignores_reversed_boundaries():
+    run = {"start_time": 12.5, "end_time": 10.0}
+
+    assert extract_runtime(run, {}) is None
+
+
+def test_extract_agent_data_points_records_runtime_only_for_root_agent(session_json):
+    nested_agent_id = UUID("aaaaaaaa-0000-0000-0000-000000000002")
+    run = session_json["runs"][0]
+    run["start_time"] = 10.0
+    run["end_time"] = 12.5
+    run["nodes"].append(
+        {
+            "identifier": str(nested_agent_id),
+            "node_type": "Agent",
+            "name": "NestedAgent",
+            "details": {},
+        }
+    )
+
+    data_points = extract_agent_data_points([session_json])
+    runtimes = {data_point.agent_name: data_point.runtime for data_point in data_points}
+
+    assert runtimes["TestAgent"] == pytest.approx(2.5)
+    assert runtimes["NestedAgent"] is None
 
 
 def test_extract_agent_data_points_tool_details(tmp_path, session_json):


### PR DESCRIPTION
## Summary

Add a `RuntimeEvaluator` for comparing end-to-end wall-clock time across complete agent invocations. Run boundaries are retained on root agent data points, while open or incomplete runs are omitted instead of being reported as zero.

The evaluator reuses the existing numerical aggregate result, so serialized evaluation output includes minimum, maximum, mean, median, mode, and standard deviation without introducing a visualizer-specific result type. Legacy session payloads without per-run boundaries remain supported.

Closes #1163

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Verification

- `pytest -q packages/railtracks/tests/unit_tests/evaluations packages/railtracks/tests/integration_tests/evaluations`
- `ruff check . --no-fix`
- `ruff format --check .`
- `mkdocs build --strict`

## Notes

Runtime is recorded once for each run's root agent so nested agents do not duplicate a flow-level measurement. Failed runs with complete timing boundaries remain measurable; open and malformed runs are skipped.
