### PR TITLE
1144 middleware observability

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from railtracks.built_nodes._types import LLM_CALL
 from railtracks.events.middleware import (
-    MiddlewareModelInvocationEvent,
+    MiddlewareModelOutputFailureEvent,
     MiddlewareModelOutputInvocationEvent,
     MiddlewareModelOutputResponseEvent,
 )
@@ -39,10 +39,8 @@ def after_llm(fn: Callable[[Response], Response | Awaitable[Response]]):
         try:
             response = await llm_call(message_history, schema, tools)
         except Exception as e:
-            event = MiddlewareModelInvocationEvent(
-                message_history=message_history,
-                schema=schema,
-                tools=tools,
+            event = MiddlewareModelOutputFailureEvent(
+                exception=e,
             )
             await pipe(event)
             raise e

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -3,6 +3,12 @@ from typing import Awaitable, Callable
 from pydantic import BaseModel
 
 from railtracks.built_nodes._types import LLM_CALL
+from railtracks.events.middleware import (
+    MiddlewareModelInvocationEvent,
+    MiddlewareModelOutputInvocationEvent,
+    MiddlewareModelOutputResponseEvent,
+)
+from railtracks.events.send import pipe
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool
@@ -30,7 +36,30 @@ def after_llm(fn: Callable[[Response], Response | Awaitable[Response]]):
         schema: type[BaseModel] | None,
         tools: list[Tool] | None,
     ):
-        response = await llm_call(message_history, schema, tools)
-        return await unpack_async_sync(fn(response))
+        try:
+            response = await llm_call(message_history, schema, tools)
+        except Exception as e:
+            event = MiddlewareModelInvocationEvent(
+                message_history=message_history,
+                schema=schema,
+                tools=tools,
+            )
+            await pipe(event)
+            raise e
+
+        input_event = MiddlewareModelOutputInvocationEvent(
+            response=response,
+        )
+        await pipe(input_event)
+
+        response = await unpack_async_sync(fn(response))
+
+        output_event = MiddlewareModelOutputResponseEvent(
+            response=response,
+        )
+
+        await pipe(output_event)
+
+        return response
 
     return wrapper

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
@@ -3,6 +3,11 @@ from typing import Awaitable, Callable
 from pydantic import BaseModel
 
 from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
+from railtracks.events.middleware import (
+    MiddlewareModelInputInvocationEvent,
+    MiddlewareModelInputResponseEvent,
+)
+from railtracks.events.send import pipe
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.tools.tool import Tool
 from railtracks.utils.unpack import unpack_async_sync
@@ -36,9 +41,33 @@ def before_llm(
         schema: type[BaseModel] | None,
         tools: list[Tool] | None,
     ):
-        message_history, schema, tools = await unpack_async_sync(
-            fn(message_history, schema, tools)
+        input_event = MiddlewareModelInputInvocationEvent(
+            message_history=message_history,
+            schema=schema,
+            tools=tools,
         )
+        await pipe(input_event)
+
+        try:
+            message_history, schema, tools = await unpack_async_sync(
+                fn(message_history, schema, tools)
+            )
+        except Exception as e:
+            event = MiddlewareModelInputInvocationEvent(
+                message_history=message_history,
+                schema=schema,
+                tools=tools,
+            )
+            await pipe(event)
+            raise e
+
+        output_event = MiddlewareModelInputResponseEvent(
+            message_history=message_history,
+            schema=schema,
+            tools=tools,
+        )
+        await pipe(output_event)
+
         return await llm_call(message_history, schema, tools)
 
     return wrapper

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
@@ -2,6 +2,12 @@ from typing import Awaitable, Callable
 
 from pydantic import BaseModel
 
+from railtracks.events.middleware import (
+    MiddlewareModelFailureEvent,
+    MiddlewareModelInvocationEvent,
+    MiddlewareModelResponseEvent,
+)
+from railtracks.events.send import pipe
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool
@@ -29,6 +35,36 @@ def wrap_llm(
         return response
     ```
     """
-    wrapped = wrap_node(fn)
 
-    return wrapped
+    @wrap_node
+    async def _pipe_wrapped(
+        llm_call: LLM_CALL,
+        message_history: MessageHistory,
+        schema: type[BaseModel] | None,
+        tools: list[Tool] | None,
+    ):
+        input_event = MiddlewareModelInvocationEvent(
+            message_history=message_history,
+            schema=schema,
+            tools=tools,
+        )
+        await pipe(input_event)
+
+        try:
+            response = await fn(llm_call, message_history, schema, tools)
+        except Exception as e:
+            event = MiddlewareModelFailureEvent(
+                exception=e,
+            )
+            await pipe(event)
+            raise e
+
+        output_event = MiddlewareModelResponseEvent(
+            response=response,
+        )
+
+        await pipe(output_event)
+
+        return response
+
+    return _pipe_wrapped

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -121,7 +121,7 @@ class ModelInvoker:
 
         await pipe(
             LLMCreationEvent(
-                model_id=model.id,
+                llm_model_id=model.id,
                 model_name=model.model_name(),
                 model_provider=model.model_provider(),
             )

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -120,7 +120,7 @@ class ModelInvoker:
 
         await emit(
             LLMCreationEvent(
-                llm_model_id=model.id,
+                llm_id=model.id,
                 model_name=model.model_name(),
                 model_provider=model.model_provider(),
             )

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -129,6 +129,30 @@ def get_parent_id() -> str | None:
     )
 
 
+def get_node_or_llm() -> str | LLMCallData | None:
+    context = safe_get_runner_context()
+
+    scope = context.session_context.scope
+
+    result = scope.find(lambda e: e.kind in [ScopeKind.NODE, ScopeKind.LLM])
+
+    if result is None:
+        return None
+
+    if result.kind == ScopeKind.NODE:
+        return result.id
+
+    if result.kind == ScopeKind.LLM:
+        type_id = result.type_id
+
+        # defensive check
+        assert type_id is not None, (
+            "LLM call ID should have a type_id set in the context."
+        )
+
+        return LLMCallData(result.id, type_id)
+
+
 LLMCallData = NamedTuple("LLMCallData", [("call_id", str), ("type_id", str)])
 
 
@@ -160,13 +184,39 @@ MiddlewareCallData = NamedTuple(
 )
 
 
+def get_parent_middleware_id() -> MiddlewareCallData | None:
+    """
+    Get the id of the currently active middleware invocation (walks up the
+    scope chain to the nearest middleware entry).
+
+    Returns:
+        MiddlewareCallData | None: The middleware id, or None if no middleware is currently active.
+
+    Raises:
+        ContextError: If the global variables have not been registered.
+    """
+    context = safe_get_runner_context()
+    if context.session_context.parent_middleware_id is None:
+        return None
+
+    call_id = context.session_context.parent_middleware_id.id
+    type_id = context.session_context.parent_middleware_id.type_id
+
+    # defensive check
+    assert type_id is not None, (
+        "Middleware ID should have a type_id set in the context."
+    )
+
+    return MiddlewareCallData(call_id, type_id)
+
+
 def get_middleware_id() -> MiddlewareCallData | None:
     """
     Get the id of the currently active middleware invocation (walks up the
     scope chain to the nearest middleware entry).
 
     Returns:
-        str | None: The middleware id, or None if no middleware is currently active.
+        MiddlewareCallData | None: The middleware id, or None if no middleware is currently active.
 
     Raises:
         ContextError: If the global variables have not been registered.

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -160,32 +160,6 @@ MiddlewareCallData = NamedTuple(
 )
 
 
-def get_parent_middleware_id() -> MiddlewareCallData | None:
-    """
-    Get the id of the currently active middleware invocation (walks up the
-    scope chain to the nearest middleware entry).
-
-    Returns:
-        MiddlewareCallData | None: The middleware id, or None if no middleware is currently active.
-
-    Raises:
-        ContextError: If the global variables have not been registered.
-    """
-    context = safe_get_runner_context()
-    if context.session_context.parent_middleware_id is None:
-        return None
-
-    call_id = context.session_context.parent_middleware_id.id
-    type_id = context.session_context.parent_middleware_id.type_id
-
-    # defensive check
-    assert type_id is not None, (
-        "Middleware ID should have a type_id set in the context."
-    )
-
-    return MiddlewareCallData(call_id, type_id)
-
-
 def get_middleware_id() -> MiddlewareCallData | None:
     """
     Get the id of the currently active middleware invocation (walks up the

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -129,30 +129,6 @@ def get_parent_id() -> str | None:
     )
 
 
-def get_node_or_llm() -> str | LLMCallData | None:
-    context = safe_get_runner_context()
-
-    scope = context.session_context.scope
-
-    result = scope.find(lambda e: e.kind in [ScopeKind.NODE, ScopeKind.LLM])
-
-    if result is None:
-        return None
-
-    if result.kind == ScopeKind.NODE:
-        return result.id
-
-    if result.kind == ScopeKind.LLM:
-        type_id = result.type_id
-
-        # defensive check
-        assert type_id is not None, (
-            "LLM call ID should have a type_id set in the context."
-        )
-
-        return LLMCallData(result.id, type_id)
-
-
 LLMCallData = NamedTuple("LLMCallData", [("call_id", str), ("type_id", str)])
 
 

--- a/packages/railtracks/src/railtracks/context/scope_link.py
+++ b/packages/railtracks/src/railtracks/context/scope_link.py
@@ -16,10 +16,15 @@ class ScopeLink(Generic[T]):
     def pushed(self, value: T) -> "ScopeLink[T]":
         return ScopeLink(value=value, parent=self)
 
-    def find(self, predicate: Callable[[T], bool]) -> T | None:
+    def find(self, predicate: Callable[[T], bool], skip: int = 0) -> T | None:
         link: ScopeLink[T] | None = self
+        counter = 0
+
         while link is not None:
             if predicate(link.value):
-                return link.value
+                counter += 1
+                if counter > skip:
+                    return link.value
+
             link = link.parent
         return None

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -43,10 +43,10 @@ class SessionContext:
         session_id: str,
         run_id: str | None = None,
         publisher: RTPublisher | None = None,
-        scope: ScopeLink[ScopeEntry] | None = None,
+        scope: ScopeLink[ScopeEntry],
         executor_config: ExecutorConfig,
     ):
-        self._scope: ScopeLink[ScopeEntry] | None = scope
+        self._scope: ScopeLink[ScopeEntry] = scope
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
@@ -67,7 +67,7 @@ class SessionContext:
         self._executor_config = value
 
     @property
-    def scope(self) -> ScopeLink[ScopeEntry] | None:
+    def scope(self) -> ScopeLink[ScopeEntry]:
         return self._scope
 
     @property
@@ -85,6 +85,24 @@ class SessionContext:
             return None
         entry = self._scope.find(lambda e: e.kind is ScopeKind.MIDDLEWARE)
         return entry
+
+    @property
+    def parent_middleware_id(self) -> ScopeEntry | None:
+        if self._scope is None:
+            return None
+
+        scope_entry = self._scope
+
+        # note parent middleware must be the parent according to our usage of the stack.
+        parent_entry = scope_entry.parent
+
+        if parent_entry is None:
+            return None
+
+        if parent_entry.value.kind == ScopeKind.MIDDLEWARE:
+            return parent_entry.value
+
+        return None
 
     @property
     def current_llm_call_id(self) -> ScopeEntry | None:

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -43,10 +43,10 @@ class SessionContext:
         session_id: str,
         run_id: str | None = None,
         publisher: RTPublisher | None = None,
-        scope: ScopeLink[ScopeEntry],
+        scope: ScopeLink[ScopeEntry] | None = None,
         executor_config: ExecutorConfig,
     ):
-        self._scope: ScopeLink[ScopeEntry] = scope
+        self._scope: ScopeLink[ScopeEntry] | None = scope
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
@@ -67,7 +67,7 @@ class SessionContext:
         self._executor_config = value
 
     @property
-    def scope(self) -> ScopeLink[ScopeEntry]:
+    def scope(self) -> ScopeLink[ScopeEntry] | None:
         return self._scope
 
     @property

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -87,24 +87,6 @@ class SessionContext:
         return entry
 
     @property
-    def parent_middleware_id(self) -> ScopeEntry | None:
-        if self._scope is None:
-            return None
-
-        scope_entry = self._scope
-
-        # note parent middleware must be the parent according to our usage of the stack.
-        parent_entry = scope_entry.parent
-
-        if parent_entry is None:
-            return None
-
-        if parent_entry.value.kind == ScopeKind.MIDDLEWARE:
-            return parent_entry.value
-
-        return None
-
-    @property
     def current_llm_call_id(self) -> ScopeEntry | None:
         if self._scope is None:
             return None

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -38,7 +38,7 @@ class SpatialParent:
 @dataclass(frozen=True)
 class MiddlewareSpatialParent(SpatialParent):
     spatial_type: Literal["middleware"] = field(init=False, default="middleware")
-    middleware_id: str
+    middleware_type_id: str
 
 
 @dataclass(frozen=True)
@@ -53,7 +53,7 @@ class NodeAndMiddlewareSpatialParent(SpatialParent):
         init=False, default="node_and_middleware"
     )
     node_id: str
-    middleware_id: str | None
+    middleware_invoke_id: str | None
 
 
 @dataclass(frozen=True)
@@ -61,8 +61,8 @@ class LLMAndMiddlewareSpatialParent(SpatialParent):
     spatial_type: Literal["llm_and_middleware"] = field(
         init=False, default="llm_and_middleware"
     )
-    llm_id: str
-    middleware_id: str | None
+    llm_invoke_id: str
+    middleware_invoke_id: str | None
 
 
 @dataclass(frozen=True)
@@ -85,7 +85,7 @@ class NodeParent(Parent):
 @dataclass(frozen=True)
 class MiddlewareParent(Parent):
     parent_type: Literal["middleware"] = field(init=False, default="middleware")
-    middleware_id: str
+    middleware_type_id: str
     middleware_invoke_id: str
 
 

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -63,12 +63,6 @@ class NodeParent(Parent):
     node_id: str
 
 
-@dataclass(frozen=True)
-class MiddlewareParent(Parent):
-    middleware_id: str
-    middleware_invoke_id: str
-
-
 TSpatialParent = TypeVar("TSpatialParent", bound=SpatialParent)
 
 

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -38,7 +38,7 @@ class SpatialParent:
 @dataclass(frozen=True)
 class MiddlewareSpatialParent(SpatialParent):
     spatial_type: Literal["middleware"] = field(init=False, default="middleware")
-    middleware_type_id: str
+    middleware_invoke_id: str
 
 
 @dataclass(frozen=True)

--- a/packages/railtracks/src/railtracks/events/_resolve.py
+++ b/packages/railtracks/src/railtracks/events/_resolve.py
@@ -42,7 +42,7 @@ def node_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
 
     # 3. the node is called by a middleware
     if parent.value.kind is ScopeKind.MIDDLEWARE:
-        return MiddlewareSpatialParent(middleware_type_id=parent.value.id)
+        return MiddlewareSpatialParent(middleware_invoke_id=parent.value.id)
 
     # 2 levels up please
     node_link = scope.find_link(lambda e: e.kind is ScopeKind.NODE)

--- a/packages/railtracks/src/railtracks/events/_resolve.py
+++ b/packages/railtracks/src/railtracks/events/_resolve.py
@@ -6,6 +6,7 @@ from railtracks.events._base import (
     LLMAndMiddlewareSpatialParent,
     LLMParent,
     MiddlewareParent,
+    MiddlewareSpatialParent,
     NodeAndMiddlewareSpatialParent,
     NodeParent,
     NodeSpatialParent,
@@ -20,6 +21,32 @@ def node_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
     """Parent of a running node event (NodeInvocation/Response/Failure/Destruction)."""
     if scope is None:
         return NodeSpatialParent(node_id=None)
+
+    # first we need to traverse up to find the parent
+    node_link = scope.find_link(lambda e: e.kind is ScopeKind.NODE)
+
+    assert node_link is not None, (
+        "Expected a node scope entry for node spatial parent resolution"
+    )
+
+
+
+    parent = node_link.parent
+
+    # there are 3 cases here
+    # 1. This is the top level node, so it has no parent
+    if parent is None:
+        return NodeSpatialParent(node_id=None)
+
+    # 2. the node is called by another node
+    if parent.value.kind is ScopeKind.NODE_BODY:
+        return NodeSpatialParent(node_id=parent.value.id)
+
+    # 3. the node is called by a middleware
+    if parent.value.kind is ScopeKind.MIDDLEWARE:
+        return MiddlewareSpatialParent(middleware_type_id=parent.value.id)
+    
+
 
     # 2 levels up please
     node_link = scope.find_link(lambda e: e.kind is ScopeKind.NODE)
@@ -78,13 +105,14 @@ def llm_parent(scope: ScopeLink[ScopeEntry] | None):
         llm_invoke_id=call_id,
     )
 
+
 def middleware_parent(scope: ScopeLink[ScopeEntry] | None):
     assert scope is not None, "Expected a scope chain for middleware parent resolution"
     assert scope.value.kind == ScopeKind.MIDDLEWARE, "Expected a middleware scope entry for middleware parent resolution"
     assert scope.value.type_id is not None, "Expected a middleware scope entry with a type_id"
 
     return MiddlewareParent(
-        middleware_id=scope.value.type_id,
+        middleware_type_id=scope.value.type_id,
         middleware_invoke_id=scope.value.id,
     )
 
@@ -107,29 +135,28 @@ def middleware_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
         """Parent of a regular middleware event — the enclosing node (+ intervening middleware)."""
         assert scope is not None, "Expected a scope chain for model middleware spatial parent resolution"
         link = scope.parent
-    
+
         # Skip the first entry
-        middleware_id: str | None = None
-    
+        middleware_invoke_id: str | None = None
+
         while True:
             assert link is not None, "Expected a scope chain for model middleware spatial parent resolution"
-            if link.value.kind == ScopeKind.MIDDLEWARE:
-                middleware_id = link.value.type_id
-
+            if link.value.kind == ScopeKind.MIDDLEWARE and middleware_invoke_id is None:
+                middleware_invoke_id = link.value.id
+                
             if link.value.kind == ScopeKind.NODE:
                 return NodeAndMiddlewareSpatialParent(
                     node_id=link.value.id,
-                    middleware_id=middleware_id,
+                    middleware_invoke_id=middleware_invoke_id,
                 )
-    
+
             if link.value.kind == ScopeKind.LLM:
-                
+
                 return LLMAndMiddlewareSpatialParent(
-                    llm_id=link.value.id,
-                    middleware_id=middleware_id,
+                    llm_invoke_id=link.value.id,
+                    middleware_invoke_id=middleware_invoke_id,
                 )
 
             assert not link.value.kind == ScopeKind.NODE_BODY, "Unexpected NODE_BODY scope entry for model middleware spatial parent resolution"
 
             link = link.parent
-                

--- a/packages/railtracks/src/railtracks/events/_resolve.py
+++ b/packages/railtracks/src/railtracks/events/_resolve.py
@@ -29,8 +29,6 @@ def node_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
         "Expected a node scope entry for node spatial parent resolution"
     )
 
-
-
     parent = node_link.parent
 
     # there are 3 cases here
@@ -45,8 +43,6 @@ def node_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
     # 3. the node is called by a middleware
     if parent.value.kind is ScopeKind.MIDDLEWARE:
         return MiddlewareSpatialParent(middleware_type_id=parent.value.id)
-    
-
 
     # 2 levels up please
     node_link = scope.find_link(lambda e: e.kind is ScopeKind.NODE)
@@ -108,55 +104,70 @@ def llm_parent(scope: ScopeLink[ScopeEntry] | None):
 
 def middleware_parent(scope: ScopeLink[ScopeEntry] | None):
     assert scope is not None, "Expected a scope chain for middleware parent resolution"
-    assert scope.value.kind == ScopeKind.MIDDLEWARE, "Expected a middleware scope entry for middleware parent resolution"
-    assert scope.value.type_id is not None, "Expected a middleware scope entry with a type_id"
+    assert scope.value.kind == ScopeKind.MIDDLEWARE, (
+        "Expected a middleware scope entry for middleware parent resolution"
+    )
+    assert scope.value.type_id is not None, (
+        "Expected a middleware scope entry with a type_id"
+    )
 
     return MiddlewareParent(
         middleware_type_id=scope.value.type_id,
         middleware_invoke_id=scope.value.id,
     )
 
+
 def model_middleware_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
     """Parent of a model middleware event — the enclosing node (+ intervening middleware)."""
     result = middleware_spatial_parent(scope)
 
-    assert isinstance(result, LLMAndMiddlewareSpatialParent), "Expected a model middleware spatial parent to be an LLMAndMiddlewareSpatialParent"
+    assert isinstance(result, LLMAndMiddlewareSpatialParent), (
+        "Expected a model middleware spatial parent to be an LLMAndMiddlewareSpatialParent"
+    )
     return result
+
 
 def regular_middleware_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
     """Parent of a regular middleware event — the enclosing node (+ intervening middleware)."""
     result = middleware_spatial_parent(scope)
 
-    assert isinstance(result, NodeAndMiddlewareSpatialParent), "Expected a regular middleware spatial parent to be a NodeAndMiddlewareSpatialParent"
+    assert isinstance(result, NodeAndMiddlewareSpatialParent), (
+        "Expected a regular middleware spatial parent to be a NodeAndMiddlewareSpatialParent"
+    )
     return result
 
 
 def middleware_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
-        """Parent of a regular middleware event — the enclosing node (+ intervening middleware)."""
-        assert scope is not None, "Expected a scope chain for model middleware spatial parent resolution"
-        link = scope.parent
+    """Parent of a regular middleware event — the enclosing node (+ intervening middleware)."""
+    assert scope is not None, (
+        "Expected a scope chain for model middleware spatial parent resolution"
+    )
+    link = scope.parent
 
-        # Skip the first entry
-        middleware_invoke_id: str | None = None
+    # Skip the first entry
+    middleware_invoke_id: str | None = None
 
-        while True:
-            assert link is not None, "Expected a scope chain for model middleware spatial parent resolution"
-            if link.value.kind == ScopeKind.MIDDLEWARE and middleware_invoke_id is None:
-                middleware_invoke_id = link.value.id
-                
-            if link.value.kind == ScopeKind.NODE:
-                return NodeAndMiddlewareSpatialParent(
-                    node_id=link.value.id,
-                    middleware_invoke_id=middleware_invoke_id,
-                )
+    while True:
+        assert link is not None, (
+            "Expected a scope chain for model middleware spatial parent resolution"
+        )
+        if link.value.kind == ScopeKind.MIDDLEWARE and middleware_invoke_id is None:
+            middleware_invoke_id = link.value.id
 
-            if link.value.kind == ScopeKind.LLM:
+        if link.value.kind == ScopeKind.NODE:
+            return NodeAndMiddlewareSpatialParent(
+                node_id=link.value.id,
+                middleware_invoke_id=middleware_invoke_id,
+            )
 
-                return LLMAndMiddlewareSpatialParent(
-                    llm_invoke_id=link.value.id,
-                    middleware_invoke_id=middleware_invoke_id,
-                )
+        if link.value.kind == ScopeKind.LLM:
+            return LLMAndMiddlewareSpatialParent(
+                llm_invoke_id=link.value.id,
+                middleware_invoke_id=middleware_invoke_id,
+            )
 
-            assert not link.value.kind == ScopeKind.NODE_BODY, "Unexpected NODE_BODY scope entry for model middleware spatial parent resolution"
+        assert not link.value.kind == ScopeKind.NODE_BODY, (
+            "Unexpected NODE_BODY scope entry for model middleware spatial parent resolution"
+        )
 
-            link = link.parent
+        link = link.parent

--- a/packages/railtracks/src/railtracks/events/_resolve.py
+++ b/packages/railtracks/src/railtracks/events/_resolve.py
@@ -31,7 +31,6 @@ def node_spatial_parent(scope: ScopeLink[ScopeEntry] | None):
 
     parent = node_link.parent
 
-    # there are 3 cases here
     # 1. This is the top level node, so it has no parent
     if parent is None:
         return NodeSpatialParent(node_id=None)

--- a/packages/railtracks/src/railtracks/events/llm.py
+++ b/packages/railtracks/src/railtracks/events/llm.py
@@ -28,7 +28,7 @@ class LLMMessageBase(ParentEventBase[NodeSpatialParent, LLMParent]):
 
 @dataclass(kw_only=True)
 class LLMCreationEvent(CreationEventBase):
-    model_id: str
+    llm_model_id: str
     model_provider: ModelProvider
     model_name: str
 

--- a/packages/railtracks/src/railtracks/events/llm.py
+++ b/packages/railtracks/src/railtracks/events/llm.py
@@ -28,7 +28,7 @@ class LLMMessageBase(ParentEventBase[NodeSpatialParent, LLMParent]):
 
 @dataclass(kw_only=True)
 class LLMCreationEvent(CreationEventBase):
-    llm_model_id: str
+    llm_id: str
     model_provider: ModelProvider
     model_name: str
 

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -1,0 +1,226 @@
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+from railtracks.events._base import (
+    UNSET,
+    LLMSpatialParent,
+    NodeSpatialParent,
+    Parent,
+    SessionEventBase,
+    Unset,
+)
+from railtracks.guardrails.core.decision import GuardrailDecision
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.message import Message
+from railtracks.llm.response import Response
+from railtracks.llm.tools.tool import Tool
+
+
+@dataclass(frozen=True)
+class MiddlewareParent(Parent):
+    middleware_id: str
+    middleware_invoke_id: str
+
+
+@dataclass(kw_only=True)
+class MiddlewareCreationEvent:
+    middleware_id: str
+    middleware_name: str
+
+
+@dataclass(kw_only=True)
+class MiddlewareEventBase(SessionEventBase[NodeSpatialParent | LLMSpatialParent]):
+    parent: MiddlewareParent | Unset = UNSET
+    name: str
+
+    def verify(self) -> None:
+        super().verify()
+        assert self.parent != UNSET, (
+            "Parent ID should be resolved before publishing the event."
+        )
+
+
+@dataclass(kw_only=True)
+class MiddlewareRegularEventBase(SessionEventBase[NodeSpatialParent]):
+    pass
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelEventBase(SessionEventBase[LLMSpatialParent]):
+    pass
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelInputTypesBase(MiddlewareModelEventBase):
+    message_history: MessageHistory
+    tools: list[Tool] | None
+    schema: type[BaseModel] | None
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelInputInvocationEvent(MiddlewareModelInputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.model.input.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelInputResponseEvent(MiddlewareModelInputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.model.input.response"
+
+
+## Middleware Model Guardrails input (invocation and response)
+@dataclass(kw_only=True)
+class MiddlewareGuardInputInvocationEvent(MiddlewareModelEventBase):
+    message_history: MessageHistory
+
+    def event_type(self) -> str:
+        return "middleware.guard.input.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareGuardInputResponseEvent(MiddlewareModelEventBase):
+    decision: GuardrailDecision
+    message_history: MessageHistory
+
+    def event_type(self) -> str:
+        return "middleware.guard.input.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareGuardInputFailureEvent(MiddlewareModelEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.guard.input.failure"
+
+
+## Middleware Model output (invocation and response)
+@dataclass(kw_only=True)
+class MiddlewareModelOutputTypesBase(MiddlewareModelEventBase):
+    response: Response
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelOutputInvocationEvent(MiddlewareModelOutputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.model.output.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelOutputResponseEvent(MiddlewareModelOutputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.model.output.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelOutputFailureEvent(MiddlewareModelEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.model.output.failure"
+
+
+## Middleware General output (invocation and response)
+@dataclass(kw_only=True)
+class MiddlewareOutputTypesBase(MiddlewareRegularEventBase):
+    response: Any
+
+
+@dataclass(kw_only=True)
+class MiddlewareOutputInvocationEvent(MiddlewareOutputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.regular.output.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareOutputResponseEvent(MiddlewareOutputTypesBase):
+    def event_type(self) -> str:
+        return "middleware.regular.output.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareOutputFailureEvent(MiddlewareRegularEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.regular.output.failure"
+
+
+# Middleware model guardrails (invocation and response)
+@dataclass(kw_only=True)
+class MiddlewareGuardOutputInvocationEvent(MiddlewareModelEventBase):
+    response: Message
+
+    def event_type(self) -> str:
+        return "middleware.guard.output.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareGuardOutputResponseEvent(MiddlewareModelEventBase):
+    response: Message
+    decision: GuardrailDecision
+
+    def event_type(self) -> str:
+        return "middleware.guard.output.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareGuardOutputFailureEvent(MiddlewareModelEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.guard.output.failure"
+
+
+# General middleware (invocation and response pair)
+@dataclass(kw_only=True)
+class MiddlewareInvocationEvent(MiddlewareEventBase):
+    args: tuple[Any, ...]
+    kwargs: dict[str, Any]
+
+    def event_type(self) -> str:
+        return "middleware.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareResponseEvent(MiddlewareEventBase):
+    response: Any
+
+    def event_type(self) -> str:
+        return "middleware.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareFailureEvent(MiddlewareEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.failure"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelInvocationEvent(MiddlewareModelEventBase):
+    message_history: MessageHistory
+    tools: list[Tool] | None
+    schema: type[BaseModel] | None
+
+    def event_type(self) -> str:
+        return "middleware.model.invocation"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelResponseEvent(MiddlewareModelEventBase):
+    response: Response
+
+    def event_type(self) -> str:
+        return "middleware.model.response"
+
+
+@dataclass(kw_only=True)
+class MiddlewareModelFailureEvent(MiddlewareModelEventBase):
+    exception: Exception
+
+    def event_type(self) -> str:
+        return "middleware.model.failure"

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel
 
@@ -10,16 +10,16 @@ from railtracks.events._base import (
     CreationEventBase,
     LLMAndMiddlewareSpatialParent,
     MiddlewareParent,
-    NoSpatialParent,
     NodeAndMiddlewareSpatialParent,
-    NodeSpatialParent,
-    Parent,
     ParentEventBase,
-    SessionEventBase,
     Unset,
 )
-from railtracks.events._resolve import middleware_parent, middleware_spatial_parent, model_middleware_spatial_parent, regular_middleware_spatial_parent, regular_middleware_spatial_parent
-from yaml import Node
+from railtracks.events._resolve import (
+    middleware_parent,
+    middleware_spatial_parent,
+    model_middleware_spatial_parent,
+    regular_middleware_spatial_parent,
+)
 
 if TYPE_CHECKING:
     from railtracks.guardrails.core.decision import GuardrailDecision
@@ -40,6 +40,7 @@ class MiddlewareCreationEvent(CreationEventBase):
 
 _T = TypeVar("_T", bound=NodeAndMiddlewareSpatialParent | LLMAndMiddlewareSpatialParent)
 
+
 @dataclass(kw_only=True)
 class MiddlewareEventBase(ParentEventBase[_T, MiddlewareParent], Generic[_T]):
     parent: MiddlewareParent | Unset = UNSET
@@ -53,8 +54,6 @@ class MiddlewareEventBase(ParentEventBase[_T, MiddlewareParent], Generic[_T]):
     def _get_parent(self, scope) -> MiddlewareParent:
         return middleware_parent(scope)
 
-    
-
 
 @dataclass(kw_only=True)
 class MiddlewareRegularEventBase(MiddlewareEventBase[NodeAndMiddlewareSpatialParent]):
@@ -67,12 +66,15 @@ class MiddlewareModelEventBase(MiddlewareEventBase[LLMAndMiddlewareSpatialParent
     def _get_spatial_parent(self, scope):
         return model_middleware_spatial_parent(scope)
 
+
 @dataclass(kw_only=True)
-class MiddlewareGeneralEventBase(MiddlewareEventBase[NodeAndMiddlewareSpatialParent | LLMAndMiddlewareSpatialParent]):
+class MiddlewareGeneralEventBase(
+    MiddlewareEventBase[NodeAndMiddlewareSpatialParent | LLMAndMiddlewareSpatialParent]
+):
     def _get_spatial_parent(self, scope):
-            result = middleware_spatial_parent(scope)
-           
-            return result
+        result = middleware_spatial_parent(scope)
+
+        return result
 
 
 @dataclass(kw_only=True)

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -1,38 +1,48 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel
+
 from railtracks.events._base import (
     UNSET,
     LLMSpatialParent,
+    NoSpatialParent,
     NodeSpatialParent,
     Parent,
     SessionEventBase,
     Unset,
 )
-from railtracks.guardrails.core.decision import GuardrailDecision
-from railtracks.llm.history import MessageHistory
-from railtracks.llm.message import Message
-from railtracks.llm.response import Response
-from railtracks.llm.tools.tool import Tool
+
+if TYPE_CHECKING:
+    from railtracks.guardrails.core.decision import GuardrailDecision
+    from railtracks.llm.history import MessageHistory
+    from railtracks.llm.message import Message
+    from railtracks.llm.response import Response
+    from railtracks.llm.tools.tool import Tool
 
 
 @dataclass(frozen=True)
 class MiddlewareParent(Parent):
-    middleware_id: str
+    middleware_type_id: str
     middleware_invoke_id: str
 
 
 @dataclass(kw_only=True)
-class MiddlewareCreationEvent:
-    middleware_id: str
+class MiddlewareCreationEvent(SessionEventBase[NoSpatialParent]):
+    middleware_type_id: str
     middleware_name: str
 
+    def event_type(self) -> str:
+        return "middleware.creation"
+
+
+_T = TypeVar("_T", bound=NodeSpatialParent | LLMSpatialParent)
 
 @dataclass(kw_only=True)
-class MiddlewareEventBase(SessionEventBase[NodeSpatialParent | LLMSpatialParent]):
+class MiddlewareEventBase(SessionEventBase[_T], Generic[_T]):
     parent: MiddlewareParent | Unset = UNSET
-    name: str
 
     def verify(self) -> None:
         super().verify()
@@ -40,14 +50,13 @@ class MiddlewareEventBase(SessionEventBase[NodeSpatialParent | LLMSpatialParent]
             "Parent ID should be resolved before publishing the event."
         )
 
-
 @dataclass(kw_only=True)
-class MiddlewareRegularEventBase(SessionEventBase[NodeSpatialParent]):
+class MiddlewareRegularEventBase(MiddlewareEventBase[NodeSpatialParent]):
     pass
 
 
 @dataclass(kw_only=True)
-class MiddlewareModelEventBase(SessionEventBase[LLMSpatialParent]):
+class MiddlewareModelEventBase(MiddlewareEventBase[LLMSpatialParent]):
     pass
 
 

--- a/packages/railtracks/src/railtracks/events/node.py
+++ b/packages/railtracks/src/railtracks/events/node.py
@@ -15,9 +15,10 @@ from railtracks.events._base import (
 from railtracks.events._resolve import node_parent, node_spatial_parent
 
 
-
 @dataclass(kw_only=True)
-class NodeEventBase(ParentEventBase[NodeSpatialParent | MiddlewareSpatialParent, NodeParent]):
+class NodeEventBase(
+    ParentEventBase[NodeSpatialParent | MiddlewareSpatialParent, NodeParent]
+):
     def _get_spatial_parent(self, scope: ScopeLink[ScopeEntry] | None):
         return node_spatial_parent(scope)
 

--- a/packages/railtracks/src/railtracks/events/node.py
+++ b/packages/railtracks/src/railtracks/events/node.py
@@ -7,6 +7,7 @@ from railtracks.context.scope_link import ScopeLink
 from railtracks.context.session_context import ScopeEntry
 from railtracks.events._base import (
     CreationEventBase,
+    MiddlewareSpatialParent,
     NodeParent,
     NodeSpatialParent,
     ParentEventBase,
@@ -14,8 +15,9 @@ from railtracks.events._base import (
 from railtracks.events._resolve import node_parent, node_spatial_parent
 
 
+
 @dataclass(kw_only=True)
-class NodeEventBase(ParentEventBase[NodeSpatialParent, NodeParent]):
+class NodeEventBase(ParentEventBase[NodeSpatialParent | MiddlewareSpatialParent, NodeParent]):
     def _get_spatial_parent(self, scope: ScopeLink[ScopeEntry] | None):
         return node_spatial_parent(scope)
 

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -32,8 +32,6 @@ async def pipe(
     _resolve_parent(event)
     event.verify()
 
-    print(asdict(event))
-
     await publish_event(make_session_event(event.event_type(), asdict(event)))
 
 
@@ -58,11 +56,14 @@ def _resolve_parent(event: SessionEventBase):
         spatial_parent = _get_llm_creation_parents(event)
         event.spatial_parent = spatial_parent
     elif isinstance(event, MiddlewareEventBase):
-        spatial_parent = _get_middleware_parents(event)
+        spatial_parent, parent = _get_middleware_parents(event)
         event.spatial_parent = spatial_parent
+        event.parent = parent
     elif isinstance(event, MiddlewareCreationEvent):
         spatial_parent = _get_middleware_creation_parents(event)
         event.spatial_parent = spatial_parent
+    else:
+        raise RuntimeError(f"Unknown event type {type(event)}")
 
 
 def _get_node_parent(event: SessionEventBase) -> SpatialParent:
@@ -122,7 +123,7 @@ def _get_middleware_parents(
     )
 
     actual_parent = MiddlewareParent(
-        middleware_id=middleware_item.type_id,
+        middleware_type_id=middleware_item.type_id,
         middleware_invoke_id=middleware_item.call_id,
     )
 

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -2,29 +2,11 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
-from railtracks.context.central import (
-    LLMCallData,
-    get_llm_call_id,
-    get_middleware_id,
-    get_node_or_llm,
-    get_parent_id,
-    get_parent_middleware_id,
-)
-from railtracks.events._base import (
-    UNSET,
-    NodeSpatialParent,
-    NoSpatialParent,
-)
 from railtracks.context.central import get_current_scope
 from railtracks.events._base import (
     SessionEventBase,
 )
-from railtracks.events.llm import LLMCreationEvent, LLMMessageBase
-from railtracks.events.middleware import (
-    MiddlewareCreationEvent,
-    MiddlewareEventBase,
-    MiddlewareParent,
-)
+
 from railtracks.observability.publish import publish_event
 from railtracks.observability_bridge._factory import make_session_event
 from railtracks.utils.logging.create import get_rt_logger

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -6,7 +6,6 @@ from railtracks.context.central import get_current_scope
 from railtracks.events._base import (
     SessionEventBase,
 )
-
 from railtracks.observability.publish import publish_event
 from railtracks.observability_bridge._factory import make_session_event
 from railtracks.utils.logging.create import get_rt_logger

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -1,14 +1,27 @@
 from dataclasses import asdict
 
-from railtracks.context.central import get_llm_call_id, get_parent_id
+from railtracks.context.central import (
+    LLMCallData,
+    get_llm_call_id,
+    get_middleware_id,
+    get_node_or_llm,
+    get_parent_id,
+    get_parent_middleware_id,
+)
 from railtracks.events._base import (
     UNSET,
+    LLMSpatialParent,
     NodeSpatialParent,
     NoSpatialParent,
     SessionEventBase,
     SpatialParent,
 )
 from railtracks.events.llm import LLMCreationEvent, LLMMessageBase, LLMParent
+from railtracks.events.middleware import (
+    MiddlewareCreationEvent,
+    MiddlewareEventBase,
+    MiddlewareParent,
+)
 from railtracks.observability.publish import publish_event
 from railtracks.observability_bridge._factory import make_session_event
 
@@ -44,6 +57,12 @@ def _resolve_parent(event: SessionEventBase):
     elif isinstance(event, LLMCreationEvent):
         spatial_parent = _get_llm_creation_parents(event)
         event.spatial_parent = spatial_parent
+    elif isinstance(event, MiddlewareEventBase):
+        spatial_parent = _get_middleware_parents(event)
+        event.spatial_parent = spatial_parent
+    elif isinstance(event, MiddlewareCreationEvent):
+        spatial_parent = _get_middleware_creation_parents(event)
+        event.spatial_parent = spatial_parent
 
 
 def _get_node_parent(event: SessionEventBase) -> SpatialParent:
@@ -75,4 +94,40 @@ def _get_llm_parents(event: LLMMessageBase) -> tuple[NodeSpatialParent, LLMParen
 
 
 def _get_llm_creation_parents(event: LLMCreationEvent) -> NoSpatialParent:
+    return NoSpatialParent()
+
+
+def _get_middleware_parents(
+    event: MiddlewareEventBase,
+) -> tuple[NodeSpatialParent | LLMSpatialParent, MiddlewareParent]:
+    parent = get_node_or_llm()
+    parent_middleware = get_parent_middleware_id()
+
+    middleware_id = parent_middleware.type_id if parent_middleware is not None else None
+
+    assert parent is not None, (
+        "Middleware must be called within a node or LLM context when publishing a middleware event."
+    )
+
+    p_link: NodeSpatialParent | LLMSpatialParent
+    if isinstance(parent, LLMCallData):
+        p_link = LLMSpatialParent(llm_id=parent.type_id, middleware_id=middleware_id)
+    else:
+        p_link = NodeSpatialParent(node_id=parent, middleware_id=middleware_id)
+
+    middleware_item = get_middleware_id()
+
+    assert middleware_item is not None, (
+        "Middleware ID should be set in the context when publishing a middleware event."
+    )
+
+    actual_parent = MiddlewareParent(
+        middleware_id=middleware_item.type_id,
+        middleware_invoke_id=middleware_item.call_id,
+    )
+
+    return p_link, actual_parent
+
+
+def _get_middleware_creation_parents(event: MiddlewareCreationEvent) -> NoSpatialParent:
     return NoSpatialParent()

--- a/packages/railtracks/src/railtracks/guardrails/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/__init__.py
@@ -4,12 +4,11 @@ from .core import (
     GuardrailBlockedError,
     GuardrailDecision,
     GuardrailTrace,
-    InputGuard,
     LLMGuardrailEvent,
     LLMGuardrailPhase,
-    OutputGuard,
 )
 from .llm.decorators import input_guard, output_guard
+from .llm.concrete import InputGuard, OutputGuard
 
 # Primitives only.
 __all__ = [

--- a/packages/railtracks/src/railtracks/guardrails/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/__init__.py
@@ -7,8 +7,8 @@ from .core import (
     LLMGuardrailEvent,
     LLMGuardrailPhase,
 )
-from .llm.decorators import input_guard, output_guard
 from .llm.concrete import InputGuard, OutputGuard
+from .llm.decorators import input_guard, output_guard
 
 # Primitives only.
 __all__ = [

--- a/packages/railtracks/src/railtracks/guardrails/core/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/__init__.py
@@ -1,7 +1,4 @@
-from ..llm.concrete import (
-    InputGuard,
-    OutputGuard,
-)
+
 from .decision import GuardrailAction, GuardrailDecision
 from .errors import GuardrailBlockedError
 from .event import LLMGuardrailEvent, LLMGuardrailPhase
@@ -12,8 +9,6 @@ __all__ = [
     "GuardrailDecision",
     "GuardrailBlockedError",
     "GuardrailTrace",
-    "InputGuard",
-    "OutputGuard",
     "LLMGuardrailEvent",
     "LLMGuardrailPhase",
 ]

--- a/packages/railtracks/src/railtracks/guardrails/core/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/__init__.py
@@ -1,4 +1,3 @@
-
 from .decision import GuardrailAction, GuardrailDecision
 from .errors import GuardrailBlockedError
 from .event import LLMGuardrailEvent, LLMGuardrailPhase

--- a/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
@@ -13,7 +13,9 @@ from railtracks.events.middleware import (
     MiddlewareGuardInputFailureEvent,
     MiddlewareGuardInputInvocationEvent,
     MiddlewareGuardInputResponseEvent,
+    MiddlewareGuardOutputFailureEvent,
     MiddlewareGuardOutputInvocationEvent,
+    MiddlewareGuardOutputResponseEvent,
 )
 from railtracks.events.send import pipe
 from railtracks.guardrails.llm.llm_guard import BaseLLMGuardrail
@@ -208,15 +210,15 @@ class OutputGuard(BaseLLMGuardrail[Message]):
         try:
             new_message, traces, decision = self.run(event=event, value=result.message)
         except Exception as e:
-            failure_event = MiddlewareGuardInputFailureEvent(
+            failure_event = MiddlewareGuardOutputFailureEvent(
                 exception=e,
             )
             await pipe(failure_event)
             raise e
 
-        output_event = MiddlewareGuardInputResponseEvent(
+        output_event = MiddlewareGuardOutputResponseEvent(
             decision=decision,
-            message_history=MessageHistory([new_message]),
+            response=new_message,
         )
         await pipe(output_event)
 

--- a/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
@@ -9,6 +9,13 @@ from typing import (
 
 from pydantic import BaseModel
 
+from railtracks.events.middleware import (
+    MiddlewareGuardInputFailureEvent,
+    MiddlewareGuardInputInvocationEvent,
+    MiddlewareGuardInputResponseEvent,
+    MiddlewareGuardOutputInvocationEvent,
+)
+from railtracks.events.send import pipe
 from railtracks.guardrails.llm.llm_guard import BaseLLMGuardrail
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.message import AssistantMessage, Message
@@ -42,12 +49,12 @@ class InputGuard(BaseLLMGuardrail[MessageHistory]):
         tools: list[Tool] | None,
     ):
         """Run this guard on the message history, then call onward with the result."""
-        message_history, schema, tools = self._input_wrapper(
+        message_history, schema, tools = await self._input_wrapper(
             message_history, schema, tools
         )
         return await call(message_history, schema, tools)
 
-    def _input_wrapper(
+    async def _input_wrapper(
         self,
         message_history: MessageHistory,
         schema: type[BaseModel] | None,
@@ -61,9 +68,30 @@ class InputGuard(BaseLLMGuardrail[MessageHistory]):
             node_uuid=node_uuid,
             run_id=run_id,
         )
+        input_event = MiddlewareGuardInputInvocationEvent(
+            message_history=message_history,
+        )
 
-        new_messages, traces, decision = self.run(event=event, value=message_history)
-        self._record_guard_traces(traces)
+        await pipe(input_event)
+
+        try:
+            new_messages, traces, decision = self.run(
+                event=event, value=message_history
+            )
+        except Exception as e:
+            failure_event = MiddlewareGuardInputFailureEvent(
+                exception=e,
+            )
+            await pipe(failure_event)
+            raise e
+
+        result_event = MiddlewareGuardInputResponseEvent(
+            decision=decision,
+            message_history=new_messages,
+        )
+
+        await pipe(result_event)
+
         self._raise_if_blocked(decision, traces)
 
         return new_messages, schema, tools
@@ -155,9 +183,10 @@ class OutputGuard(BaseLLMGuardrail[Message]):
         result = await call(message_history, schema, tools)
         if _is_intermediate_tool_call(result):
             return result
-        return self._output_wrapper(result=result)
 
-    def _output_wrapper(
+        return await self._output_wrapper(result=result)
+
+    async def _output_wrapper(
         self,
         result: Response,
     ):
@@ -170,8 +199,27 @@ class OutputGuard(BaseLLMGuardrail[Message]):
             node_uuid=node_uuid,
             run_id=run_id,
         )
-        new_message, traces, decision = self.run(event=event, value=result.message)
-        self._record_guard_traces(traces)
+
+        input_event = MiddlewareGuardOutputInvocationEvent(
+            response=result.message,
+        )
+
+        await pipe(input_event)
+        try:
+            new_message, traces, decision = self.run(event=event, value=result.message)
+        except Exception as e:
+            failure_event = MiddlewareGuardInputFailureEvent(
+                exception=e,
+            )
+            await pipe(failure_event)
+            raise e
+
+        output_event = MiddlewareGuardInputResponseEvent(
+            decision=decision,
+            message_history=MessageHistory([new_message]),
+        )
+        await pipe(output_event)
+
         self._raise_if_blocked(decision, traces)
 
         if new_message is result.message:

--- a/packages/railtracks/src/railtracks/guardrails/llm/llm_guard.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/llm_guard.py
@@ -93,15 +93,6 @@ class BaseLLMGuardrail(
         return get_parent_id(), get_run_id()
 
     @staticmethod
-    def _record_guard_traces(traces: list[GuardrailTrace]) -> None:
-        """The single sink for guardrail traces.
-
-        TODO: Determine the correct home for observability traces. For now, just log them at debug level.
-        """
-        for t in traces:
-            logger.debug("guardrail trace: %s", t)
-
-    @staticmethod
     def _raise_if_blocked(
         decision: GuardrailDecision | None, traces: list[GuardrailTrace]
     ) -> None:
@@ -148,7 +139,7 @@ class BaseLLMGuardrail(
         *,
         event: LLMGuardrailEvent,
         value: _TValue,
-    ) -> tuple[_TValue, list[GuardrailTrace], GuardrailDecision | None]:
+    ) -> tuple[_TValue, list[GuardrailTrace], GuardrailDecision]:
         """Run this guard once on event and value.
 
         Returns the resulting value, the traces recorded, and a blocking decision
@@ -161,12 +152,13 @@ class BaseLLMGuardrail(
             value=value,
             traces=traces,
         )
+
         if step[0] == "stop":
             return step[1], traces, step[2]
 
         _, value, event = step
 
-        return value, traces, None
+        return value, traces, GuardrailDecision.allow()
 
     def _eval_one_rail(
         self,

--- a/packages/railtracks/src/railtracks/middleware/after.py
+++ b/packages/railtracks/src/railtracks/middleware/after.py
@@ -1,6 +1,9 @@
 from typing import Awaitable, Callable, TypeVar
 
-from railtracks.events.middleware import MiddlewareOutputInvocationEvent
+from railtracks.events.middleware import (
+    MiddlewareOutputInvocationEvent,
+    MiddlewareOutputResponseEvent,
+)
 from railtracks.events.send import pipe
 from railtracks.utils.unpack import unpack_async_sync
 
@@ -29,8 +32,8 @@ def after_node(
 
         result = await unpack_async_sync(post_after_result)
 
-        output_event = MiddlewareOutputInvocationEvent(
-            response=post_after_result,
+        output_event = MiddlewareOutputResponseEvent(
+            response=result,
         )
         await pipe(output_event)
 

--- a/packages/railtracks/src/railtracks/middleware/after.py
+++ b/packages/railtracks/src/railtracks/middleware/after.py
@@ -1,5 +1,7 @@
 from typing import Awaitable, Callable, TypeVar
 
+from railtracks.events.middleware import MiddlewareOutputInvocationEvent
+from railtracks.events.send import pipe
 from railtracks.utils.unpack import unpack_async_sync
 
 from .core import wrap_node
@@ -19,8 +21,19 @@ def after_node(
     @wrap_node
     async def wrapper(call: Callable[..., Awaitable[_R]], *args, **kwargs):
         result = await call(*args, **kwargs)
+        input_event = MiddlewareOutputInvocationEvent(
+            response=result,
+        )
+        await pipe(input_event)
         post_after_result = fn(result)
 
-        return await unpack_async_sync(post_after_result)
+        result = await unpack_async_sync(post_after_result)
+
+        output_event = MiddlewareOutputInvocationEvent(
+            response=post_after_result,
+        )
+        await pipe(output_event)
+
+        return result
 
     return wrapper

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -28,11 +28,14 @@ def _scoped(
     get_scope_manager: Callable[[], ScopeManager],
 ):
     wrapped = m.wrap(inner)
-    identifier = m.id
+    middleware_type_id = m.type_id
 
     async def scoped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        # we need to ensure that the middleware creation event is sent
+        await m.start_creation_task()
+
         with get_scope_manager().enter_middleware(
-            identifier,
+            middleware_type_id,
         ):
             invocation_event = MiddlewareInvocationEvent(
                 args=args, kwargs=kwargs

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -9,6 +9,8 @@ from typing import (
     TypeVar,
 )
 
+from railtracks.events.middleware import MiddlewareFailureEvent, MiddlewareInvocationEvent, MiddlewareResponseEvent
+from railtracks.events.send import pipe
 from railtracks.middleware.core import Middleware
 from railtracks.scope_manager import ScopeManager, null_scope_manager
 
@@ -22,13 +24,31 @@ def _scoped(
     get_scope_manager: Callable[[], ScopeManager],
 ):
     wrapped = m.wrap(inner)
-    identifier = m.name
+    identifier = m.id
 
     async def scoped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         with get_scope_manager().enter_middleware(
             identifier,
         ):
-            return await wrapped(*args, **kwargs)
+            invocation_event = MiddlewareInvocationEvent(name=m.name, args=args, kwargs=kwargs)
+
+            await pipe(invocation_event)
+            try:
+                result = await wrapped(*args, **kwargs)
+                
+            except Exception as e:
+                event = MiddlewareFailureEvent(exception=e, name=m.name)
+                await pipe(event)
+                raise e
+
+            event = MiddlewareResponseEvent(
+                name=m.name,
+                response=result,
+            )
+            await pipe(event)
+
+            return result 
+                    
 
     return scoped
 

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -37,9 +37,7 @@ def _scoped(
         with get_scope_manager().enter_middleware(
             middleware_type_id,
         ):
-            invocation_event = MiddlewareInvocationEvent(
-                args=args, kwargs=kwargs
-            )
+            invocation_event = MiddlewareInvocationEvent(args=args, kwargs=kwargs)
 
             await pipe(invocation_event)
             try:

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -9,7 +9,11 @@ from typing import (
     TypeVar,
 )
 
-from railtracks.events.middleware import MiddlewareFailureEvent, MiddlewareInvocationEvent, MiddlewareResponseEvent
+from railtracks.events.middleware import (
+    MiddlewareFailureEvent,
+    MiddlewareInvocationEvent,
+    MiddlewareResponseEvent,
+)
 from railtracks.events.send import pipe
 from railtracks.middleware.core import Middleware
 from railtracks.scope_manager import ScopeManager, null_scope_manager
@@ -30,25 +34,25 @@ def _scoped(
         with get_scope_manager().enter_middleware(
             identifier,
         ):
-            invocation_event = MiddlewareInvocationEvent(name=m.name, args=args, kwargs=kwargs)
+            invocation_event = MiddlewareInvocationEvent(
+                args=args, kwargs=kwargs
+            )
 
             await pipe(invocation_event)
             try:
                 result = await wrapped(*args, **kwargs)
-                
+
             except Exception as e:
-                event = MiddlewareFailureEvent(exception=e, name=m.name)
+                event = MiddlewareFailureEvent(exception=e)
                 await pipe(event)
                 raise e
 
             event = MiddlewareResponseEvent(
-                name=m.name,
                 response=result,
             )
             await pipe(event)
 
-            return result 
-                    
+            return result
 
     return scoped
 

--- a/packages/railtracks/src/railtracks/middleware/core.py
+++ b/packages/railtracks/src/railtracks/middleware/core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import uuid
 from typing import (
@@ -62,14 +61,16 @@ class Middleware(Generic[_P, _R]):
         _require_async(fn, "Middleware function")
         self._fn = fn
         self.name = name if name is not None else fn.__name__
-        self.type_id = str(uuid.uuid4())  # identifies this middleware definition, shared by every invocation
+        self.type_id = str(
+            uuid.uuid4()
+        )  # identifies this middleware definition, shared by every invocation
 
         self._has_registered = False
-        
+
     async def start_creation_task(self):
         if self._has_registered:
             return
-        
+
         self._has_registered = True
         event = MiddlewareCreationEvent(
             middleware_type_id=self.type_id,
@@ -77,14 +78,11 @@ class Middleware(Generic[_P, _R]):
         )
         return await pipe(event)
 
-    
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
         """Compose this middleware onto ``inner``, returning a new callable with the same signature."""
         fn = self._fn
 
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            
-
             return await fn(inner, *args, **kwargs)
 
         return wrapped

--- a/packages/railtracks/src/railtracks/middleware/core.py
+++ b/packages/railtracks/src/railtracks/middleware/core.py
@@ -9,6 +9,7 @@ from typing import (
     ParamSpec,
     TypeVar,
 )
+import uuid
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -53,6 +54,7 @@ class Middleware(Generic[_P, _R]):
         _require_async(fn, "Middleware function")
         self._fn = fn
         self.name = name if name is not None else fn.__name__
+        self.id = str(uuid.uuid4())  # unique identifier for this middleware instance
 
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
         """Compose this middleware onto ``inner``, returning a new callable with the same signature."""

--- a/packages/railtracks/src/railtracks/middleware/core.py
+++ b/packages/railtracks/src/railtracks/middleware/core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
+import uuid
 from typing import (
     Awaitable,
     Callable,
@@ -9,7 +11,10 @@ from typing import (
     ParamSpec,
     TypeVar,
 )
-import uuid
+
+from railtracks.events.middleware import MiddlewareCreationEvent
+from railtracks.events.send import pipe
+from railtracks.utils.logging.create import get_rt_logger
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -26,6 +31,9 @@ def _require_async(fn: Callable, role: str) -> None:
         raise TypeError(
             f"{role} must be an async function (coroutine function): {fn!r}"
         )
+
+
+logger = get_rt_logger(__name__)
 
 
 class Middleware(Generic[_P, _R]):
@@ -56,11 +64,30 @@ class Middleware(Generic[_P, _R]):
         self.name = name if name is not None else fn.__name__
         self.id = str(uuid.uuid4())  # unique identifier for this middleware instance
 
+        self._has_registered = False
+        
+
+
+
+            
+    async def _start_creation_task(self):
+        self._has_registered = True
+        event = MiddlewareCreationEvent(
+            middleware_type_id=self.id,
+            middleware_name=self.name,
+        )
+        return await pipe(event)
+
+    
     def wrap(self, inner: Callable[_P, Awaitable[_R]]) -> Callable[_P, Awaitable[_R]]:
         """Compose this middleware onto ``inner``, returning a new callable with the same signature."""
         fn = self._fn
 
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+            # on demand registration
+            if not self._has_registered:
+                await self._start_creation_task()
+
             return await fn(inner, *args, **kwargs)
 
         return wrapped

--- a/packages/railtracks/src/railtracks/middleware/core.py
+++ b/packages/railtracks/src/railtracks/middleware/core.py
@@ -62,18 +62,17 @@ class Middleware(Generic[_P, _R]):
         _require_async(fn, "Middleware function")
         self._fn = fn
         self.name = name if name is not None else fn.__name__
-        self.id = str(uuid.uuid4())  # unique identifier for this middleware instance
+        self.type_id = str(uuid.uuid4())  # identifies this middleware definition, shared by every invocation
 
         self._has_registered = False
         
-
-
-
-            
-    async def _start_creation_task(self):
+    async def start_creation_task(self):
+        if self._has_registered:
+            return
+        
         self._has_registered = True
         event = MiddlewareCreationEvent(
-            middleware_type_id=self.id,
+            middleware_type_id=self.type_id,
             middleware_name=self.name,
         )
         return await pipe(event)
@@ -84,9 +83,7 @@ class Middleware(Generic[_P, _R]):
         fn = self._fn
 
         async def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            # on demand registration
-            if not self._has_registered:
-                await self._start_creation_task()
+            
 
             return await fn(inner, *args, **kwargs)
 

--- a/packages/railtracks/src/railtracks/observability/publish.py
+++ b/packages/railtracks/src/railtracks/observability/publish.py
@@ -8,5 +8,4 @@ from .models import Event
 
 async def publish_event(event: Event) -> None:
     """Convenience wrapper to publish an Event via the process-wide singleton Observer."""
-    print(event)
     await configure.observer.publish(event)

--- a/packages/railtracks/src/railtracks/observability/publish.py
+++ b/packages/railtracks/src/railtracks/observability/publish.py
@@ -8,4 +8,5 @@ from .models import Event
 
 async def publish_event(event: Event) -> None:
     """Convenience wrapper to publish an Event via the process-wide singleton Observer."""
+    print(event)
     await configure.observer.publish(event)

--- a/packages/railtracks/tests/unit_tests/events/test_send_resolve_parent.py
+++ b/packages/railtracks/tests/unit_tests/events/test_send_resolve_parent.py
@@ -1,0 +1,293 @@
+"""Direct unit tests for `events/send.py`'s parent-resolution logic.
+
+`pipe()` -> `_resolve_parent()` is the piece of the observability system that
+decides where a middleware/LLM event sits in the call graph: its
+`spatial_parent` (a node, an LLM call, or nothing) and its `parent` (the
+middleware/LLM invocation that owns it). It reads off the contextvars-backed
+scope stack in `context/central.py` / `context/session_context.py`.
+
+These tests drive the real `ContextVarScopeManager` (not mocks) to push actual
+scope stacks, then inspect the resolved `spatial_parent`/`parent` on the event
+object after `pipe()` mutates it in place. This is the only place these fields
+are exercised directly -- integration tests only see the effect indirectly.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass
+
+import pytest
+import railtracks.context.central as central
+from railtracks.context.central import ContextVarScopeManager
+from railtracks.events._base import (
+    LLMSpatialParent,
+    NodeSpatialParent,
+    NoSpatialParent,
+    SessionEventBase,
+)
+from railtracks.events.llm import LLMCreationEvent, LLMInvocationEvent, LLMParent
+from railtracks.events.middleware import (
+    MiddlewareCreationEvent,
+    MiddlewareInvocationEvent,
+    MiddlewareParent,
+)
+from railtracks.events.send import _resolve_parent, pipe
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.providers import ModelProvider
+from railtracks.observability import configure
+from railtracks.utils.config import ExecutorConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Every test gets a fresh scope + a started (zero-writer) observer.
+
+    `pipe()` always calls through to `publish_event`, which raises unless the
+    process-wide Observer singleton has been started -- see
+    `observability/observer.py::Observer.publish`. Zero writers is enough;
+    we only care about the mutation `_resolve_parent` performs on the event.
+    """
+    central.delete_globals()
+    configure.reset_for_tests()
+    yield
+    central.delete_globals()
+    configure.reset_for_tests()
+
+
+def _register(session_id: str = "s1") -> None:
+    central.register_globals(
+        session_id=session_id,
+        rt_publisher=None,
+        executor_config=ExecutorConfig(),
+        global_context_vars={},
+    )
+
+
+async def _pipe(event):
+    """Start the observer (idempotent, zero writers) and pipe `event`."""
+    await configure.ensure_started()
+    await pipe(event)
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Middleware events under a node
+# ---------------------------------------------------------------------------
+
+
+async def test_middleware_event_under_node_only_resolves_node_spatial_parent():
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        with mgr.enter_middleware("mw-A") as call_id:
+            event = await _pipe(MiddlewareInvocationEvent(args=(), kwargs={}))
+
+    assert event.spatial_parent == NodeSpatialParent(node_id="node-1", middleware_id=None)
+    assert event.parent == MiddlewareParent(
+        middleware_type_id="mw-A", middleware_invoke_id=call_id
+    )
+
+
+async def test_nested_middleware_event_records_enclosing_middleware_type_id():
+    """Node -> mw-A -> mw-B (nested): B's spatial parent records A's *type* id."""
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        with mgr.enter_middleware("mw-A"):
+            with mgr.enter_middleware("mw-B") as b_call_id:
+                event = await _pipe(MiddlewareInvocationEvent(args=(), kwargs={}))
+
+    assert event.spatial_parent == NodeSpatialParent(node_id="node-1", middleware_id="mw-A")
+    assert event.parent == MiddlewareParent(
+        middleware_type_id="mw-B", middleware_invoke_id=b_call_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Middleware events under an LLM call (model-level middleware / guards)
+# ---------------------------------------------------------------------------
+
+
+async def test_middleware_event_under_llm_scope_resolves_llm_spatial_parent():
+    """Model-level middleware (guards, before_llm/wrap_llm) sits *inside* the LLM
+    scope -- see `ModelInvoker.invoke`, which enters `enter_llm_call` before
+    running its middleware chain. Its events must resolve `LLMSpatialParent`,
+    never `NodeSpatialParent`, even though a node is further up the stack.
+    """
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        with mgr.enter_llm_call("model-x"):
+            with mgr.enter_middleware("guard-A") as call_id:
+                event = await _pipe(MiddlewareInvocationEvent(args=(), kwargs={}))
+
+    assert event.spatial_parent == LLMSpatialParent(llm_id="model-x", middleware_id=None)
+    assert event.parent == MiddlewareParent(
+        middleware_type_id="guard-A", middleware_invoke_id=call_id
+    )
+
+
+async def test_nested_model_middleware_under_llm_scope_records_enclosing_type_id():
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        with mgr.enter_llm_call("model-x"):
+            with mgr.enter_middleware("guard-A"):
+                with mgr.enter_middleware("guard-B") as b_call_id:
+                    event = await _pipe(MiddlewareInvocationEvent(args=(), kwargs={}))
+
+    assert event.spatial_parent == LLMSpatialParent(llm_id="model-x", middleware_id="guard-A")
+    assert event.parent == MiddlewareParent(
+        middleware_type_id="guard-B", middleware_invoke_id=b_call_id
+    )
+
+
+async def test_parent_middleware_does_not_cross_the_llm_boundary():
+    """Node -> node-mw-A -> LLM -> model-mw-B: B's spatial parent records NO
+    enclosing middleware, even though node-mw-A is further up the stack.
+
+    `SessionContext.parent_middleware_id` only looks one scope-stack level up
+    (the entry directly enclosing the current one) -- it never walks past an
+    LLM (or node) entry to find an outer middleware. This is the sharpest
+    footgun in the whole design: pinned explicitly so a "helpful" refactor to
+    walk further up doesn't silently change semantics unnoticed.
+    """
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        with mgr.enter_middleware("node-mw-A"):
+            with mgr.enter_llm_call("model-x"):
+                with mgr.enter_middleware("model-mw-B") as b_call_id:
+                    event = await _pipe(MiddlewareInvocationEvent(args=(), kwargs={}))
+
+    assert event.spatial_parent == LLMSpatialParent(llm_id="model-x", middleware_id=None)
+    assert event.parent == MiddlewareParent(
+        middleware_type_id="model-mw-B", middleware_invoke_id=b_call_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM message events (the terminal llm.invocation/response/failure family)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("middleware_depth", [0, 1, 2])
+async def test_llm_message_event_always_resolves_to_nearest_node(middleware_depth):
+    """llm.invocation/response/failure are always spatially anchored to the
+    nearest *node*, skipping past the LLM scope and any nested model
+    middleware -- regardless of how many middleware layers sit in between.
+    Their `parent` (which specific LLM call) is a separate, distinct field.
+    """
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with ExitStack() as stack:
+        stack.enter_context(mgr.enter_node("node-1"))
+        stack.enter_context(mgr.enter_llm_call("model-x"))
+        for i in range(middleware_depth):
+            stack.enter_context(mgr.enter_middleware(f"mw-{i}"))
+
+        llm_call_data = central.get_llm_call_id()
+        event = await _pipe(LLMInvocationEvent(message_input=MessageHistory([])))
+
+    assert event.spatial_parent == NodeSpatialParent(node_id="node-1", middleware_id=None)
+    assert event.parent == LLMParent(
+        llm_invoke_id=llm_call_data.call_id, llm_model_id=llm_call_data.type_id
+    )
+
+
+# ---------------------------------------------------------------------------
+# Creation events: always NoSpatialParent, never require an active scope
+# ---------------------------------------------------------------------------
+
+
+async def test_creation_events_have_no_spatial_parent_and_need_no_active_scope():
+    _register()  # session registered, but no node/middleware/LLM scope pushed
+
+    mw_event = await _pipe(
+        MiddlewareCreationEvent(middleware_type_id="mw-A", middleware_name="A")
+    )
+    assert mw_event.spatial_parent == NoSpatialParent()
+
+    llm_event = await _pipe(
+        LLMCreationEvent(
+            model_id="model-x",
+            model_provider=ModelProvider.OPENAI,
+            model_name="gpt-x",
+        )
+    )
+    assert llm_event.spatial_parent == NoSpatialParent()
+
+
+# ---------------------------------------------------------------------------
+# Missing-context assertions: defensive checks that a resolver never
+# silently invents a parent when the required scope isn't active.
+# ---------------------------------------------------------------------------
+
+
+async def test_middleware_event_with_no_node_or_llm_context_raises():
+    _register()
+    event = MiddlewareInvocationEvent(args=(), kwargs={})
+
+    with pytest.raises(AssertionError, match="node or LLM"):
+        await _pipe(event)
+
+
+async def test_middleware_event_without_active_middleware_scope_raises():
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        event = MiddlewareInvocationEvent(args=(), kwargs={})
+        with pytest.raises(AssertionError, match="Middleware ID"):
+            await _pipe(event)
+
+
+async def test_llm_message_event_without_active_llm_call_scope_raises():
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_node("node-1"):
+        event = LLMInvocationEvent(message_input=MessageHistory([]))
+        with pytest.raises(AssertionError, match="LLM call ID"):
+            await _pipe(event)
+
+
+async def test_llm_message_event_without_active_node_scope_raises():
+    _register()
+    mgr = ContextVarScopeManager()
+
+    with mgr.enter_llm_call("model-x"):
+        event = LLMInvocationEvent(message_input=MessageHistory([]))
+        with pytest.raises(AssertionError, match="Node ID"):
+            await _pipe(event)
+
+
+# ---------------------------------------------------------------------------
+# pipe() guards
+# ---------------------------------------------------------------------------
+
+
+async def test_pipe_rejects_an_event_whose_spatial_parent_is_already_set():
+    _register()
+    event = MiddlewareCreationEvent(middleware_type_id="mw-A", middleware_name="A")
+    event.spatial_parent = NoSpatialParent()  # pretend this was already resolved
+
+    with pytest.raises(RuntimeError, match="not supported"):
+        await _pipe(event)
+
+
+def test_resolve_parent_raises_for_an_unrecognized_event_type():
+    @dataclass(kw_only=True)
+    class _UnknownEvent(SessionEventBase):
+        def event_type(self) -> str:
+            return "unknown.event"
+
+    with pytest.raises(RuntimeError, match="Unknown event type"):
+        _resolve_parent(_UnknownEvent())

--- a/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
@@ -355,23 +355,6 @@ class TestCompletionMethods:
         assert calls[0].arguments == {"foo": 1}
         assert calls[0].identifier == "id123"
 
-<<<<<<< HEAD
-        
-        if stream:  # no stream in case the llm requests tool
-            for chunk in result:
-                if isinstance(chunk, Response):
-                    try:
-                        calls = json.loads(chunk.message.content)
-                        assert isinstance(calls, list)
-                        assert calls[0]["name"] == "tool_x"
-                        assert calls[0]["arguments"] == {"foo": 1}
-                        assert calls[0]["identifier"] == "id123"
-                    except Exception:
-                        pytest.fail("Structured response did not match schema")
-                elif not isinstance(chunk, str):
-                    pytest.fail("Stream yielded non-string, non-Response chunk")
-=======
->>>>>>> 4a87510c39fa122f214afe3da113c16a2bb14190
 
 # ================= START async streaming (sync bridge) tests =========================
 class TestAsyncStreaming:


### PR DESCRIPTION
## Summary

This PR builds on the work in #1303. It completes the following additions:

1. Adds emission sites inside the user created middleware. (all guards, after_llm, before_llm etc.)
2. Middleware Events
3. Implemented logic for resolving spatial parents for nodes including middleware
4. Implemented logic for resolving spatial parents for all middleware events


## Notes
I don't love ad-hoc the decision on where to place emission sites was. Looking through each decision is ok but there isn't a consistent theme which is bothersome tbh

