### PR TITLE
1206 V4 streaming (2/n): named channels — rt.broadcast(channel=) + Stream.on_channel

### DIFF
--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -34,6 +34,23 @@ A few details worth knowing:
 - **Timeouts.** The session `timeout` applies to the whole streamed run as a wall-clock limit.
 - **Tool calling.** Token streaming with tool calling is currently supported on OpenAI models only. On other providers a streamed tool-calling run falls back to a buffered model call (with a logged warning), and the final result is unaffected.
 
+### Named channels
+
+Every streamed item travels on a named channel. An agent's tokens ride the `"default"` channel, and you can send your own one-off events on any channel with `rt.broadcast(item, channel=...)` from inside a run:
+
+```python
+--8<-- "docs/scripts/streaming.py:channels"
+```
+
+By default a `Stream` yields chunks from every channel. When a run produces on more than one channel (say, the agent's tokens on `"default"` and progress notes on `"status"`), chain `on_channel` to consume just one:
+
+```python
+async for token in rt.astream(agent, user_input="...").on_channel("default"):
+    ...
+```
+
+`on_channel` is a method rather than an `astream(..., channel=...)` keyword because `astream` forwards its keyword arguments to the node, where a `channel` keyword could collide with the node's own parameters.
+
 ### Two callback lanes: `broadcast_callback` and `stream_callback`
 
 Streaming shares the same pubsub bus as `rt.broadcast`, but the two kinds of traffic travel on separate lanes so a listener never receives the wrong kind:

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -49,8 +49,6 @@ async for token in rt.astream(agent, user_input="...").on_channel("default"):
     ...
 ```
 
-`on_channel` is a method rather than an `astream(..., channel=...)` keyword because `astream` forwards its keyword arguments to the node, where a `channel` keyword could collide with the node's own parameters.
-
 ### Two callback lanes: `broadcast_callback` and `stream_callback`
 
 Streaming shares the same pubsub bus as `rt.broadcast`, but the two kinds of traffic travel on separate lanes so a listener never receives the wrong kind:

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -25,6 +25,22 @@ async def main_await():
 # --8<-- [end: astream_await]
 
 
+# --8<-- [start: channels]
+@rt.function_node
+async def worker(topic: str) -> str:
+    # one-off events on a named channel, consumable via on_channel / broadcast_callback
+    await rt.broadcast("started", channel="status")
+    await rt.broadcast("finished", channel="status")
+    return f"done: {topic}"
+
+
+async def main_channels():
+    # consume only the "status" channel
+    async for note in rt.astream(worker, topic="rain").on_channel("status"):
+        print(note)
+# --8<-- [end: channels]
+
+
 # --8<-- [start: stream_callback]
 # Passive session-wide listeners — neither enables streaming (only rt.astream does):
 #   stream_callback    -> chunks from rt.broadcast_stream (LLM tokens included)

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -110,6 +110,9 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         self._node = node
         self._args = args
         self._kwargs = kwargs
+        # None means "yield chunks from every channel"; a name restricts to that one channel
+        # (set via `on_channel`).
+        self._channel: str | None = None
 
         # the request id doubles as the stream scope id used to tag every chunk of this run
         self._request_id = str(uuid4())
@@ -127,6 +130,40 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         self._on_start = on_start
         self._on_close = on_close
         self._closed = False
+
+    # ------------------------------------------------------------------ configuration
+
+    def on_channel(self, channel: str) -> Stream[_TOutput]:
+        """
+        Restrict this stream to chunks emitted on a single named channel.
+
+        By default a `Stream` yields chunks from every channel in the run. Chaining
+        `on_channel` before iterating narrows it to one, which is useful when a run produces
+        on several channels (e.g. the agent's tokens on `"default"` and progress notes on
+        `"status"`) and you only want one of them:
+
+        ```python
+        async for token in rt.astream(agent, user_input="...").on_channel("default"):
+            ...
+        ```
+
+        It is a method rather than an `astream(..., channel=...)` keyword because `astream`
+        forwards its keyword arguments to the node, where a `channel` keyword could collide
+        with the node's own parameters.
+
+        Args:
+            channel: The channel name to yield chunks from.
+
+        Returns:
+            Stream[_TOutput]: This same stream, so the call can be chained.
+
+        Raises:
+            RuntimeError: If iteration has already started.
+        """
+        if self._started:
+            raise RuntimeError("on_channel() must be called before iterating the stream.")
+        self._channel = channel
+        return self
 
     # ------------------------------------------------------------------ lifecycle
 
@@ -149,9 +186,13 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
 
         request_id = self._request_id
 
+        channel = self._channel
+
         def _subscriber(message: RequestCompletionMessage) -> None:
             if isinstance(message, Streaming):
-                if message.stream_id == request_id:
+                if message.stream_id == request_id and (
+                    channel is None or message.channel == channel
+                ):
                     queue.put_nowait(("chunk", message.streamed_object))
             elif isinstance(message, RequestFinishedBase):
                 if message.request_id == request_id:

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -8,20 +8,29 @@ from railtracks.llm.response import Response
 from railtracks.pubsub.messages import Streaming
 
 
-async def broadcast(item: str):
+async def broadcast(item: str, channel: str = "default"):
     """
     Broadcasts a one-off **event** to the session bus.
 
-    This triggers the `broadcast_callback` you have already provided. Events are 
-    separate from stream callbacks.
+    The event is delivered to a `broadcast_callback` and, when emitted inside a streamed run,
+    to `rt.astream` (which can filter to a single channel with `on_channel`). Events travel on
+    a separate lane from stream chunks, so a `broadcast_callback` never receives tokens.
 
     Args:
         item (str): The item you want to broadcast.
+        channel (str): The named channel to emit on. Consumers can select a single channel
+            (e.g. `stream.on_channel("status")`). Defaults to `"default"`.
     """
     publisher = get_publisher()
 
     await publisher.publish(
-        Streaming(node_id=get_parent_id(), streamed_object=item, kind="event")
+        Streaming(
+            node_id=get_parent_id(),
+            streamed_object=item,
+            channel=channel,
+            stream_id=get_stream_id(),
+            kind="event",
+        )
     )
 
 

--- a/packages/railtracks/tests/integration_tests/run/test_astream_channels.py
+++ b/packages/railtracks/tests/integration_tests/run/test_astream_channels.py
@@ -1,0 +1,66 @@
+"""Integration tests for named channels on `rt.astream`: `rt.broadcast(channel=)` +
+`Stream.on_channel(...)`."""
+
+import pytest
+import railtracks as rt
+
+
+@rt.function_node
+async def multi_channel() -> str:
+    """Emits one-off events across two named channels within a streamed run."""
+    await rt.broadcast("d1", channel="default")
+    await rt.broadcast("s1", channel="status")
+    await rt.broadcast("d2", channel="default")
+    return "done"
+
+
+@pytest.mark.asyncio
+async def test_astream_yields_all_channels_by_default():
+    with rt.Session(flow_name="chan"):
+        chunks = [c async for c in rt.astream(multi_channel)]
+    assert chunks == ["d1", "s1", "d2"]
+
+
+@pytest.mark.asyncio
+async def test_on_channel_filters_to_one_channel():
+    with rt.Session(flow_name="chan"):
+        stream = rt.astream(multi_channel).on_channel("status")
+        chunks = [c async for c in stream]
+        assert chunks == ["s1"]
+        assert stream.result == "done"
+
+        default_only = [c async for c in rt.astream(multi_channel).on_channel("default")]
+        assert default_only == ["d1", "d2"]
+
+
+@pytest.mark.asyncio
+async def test_on_channel_unused_yields_nothing_but_result_intact():
+    with rt.Session(flow_name="chan"):
+        stream = rt.astream(multi_channel).on_channel("does-not-exist")
+        chunks = [c async for c in stream]
+        assert chunks == []
+        assert stream.result == "done"
+
+
+@pytest.mark.asyncio
+async def test_on_channel_after_iteration_raises():
+    with rt.Session(flow_name="chan"):
+        stream = rt.astream(multi_channel)
+        await stream.__anext__()
+        with pytest.raises(RuntimeError):
+            stream.on_channel("default")
+        await stream  # let the run finish
+
+
+@pytest.mark.asyncio
+async def test_agent_tokens_ride_default_channel(mock_llm):
+    agent = rt.agent_node(
+        name="Streamer",
+        llm=mock_llm(custom_response="hello"),
+        system_message="s",
+    )
+    with rt.Session(flow_name="chan"):
+        tokens = [
+            c async for c in rt.astream(agent, user_input="hi").on_channel("default")
+        ]
+    assert "".join(tokens) == "hello"


### PR DESCRIPTION
## Summary

Second slice of the V4 streaming rollout: **named channels**.

Every streamed item already travels on a named channel (`Streaming.channel`, from mini_1). This PR exposes that to users on both ends:

- **`rt.broadcast(item, channel="default")`** — the one-off event producer now takes a channel. It also stamps the current stream scope (`get_stream_id()`), so an event emitted inside a streamed run now reaches `rt.astream` as well as `broadcast_callback`. Events stay on the event lane (`kind="event"`); a `stream_callback` is never flooded.
- **`Stream.on_channel(name)`** — restrict a pull stream to a single channel. Chain it before iterating:

```python
async for token in rt.astream(agent, user_input="...").on_channel("default"):
    ...
```

Agent tokens ride `"default"`, so `on_channel("default")` selects just the tokens while a custom node emits progress events on another channel in the same run. By default (no `on_channel`) a stream still yields every channel.

## Why `on_channel` is a method, not `astream(..., channel=...)`

`astream` forwards its keyword arguments to the node (like `rt.call`), so a `channel=` keyword could collide with a node's own parameter. Selecting the channel on the returned handle keeps the node's argument list unambiguous. It must be called before iteration starts (raises `RuntimeError` otherwise).

