### PR TITLE
1296 add llm call

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -70,6 +70,7 @@ class ModelInvoker:
         self._middleware = MiddlewareChain(
             middleware or [], get_scope_manager=get_scope_manager
         )
+        self.get_scope_manager = get_scope_manager
 
     @classmethod
     def create_with_llm_observe(
@@ -113,7 +114,8 @@ class ModelInvoker:
             else:
                 return await asyncio.to_thread(model.chat, messages)
 
-        return await self._middleware.run(_core_llm_call, messages, schema, tools)
+        with self.get_scope_manager().enter_llm_call():
+            return await self._middleware.run(_core_llm_call, messages, schema, tools)
 
     def extend_middleware(self, *model_middleware: ModelMiddleware) -> ModelInvoker:
         """

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -213,7 +213,7 @@ def register_globals(
     global_context_vars: dict[str, Any],
 ):
     """
-    Register the global variables for the current thread
+    Register the global variables for the current thread.
     """
     s_c = SessionContext(
         publisher=rt_publisher,

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -128,6 +128,19 @@ def get_parent_id() -> str | None:
         else None
     )
 
+def get_llm_call_id() -> str | None:
+    """
+    Get the id of the currently active LLM call (walks up the scope chain to the
+    nearest LLM entry).
+
+    Returns:
+        str | None: The LLM call ID associated with the current thread's global variables, or None if not set.
+
+    Raises:
+        ContextError: If the global variables have not been registered.
+    """
+    context = safe_get_runner_context()
+    return context.session_context.llm_call_id
 
 def get_middleware_id() -> str | None:
     """
@@ -346,6 +359,28 @@ class ContextVarScopeManager:
         token = _push_scope(ScopeEntry(ScopeKind.MIDDLEWARE, middleware_id, name=name))
         try:
             yield middleware_id
+        finally:
+            runner_context.reset(token)
+
+    @contextmanager
+    def enter_llm_call(self):
+        llm_call_id = str(uuid.uuid4())
+        ctx = safe_get_runner_context()
+        new_session_context = SessionContext(
+            session_id=ctx.session_context.session_id,
+            run_id=ctx.session_context.run_id,
+            publisher=ctx.session_context.publisher,
+            scope=ctx.session_context.scope,
+            executor_config=ctx.session_context.executor_config,
+            llm_call_id=llm_call_id,
+        )
+        new_ctx = RunnerContextVars(
+            session_context=new_session_context,
+            external_context=ctx.external_context,
+        )
+        token = runner_context.set(new_ctx)
+        try:
+            yield
         finally:
             runner_context.reset(token)
 

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -128,10 +128,10 @@ def get_parent_id() -> str | None:
         else None
     )
 
+
 def get_llm_call_id() -> str | None:
     """
-    Get the id of the currently active LLM call (walks up the scope chain to the
-    nearest LLM entry).
+    Get the id of the currently active LLM call, if one is in progress.
 
     Returns:
         str | None: The LLM call ID associated with the current thread's global variables, or None if not set.
@@ -141,6 +141,7 @@ def get_llm_call_id() -> str | None:
     """
     context = safe_get_runner_context()
     return context.session_context.llm_call_id
+
 
 def get_middleware_id() -> str | None:
     """

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -192,6 +192,7 @@ def restore_scope(scope: ScopeLink[ScopeEntry] | None, run_id: str | None):
         publisher=ctx.session_context.publisher,
         scope=scope,
         executor_config=ctx.session_context.executor_config,
+        llm_call_id=ctx.session_context.llm_call_id,
     )
     new_ctx = RunnerContextVars(
         session_context=new_session_context,

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -192,7 +192,6 @@ def restore_scope(scope: ScopeLink[ScopeEntry] | None, run_id: str | None):
         publisher=ctx.session_context.publisher,
         scope=scope,
         executor_config=ctx.session_context.executor_config,
-        llm_call_id=ctx.session_context.llm_call_id,
     )
     new_ctx = RunnerContextVars(
         session_context=new_session_context,

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -213,7 +213,7 @@ def register_globals(
     global_context_vars: dict[str, Any],
 ):
     """
-    Register the global variables for the current thread.
+    Register the global variables for the current thread
     """
     s_c = SessionContext(
         publisher=rt_publisher,

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -141,4 +141,5 @@ class SessionContext:
             publisher=self._publisher,
             scope=new_scope,
             executor_config=self._executor_config,
+            llm_call_id=self._llm_call_id,
         )

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -39,8 +39,10 @@ class SessionContext:
         publisher: RTPublisher | None = None,
         scope: ScopeLink[ScopeEntry] | None = None,
         executor_config: ExecutorConfig,
+        llm_call_id: str | None = None,
     ):
         self._scope: ScopeLink[ScopeEntry] | None = scope
+        self._llm_call_id: str | None = llm_call_id
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
@@ -59,6 +61,14 @@ class SessionContext:
         Sets the executor configuration for this run.
         """
         self._executor_config = value
+
+    @property
+    def llm_call_id(self) -> str | None:
+        return self._llm_call_id
+
+    @llm_call_id.setter
+    def llm_call_id(self, value: str | None):
+        self._llm_call_id = value
 
     @property
     def scope(self) -> ScopeLink[ScopeEntry] | None:

--- a/packages/railtracks/src/railtracks/scope_manager.py
+++ b/packages/railtracks/src/railtracks/scope_manager.py
@@ -13,6 +13,8 @@ class ScopeManager(Protocol):
 
     def enter_middleware(self, name: str) -> ContextManager[str | None]: ...
 
+    def enter_llm_call(self) -> ContextManager[None]: ...
+
 
 class NullScopeManager:
     """No-op ScopeManager: pushes nothing, touches no global state."""
@@ -28,6 +30,10 @@ class NullScopeManager:
     @contextmanager
     def enter_middleware(self, name: str):
         yield None
+
+    @contextmanager
+    def enter_llm_call(self):
+        yield
 
 
 _NULL_SCOPE_MANAGER = NullScopeManager()

--- a/packages/railtracks/tests/unit_tests/built_nodes/llm/test_model_invoker.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/llm/test_model_invoker.py
@@ -1,0 +1,73 @@
+"""Tests for ModelInvoker's LLM-call scoping (llm_call_id)."""
+
+import pytest
+
+import railtracks.context.central as central
+from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
+from railtracks.built_nodes.llm.model_invoker import ModelInvoker
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.message import Message, Role
+from railtracks.llm.response import Response
+from railtracks.utils.config import ExecutorConfig
+
+
+class _FakeModel:
+    def chat(self, messages):
+        return Response(message=Message(role=Role.assistant, content="hi"))
+
+
+@pytest.fixture(autouse=True)
+def cleanup_globals():
+    central.delete_globals()
+    yield
+    central.delete_globals()
+
+
+def _register():
+    central.register_globals(
+        session_id="s1",
+        rt_publisher=None,
+        executor_config=ExecutorConfig(),
+        global_context_vars={},
+    )
+
+
+async def test_invoke_scopes_llm_call_id_for_middleware_and_reverts_after():
+    _register()
+    captured = []
+
+    @wrap_llm
+    async def capture(call, message_history, schema, tools):
+        captured.append(central.get_llm_call_id())
+        return await call(message_history, schema, tools)
+
+    invoker = ModelInvoker(
+        _FakeModel(), [capture], get_scope_manager=central.ContextVarScopeManager
+    )
+
+    assert central.get_llm_call_id() is None
+    await invoker.invoke(MessageHistory())
+    assert central.get_llm_call_id() is None
+
+    assert captured == [captured[0]]
+    assert captured[0] is not None
+
+
+async def test_invoke_generates_a_fresh_llm_call_id_each_call():
+    _register()
+    captured = []
+
+    @wrap_llm
+    async def capture(call, message_history, schema, tools):
+        captured.append(central.get_llm_call_id())
+        return await call(message_history, schema, tools)
+
+    invoker = ModelInvoker(
+        _FakeModel(), [capture], get_scope_manager=central.ContextVarScopeManager
+    )
+
+    await invoker.invoke(MessageHistory())
+    await invoker.invoke(MessageHistory())
+
+    assert len(captured) == 2
+    assert captured[0] != captured[1]

--- a/packages/railtracks/tests/unit_tests/context/conftest.py
+++ b/packages/railtracks/tests/unit_tests/context/conftest.py
@@ -23,6 +23,7 @@ def make_session_context_mock():
         sc.is_active = kwargs.get("is_active", True)
         sc.current_node_id = kwargs.get("current_node_id", "parent-123")
         sc.current_middleware_id = kwargs.get("current_middleware_id", None)
+        sc.llm_call_id = kwargs.get("llm_call_id", None)
         sc.session_id = kwargs.get("session_id", "session-123")
         sc.run_id = kwargs.get("run_id", None)
         sc.scope = kwargs.get("scope", None)

--- a/packages/railtracks/tests/unit_tests/context/test_central.py
+++ b/packages/railtracks/tests/unit_tests/context/test_central.py
@@ -245,8 +245,7 @@ def test_nested_enter_llm_call_gets_new_id_and_restores_outer():
 
 
 def test_llm_call_id_survives_nested_node_and_middleware_scopes():
-    # regression test: with_scope_pushed must carry llm_call_id through, otherwise
-    # entering a node/middleware scope inside an active LLM call silently drops it.
+    # with_scope_pushed must forward llm_call_id, or nested scopes clear it.
     _register()
     manager = central.ContextVarScopeManager()
 

--- a/packages/railtracks/tests/unit_tests/context/test_central.py
+++ b/packages/railtracks/tests/unit_tests/context/test_central.py
@@ -63,6 +63,11 @@ def test_get_middleware_id(monkeypatch, make_runner_context_vars, make_session_c
     rt = make_runner_context_vars(session_context=make_session_context_mock(current_middleware_id="mw-abc"))
     monkeypatch.setattr(central, "runner_context", mock.Mock(get=mock.Mock(return_value=rt)))
     assert central.get_middleware_id() == "mw-abc"
+
+def test_get_llm_call_id(monkeypatch, make_runner_context_vars, make_session_context_mock):
+    rt = make_runner_context_vars(session_context=make_session_context_mock(llm_call_id="llm-abc"))
+    monkeypatch.setattr(central, "runner_context", mock.Mock(get=mock.Mock(return_value=rt)))
+    assert central.get_llm_call_id() == "llm-abc"
 # ============ END ID Accessor Tests ===============
 
 # ============ START Globals Registration/Deletion Tests ===============
@@ -213,6 +218,61 @@ def test_restore_scope_replaces_ambient_scope():
         assert central.get_run_id() == captured_run_id
 
     assert central.get_parent_id() is None
+
+
+def test_enter_llm_call_generates_fresh_id_and_reverts():
+    _register()
+    manager = central.ContextVarScopeManager()
+
+    assert central.get_llm_call_id() is None
+
+    with manager.enter_llm_call():
+        assert central.get_llm_call_id() is not None
+
+    assert central.get_llm_call_id() is None
+
+
+def test_nested_enter_llm_call_gets_new_id_and_restores_outer():
+    _register()
+    manager = central.ContextVarScopeManager()
+
+    with manager.enter_llm_call():
+        outer_id = central.get_llm_call_id()
+        with manager.enter_llm_call():
+            inner_id = central.get_llm_call_id()
+            assert inner_id != outer_id
+        assert central.get_llm_call_id() == outer_id
+
+
+def test_llm_call_id_survives_nested_node_and_middleware_scopes():
+    # regression test: with_scope_pushed must carry llm_call_id through, otherwise
+    # entering a node/middleware scope inside an active LLM call silently drops it.
+    _register()
+    manager = central.ContextVarScopeManager()
+
+    with manager.enter_llm_call():
+        llm_call_id = central.get_llm_call_id()
+        assert llm_call_id is not None
+
+        with manager.enter_node("node-1"):
+            assert central.get_llm_call_id() == llm_call_id
+            with manager.enter_middleware("guard"):
+                assert central.get_llm_call_id() == llm_call_id
+            assert central.get_llm_call_id() == llm_call_id
+
+    assert central.get_llm_call_id() is None
+
+
+def test_restore_scope_does_not_carry_llm_call_id():
+    _register()
+    manager = central.ContextVarScopeManager()
+
+    with manager.enter_llm_call():
+        captured_scope = central.get_current_scope()
+        captured_run_id = central.get_run_id()
+
+    with central.restore_scope(captured_scope, captured_run_id):
+        assert central.get_llm_call_id() is None
 # ============ END ContextVarScopeManager Tests ===============
 
 # ============ START External Context Access Tests ===============

--- a/packages/railtracks/tests/unit_tests/context/test_session_context.py
+++ b/packages/railtracks/tests/unit_tests/context/test_session_context.py
@@ -25,6 +25,7 @@ def test_session_context_properties(dummy_executor_config):
     assert ctx.is_active is True
     assert ctx.current_node_id is None
     assert ctx.current_middleware_id is None
+    assert ctx.llm_call_id is None
 # ============ END SessionContext Property Tests ===============
 
 # ============ START SessionContext Setter Tests ===============
@@ -39,9 +40,11 @@ def test_session_context_setters(dummy_executor_config):
     ctx.publisher = pub
     new_config = mock.Mock()
     ctx.executor_config = new_config
+    ctx.llm_call_id = "llm-1"
     assert ctx.session_id == "r2"
     assert ctx.publisher is pub
     assert ctx.executor_config is new_config
+    assert ctx.llm_call_id == "llm-1"
 # ============ END SessionContext Setter Tests ===============
 
 # ============ START SessionContext is_active Tests ===============
@@ -70,6 +73,7 @@ def test_with_scope_pushed_creates_new_context_and_preserves_lineage(dummy_execu
         session_id="r",
         publisher=pub,
         executor_config=dummy_executor_config,
+        llm_call_id="llm-1",
     )
     new_ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.NODE, "node-1"), run_id="node-1")
     assert isinstance(new_ctx, SessionContext)
@@ -78,6 +82,8 @@ def test_with_scope_pushed_creates_new_context_and_preserves_lineage(dummy_execu
     assert new_ctx.publisher is pub
     assert new_ctx.session_id == ctx.session_id
     assert new_ctx.executor_config is ctx.executor_config
+    # llm_call_id is carried through the scope push, not reset
+    assert new_ctx.llm_call_id == "llm-1"
     # original context is untouched (immutable push)
     assert ctx.current_node_id is None
     assert ctx.run_id is None


### PR DESCRIPTION
## Summary

In this short PR I make a couple of adjustments to the ground work laid in #1288. In this PR i will be adding an additional id param for llm calls and adding that to the `SessionContext` object. Additionally I added a new context manager to be used to inject the id param. 

One important design consideration i would like to pay careful attention to:
- The location in which I decided to inject the `llm call id`. I chose to put it in the model invoker instead of wrapping it invoke body. This is done because `ModelInvoker`'s purpose is to inject observability and middleware into an llm. This feels like the natural location to put it in.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes


closes #1296 



