### PR TITLE
1206 V4 streaming (3/n): Flow.astream — stream a flow's entry point

### DIFF
--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -26,6 +26,12 @@ A `Stream` is also awaitable. Awaiting it consumes the stream to completion and 
 !!! Note "The final result is authoritative"
     `stream.result` can differ from the concatenation of the streamed chunks. For example, an output guardrail may correct the buffered response after the raw tokens were already streamed. Treat the chunks as live progress and `.result` as the answer.
 
+A `Flow` streams the same way with `flow.astream(...)`, which runs the entry point in a session built from the flow's configuration and closes it once the stream finishes:
+
+```python
+--8<-- "docs/scripts/streaming.py:flow_astream"
+```
+
 A few details worth knowing:
 
 - **Frame-local.** Only the node you invoke streams its LLM response. Nested `rt.call` children, such as agents used as tools, run buffered.

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -25,6 +25,18 @@ async def main_await():
 # --8<-- [end: astream_await]
 
 
+# --8<-- [start: flow_astream]
+poem_flow = rt.Flow(name="poem", entry_point=agent)
+
+
+async def main_flow_astream():
+    stream = poem_flow.astream("Write a short poem about rain.")
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+    final = stream.result
+# --8<-- [end: flow_astream]
+
+
 # --8<-- [start: channels]
 @rt.function_node
 async def worker(topic: str) -> str:

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
 
 from railtracks._session import Session
 from railtracks.built_nodes.function.base import RTFunction
+from railtracks.interaction._astream import Stream
 from railtracks.interaction._call import call
 
 from ..nodes.nodes import Node
@@ -78,8 +79,9 @@ class Flow(Generic[_P, _TOutput]):
         new_obj._context.update(context)
         return new_obj
 
-    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
-        with Session(
+    def _new_session(self) -> Session:
+        """Builds a fresh `Session` configured from this flow (one per run)."""
+        return Session(
             context=deepcopy(self._context),
             flow_name=self.name,
             flow_id=self.equality_hash(),
@@ -91,7 +93,10 @@ class Flow(Generic[_P, _TOutput]):
             prompt_injection=self._prompt_injection,
             save_state=self._save_state,
             payload_callback=self._payload_callback,
-        ):
+        )
+
+    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        with self._new_session():
             result = await call(self.entry_point, *args, **kwargs)
 
         return result
@@ -104,6 +109,48 @@ class Flow(Generic[_P, _TOutput]):
             raise RuntimeError(
                 "Cannot invoke flow synchronously within an active event loop. Use 'ainvoke' instead."
             )
+
+    def astream(self, *args: _P.args, **kwargs: _P.kwargs) -> Stream[_TOutput]:
+        """
+        Run this flow with streaming enabled and return a `Stream` over the emitted chunks.
+
+        This is the flow-level counterpart to `rt.astream`: it runs the flow's entry point in
+        a session configured from this flow (context, callbacks, timeout, ...), and yields the
+        entry point's streamed chunks. The session is created when iteration begins and closed
+        automatically once the stream completes, so the flow owns its own run just like
+        `ainvoke` does.
+
+        ```python
+        flow = rt.Flow(name="poem", entry_point=agent)
+        stream = flow.astream("Write a short poem about rain.")
+        async for chunk in stream:
+            print(chunk, end="", flush=True)
+        final = stream.result
+        ```
+
+        `on_channel` and the awaitable form work exactly as they do for `rt.astream`.
+
+        Args:
+            *args: Positional arguments forwarded to the entry point.
+            **kwargs: Keyword arguments forwarded to the entry point.
+
+        Returns:
+            Stream[_TOutput]: An async iterator over the chunks, with `.result` for the final
+                value.
+        """
+        # The flow owns the session lifecycle: open it when the stream starts and close it
+        # when the stream finishes. The Stream itself stays out of session management (it just
+        # calls these hooks) — mirroring how rt.astream wires a default session.
+        session_box: list[Session] = []
+
+        def _open() -> None:
+            session_box.append(self._new_session())
+
+        def _close() -> None:
+            while session_box:
+                session_box.pop().__exit__(None, None, None)
+
+        return Stream(self.entry_point, args, kwargs, on_start=_open, on_close=_close)
 
     def equality_hash(self) -> str:
         """

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -114,21 +114,12 @@ class Flow(Generic[_P, _TOutput]):
         """
         Run this flow with streaming enabled and return a `Stream` over the emitted chunks.
 
-        This is the flow-level counterpart to `rt.astream`: it runs the flow's entry point in
-        a session configured from this flow (context, callbacks, timeout, ...), and yields the
-        entry point's streamed chunks. The session is created when iteration begins and closed
-        automatically once the stream completes, so the flow owns its own run just like
-        `ainvoke` does.
+        Yields the entry point's streamed chunks. 
+        
+        The session is created when iteration begins and closed automatically once the stream completes, 
+        owning its own run just lik `ainvoke`.
 
-        ```python
-        flow = rt.Flow(name="poem", entry_point=agent)
-        stream = flow.astream("Write a short poem about rain.")
-        async for chunk in stream:
-            print(chunk, end="", flush=True)
-        final = stream.result
-        ```
-
-        `on_channel` and the awaitable form work exactly as they do for `rt.astream`.
+        `on_channel` and the awaitable form work as they do for `rt.astream`.
 
         Args:
             *args: Positional arguments forwarded to the entry point.

--- a/packages/railtracks/tests/integration_tests/run/test_flow_astream.py
+++ b/packages/railtracks/tests/integration_tests/run/test_flow_astream.py
@@ -1,0 +1,71 @@
+"""Integration tests for `Flow.astream`: streaming a flow's entry point in a
+flow-configured session that opens on first iteration and closes on completion."""
+
+import pytest
+import railtracks as rt
+
+
+@pytest.mark.asyncio
+async def test_flow_astream_yields_chunks_and_result(mock_llm):
+    agent = rt.agent_node(
+        name="Streamer", llm=mock_llm(custom_response="hello"), system_message="s"
+    )
+    flow = rt.Flow(name="poem", entry_point=agent)
+
+    stream = flow.astream("hi")
+    chunks = [c async for c in stream]
+
+    assert "".join(chunks) == "hello"
+    assert stream.result.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_flow_astream_awaitable(mock_llm):
+    agent = rt.agent_node(
+        name="Streamer", llm=mock_llm(custom_response="world"), system_message="s"
+    )
+    flow = rt.Flow(name="poem", entry_point=agent)
+
+    final = await flow.astream("hi")
+    assert final.text == "world"
+
+
+@pytest.mark.asyncio
+async def test_flow_astream_closes_session(mock_llm):
+    """After the stream completes the flow's session is torn down (no active context)."""
+    from railtracks.context.central import is_context_present
+
+    agent = rt.agent_node(
+        name="Streamer", llm=mock_llm(custom_response="x"), system_message="s"
+    )
+    flow = rt.Flow(name="poem", entry_point=agent)
+
+    async for _ in flow.astream("hi"):
+        pass
+
+    assert not is_context_present()
+
+
+@pytest.mark.asyncio
+async def test_flow_astream_applies_flow_stream_callback(mock_llm):
+    """The stream lane callback configured on the Flow receives the streamed chunks."""
+    seen: list[str] = []
+    agent = rt.agent_node(
+        name="Streamer", llm=mock_llm(custom_response="abc"), system_message="s"
+    )
+    flow = rt.Flow(name="poem", entry_point=agent, stream_callback=seen.append)
+
+    await flow.astream("hi")
+    assert "".join(seen) == "abc"
+
+
+@pytest.mark.asyncio
+async def test_flow_astream_on_channel(mock_llm):
+    """on_channel works on a flow stream, same as rt.astream (tokens ride 'default')."""
+    agent = rt.agent_node(
+        name="Streamer", llm=mock_llm(custom_response="tok"), system_message="s"
+    )
+    flow = rt.Flow(name="poem", entry_point=agent)
+
+    chunks = [c async for c in flow.astream("hi").on_channel("default")]
+    assert "".join(chunks) == "tok"


### PR DESCRIPTION
## Summary

Third slice of the V4 streaming rollout: **`Flow.astream`** (the flow-level counterpart to `rt.astream`, left out of mini_1). Stacked on mini_2, so this PR's base is `1206/v4_streaming_mini_2` and the diff shows only the `Flow.astream` delta. Retarget once the lower slices merge.

```python
flow = rt.Flow(name="poem", entry_point=agent)
stream = flow.astream("Write a short poem about rain.")
async for chunk in stream:
    print(chunk, end="", flush=True)
final = stream.result
```

- **`Flow.astream(*args, **kwargs) -> Stream`** runs the flow's entry point in a session built from the flow's configuration (context, `broadcast_callback`/`stream_callback`, timeout, `save_state`, ...), and yields the entry point's streamed chunks. The session opens when iteration begins and closes when the stream completes, so the flow owns its run exactly like `ainvoke`.
- Session lifecycle rides the `Stream` `on_start`/`on_close` hooks introduced in mini_1, so **Flow** owns session creation/teardown and the `Stream` stays out of session management.
- Extracted **`Flow._new_session()`** and pointed `ainvoke` at it, removing the duplicated `Session(...)` config block.
- `on_channel` (mini_2) and the awaitable form work on a flow stream just as they do on `rt.astream`.

## Not in this PR (later minis)

`agent_node(stream_channel=...)`, `Stream.route()` (push), public `rt.broadcast_stream`, `rt.context.get_stream`.

## Verification

- New `test_flow_astream.py` (5 tests): chunks + `.result`, awaitable form, session closes on completion (no active context afterward), the flow's `stream_callback` receives the chunks, and `on_channel`.
- ruff clean on `src`; pyright `standard` clean on the `flow.py` streaming additions (the two `entry_point`/`node_type` errors are pre-existing on base, unchanged by this PR).
- Integration (run + library): failure set identical to base (the 3 tool-calling/function failures are pre-existing).
- Regression: mini_1 and mini_2 smokes still pass.

> Note: the unit suite currently shows 8 `test_couple.py` failures — these are **pre-existing base breakage** (base's `agent_node` dropped `context_injection`, but base `test_couple.py` still passes it); they reproduce identically on `feature-branch-node-add-on` and are untouched by this PR.
