### PR TITLE
pooria/llm scope

### DIFF
--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -140,7 +140,11 @@ def get_llm_call_id() -> str | None:
         ContextError: If the global variables have not been registered.
     """
     context = safe_get_runner_context()
-    return context.session_context.llm_call_id
+    return (
+        context.session_context.current_llm_call_id.id
+        if context.session_context.current_llm_call_id is not None
+        else None
+    )
 
 
 def get_middleware_id() -> str | None:
@@ -366,20 +370,7 @@ class ContextVarScopeManager:
     @contextmanager
     def enter_llm_call(self):
         llm_call_id = str(uuid.uuid4())
-        ctx = safe_get_runner_context()
-        new_session_context = SessionContext(
-            session_id=ctx.session_context.session_id,
-            run_id=ctx.session_context.run_id,
-            publisher=ctx.session_context.publisher,
-            scope=ctx.session_context.scope,
-            executor_config=ctx.session_context.executor_config,
-            llm_call_id=llm_call_id,
-        )
-        new_ctx = RunnerContextVars(
-            session_context=new_session_context,
-            external_context=ctx.external_context,
-        )
-        token = runner_context.set(new_ctx)
+        token = _push_scope(ScopeEntry(ScopeKind.LLM, llm_call_id))
         try:
             yield
         finally:

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -15,6 +15,7 @@ class ScopeKind(Enum):
     NODE = "node"
     MIDDLEWARE = "middleware"
     NODE_BODY = "node_body"
+    LLM = "llm"
 
 
 @dataclass(frozen=True)
@@ -39,10 +40,8 @@ class SessionContext:
         publisher: RTPublisher | None = None,
         scope: ScopeLink[ScopeEntry] | None = None,
         executor_config: ExecutorConfig,
-        llm_call_id: str | None = None,
     ):
         self._scope: ScopeLink[ScopeEntry] | None = scope
-        self._llm_call_id: str | None = llm_call_id
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
@@ -63,14 +62,6 @@ class SessionContext:
         self._executor_config = value
 
     @property
-    def llm_call_id(self) -> str | None:
-        return self._llm_call_id
-
-    @llm_call_id.setter
-    def llm_call_id(self, value: str | None):
-        self._llm_call_id = value
-
-    @property
     def scope(self) -> ScopeLink[ScopeEntry] | None:
         return self._scope
 
@@ -88,6 +79,13 @@ class SessionContext:
         if self._scope is None:
             return None
         entry = self._scope.find(lambda e: e.kind is ScopeKind.MIDDLEWARE)
+        return entry
+
+    @property
+    def current_llm_call_id(self) -> ScopeEntry | None:
+        if self._scope is None:
+            return None
+        entry = self._scope.find(lambda e: e.kind is ScopeKind.LLM)
         return entry
 
     @property
@@ -141,5 +139,4 @@ class SessionContext:
             publisher=self._publisher,
             scope=new_scope,
             executor_config=self._executor_config,
-            llm_call_id=self._llm_call_id,
         )

--- a/packages/railtracks/tests/unit_tests/context/conftest.py
+++ b/packages/railtracks/tests/unit_tests/context/conftest.py
@@ -1,6 +1,19 @@
-import pytest
+from types import SimpleNamespace
 from unittest import mock
+
+import pytest
 import railtracks.context.central as central
+
+
+def _as_entry(value):
+    """Wrap a raw id as a ScopeEntry-like object exposing `.id`.
+
+    The id accessors (`get_parent_id`, `get_middleware_id`, `get_llm_call_id`) read
+    `<current_*>.id`, so the mocked properties must return an object, not a bare string.
+    """
+    if value is None:
+        return None
+    return SimpleNamespace(id=value)
 
 
 @pytest.fixture
@@ -21,9 +34,9 @@ def make_session_context_mock():
     def _make_session_context_mock(**kwargs):
         sc = mock.Mock()
         sc.is_active = kwargs.get("is_active", True)
-        sc.current_node_id = kwargs.get("current_node_id", "parent-123")
-        sc.current_middleware_id = kwargs.get("current_middleware_id", None)
-        sc.llm_call_id = kwargs.get("llm_call_id", None)
+        sc.current_node_id = _as_entry(kwargs.get("current_node_id", "parent-123"))
+        sc.current_middleware_id = _as_entry(kwargs.get("current_middleware_id", None))
+        sc.current_llm_call_id = _as_entry(kwargs.get("current_llm_call_id", None))
         sc.session_id = kwargs.get("session_id", "session-123")
         sc.run_id = kwargs.get("run_id", None)
         sc.scope = kwargs.get("scope", None)

--- a/packages/railtracks/tests/unit_tests/context/test_central.py
+++ b/packages/railtracks/tests/unit_tests/context/test_central.py
@@ -1,9 +1,10 @@
-import pytest
 from unittest import mock
 
+import pytest
 import railtracks.context.central as central
 from railtracks.context.session_context import ScopeEntry, ScopeKind
 from railtracks.utils.config import ExecutorConfig
+
 
 # ============ START Session Context Tests ===============
 def test_safe_get_runner_context_raises_when_none():
@@ -65,7 +66,7 @@ def test_get_middleware_id(monkeypatch, make_runner_context_vars, make_session_c
     assert central.get_middleware_id() == "mw-abc"
 
 def test_get_llm_call_id(monkeypatch, make_runner_context_vars, make_session_context_mock):
-    rt = make_runner_context_vars(session_context=make_session_context_mock(llm_call_id="llm-abc"))
+    rt = make_runner_context_vars(session_context=make_session_context_mock(current_llm_call_id="llm-abc"))
     monkeypatch.setattr(central, "runner_context", mock.Mock(get=mock.Mock(return_value=rt)))
     assert central.get_llm_call_id() == "llm-abc"
 # ============ END ID Accessor Tests ===============
@@ -169,7 +170,7 @@ def test_enter_node_body_requires_active_node_scope():
     _register()
     manager = central.ContextVarScopeManager()
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(RuntimeError):
         with manager.enter_node_body():
             pass
 
@@ -262,16 +263,21 @@ def test_llm_call_id_survives_nested_node_and_middleware_scopes():
     assert central.get_llm_call_id() is None
 
 
-def test_restore_scope_does_not_carry_llm_call_id():
+def test_captured_scope_after_llm_call_carries_no_llm_id():
+    # tool calls dispatch after the llm call returns, so the captured scope has no LLM entry
     _register()
     manager = central.ContextVarScopeManager()
 
-    with manager.enter_llm_call():
-        captured_scope = central.get_current_scope()
-        captured_run_id = central.get_run_id()
+    with manager.enter_node("node-1"):
+        with manager.enter_node_body():
+            with manager.enter_llm_call():
+                assert central.get_llm_call_id() is not None
+            captured_scope = central.get_current_scope()
+            captured_run_id = central.get_run_id()
 
     with central.restore_scope(captured_scope, captured_run_id):
         assert central.get_llm_call_id() is None
+        assert central.get_parent_id() == "node-1"
 # ============ END ContextVarScopeManager Tests ===============
 
 # ============ START External Context Access Tests ===============

--- a/packages/railtracks/tests/unit_tests/context/test_session_context.py
+++ b/packages/railtracks/tests/unit_tests/context/test_session_context.py
@@ -1,7 +1,8 @@
 
-import pytest
 from unittest import mock
+
 from railtracks.context.session_context import ScopeEntry, ScopeKind, SessionContext
+
 
 # ============ START DummyPublisher Helper ===============
 class DummyPublisher:
@@ -25,7 +26,7 @@ def test_session_context_properties(dummy_executor_config):
     assert ctx.is_active is True
     assert ctx.current_node_id is None
     assert ctx.current_middleware_id is None
-    assert ctx.llm_call_id is None
+    assert ctx.current_llm_call_id is None
 # ============ END SessionContext Property Tests ===============
 
 # ============ START SessionContext Setter Tests ===============
@@ -40,11 +41,9 @@ def test_session_context_setters(dummy_executor_config):
     ctx.publisher = pub
     new_config = mock.Mock()
     ctx.executor_config = new_config
-    ctx.llm_call_id = "llm-1"
     assert ctx.session_id == "r2"
     assert ctx.publisher is pub
     assert ctx.executor_config is new_config
-    assert ctx.llm_call_id == "llm-1"
 # ============ END SessionContext Setter Tests ===============
 
 # ============ START SessionContext is_active Tests ===============
@@ -73,17 +72,14 @@ def test_with_scope_pushed_creates_new_context_and_preserves_lineage(dummy_execu
         session_id="r",
         publisher=pub,
         executor_config=dummy_executor_config,
-        llm_call_id="llm-1",
     )
     new_ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.NODE, "node-1"), run_id="node-1")
     assert isinstance(new_ctx, SessionContext)
-    assert new_ctx.current_node_id == "node-1"
+    assert new_ctx.current_node_id.id == "node-1"
     assert new_ctx.run_id == "node-1"
     assert new_ctx.publisher is pub
     assert new_ctx.session_id == ctx.session_id
     assert new_ctx.executor_config is ctx.executor_config
-    # llm_call_id is carried through the scope push, not reset
-    assert new_ctx.llm_call_id == "llm-1"
     # original context is untouched (immutable push)
     assert ctx.current_node_id is None
     assert ctx.run_id is None
@@ -104,13 +100,13 @@ def test_current_node_id_walks_past_middleware_entry(dummy_executor_config):
     ctx = SessionContext(session_id="r", publisher=None, executor_config=dummy_executor_config)
     ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.NODE, "node-1"))
     ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.MIDDLEWARE, "mw-1", name="guard"))
-    assert ctx.current_node_id == "node-1"
-    assert ctx.current_middleware_id == "mw-1"
+    assert ctx.current_node_id.id == "node-1"
+    assert ctx.current_middleware_id.id == "mw-1"
 
 
 def test_current_node_id_prefers_node_body_over_stale_node(dummy_executor_config):
     ctx = SessionContext(session_id="r", publisher=None, executor_config=dummy_executor_config)
     ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.NODE, "node-1"))
     ctx = ctx.with_scope_pushed(ScopeEntry(ScopeKind.NODE_BODY, "node-1"))
-    assert ctx.current_node_id == "node-1"
+    assert ctx.current_node_id.id == "node-1"
 # ============ END SessionContext with_scope_pushed Tests ===============


### PR DESCRIPTION
## Summary

Move the LLM-call identifier off the ad-hoc flat `SessionContext.llm_call_id`
field and onto the scope chain as a new `ScopeKind.LLM` entry, so all four scope
kinds (node, node-body, middleware, llm) are tracked by the **one** immutable
`ScopeLink` mechanism.

`enter_llm_call()` now pushes/pops a `ScopeEntry` exactly
like `enter_middleware()`, and `get_llm_call_id()` resolves it with the same
chain walk as the other id accessors. 

`get_llm_call_id()` keeps its signature. This unblocks the upcoming event parent-resolution work: a single chain walk can
now resolve every parent kind uniformly instead of special-casing LLM.

Part of the observability event work (#1138, design #1264).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

- **Behavior nuance (intended):** because a node's tool calls are dispatched
  *after* the LLM call returns, the LLM scope entry is already popped at
  child-dispatch time, so children still do not inherit an `llm_call_id`. This
  invariant is now covered by `test_captured_scope_after_llm_call_carries_no_llm_id`
  (replaces the old `test_restore_scope_does_not_carry_llm_call_id`, whose
  "flat field is always reset" premise no longer applies).
- The base branch has **pre-existing, unrelated** red tests and one file that
  fails collection (`built_nodes/function/test_function.py`), so a full
  `pytest tests` / `ruff check .` is not clean repo-wide independent of this PR.
  This PR introduces no new failures (verified: the failure set for
  execution + middlewares is identical with and without these changes).
