### PR TITLE
Fix AzureAILLM rejecting custom Foundry deployment names

### DIFF
--- a/docs/integrations/llms/platforms.md
+++ b/docs/integrations/llms/platforms.md
@@ -13,6 +13,15 @@ The code remains the same as [LLM Providers](providers.md) with the provider nam
     --8<-- "docs/scripts/providers.py:azure"
     ```
 
+    !!! info "Environment Variables"
+
+        Add `AZURE_API_BASE` and `AZURE_API_KEY` to your `.env`. `AZURE_API_BASE` is your Foundry endpoint (e.g. `https://<your-resource>.cognitiveservices.azure.com/`), and `AZURE_API_KEY` is the resource key from the Azure portal.
+
+    `AzureAILLM` accepts either litellm prefix, depending on how your model is deployed in Foundry:
+
+    - `azure/<deployment>` — Azure OpenAI Service route. The string after the slash is the deployment name you chose in the portal and can be anything (e.g. `azure/my-gpt-5-deployment`).
+    - `azure_ai/<model>` — Azure AI Foundry model-inference route. The string after the slash is a model identifier from Foundry's catalog (e.g. `azure_ai/deepseek-r1`).
+
 === "Ollama"
     ```python
     --8<-- "docs/scripts/providers.py:ollama"

--- a/docs/scripts/providers.py
+++ b/docs/scripts/providers.py
@@ -34,8 +34,14 @@ model = rt.llm.GeminiLLM(model_name="gemini-3-flash-preview")
 
 # --8<-- [start: azure]
 import railtracks as rt
-# make sure to configure your environment variables for Azure AI
+# Railtracks loads .env automatically; set AZURE_API_BASE and AZURE_API_KEY there.
 
+# Azure OpenAI Service (deployment-routed) — the string after "azure/" is your
+# Foundry deployment name and can be anything you chose in the portal.
+model = rt.llm.AzureAILLM("azure/my-gpt-5-deployment")
+
+# Azure AI Foundry catalog model (model-routed) — the string after "azure_ai/"
+# is a model identifier from Foundry's model catalog.
 model = rt.llm.AzureAILLM("azure_ai/deepseek-r1")
 # --8<-- [end: azure]
 

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -43,6 +43,10 @@ _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 litellm.drop_params = True
 litellm.modify_params = True
 
+# this flag is only used in two places in litellm
+# https://github.com/search?q=repo%3ABerriAI%2Flitellm%20suppress_debug_info&type=code
+litellm.suppress_debug_info = True
+
 
 def _process_single_parameter(p: Parameter) -> tuple[str, Dict[str, Any], bool]:
     """

--- a/packages/railtracks/src/railtracks/llm/models/cloud/azureai.py
+++ b/packages/railtracks/src/railtracks/llm/models/cloud/azureai.py
@@ -1,14 +1,14 @@
 import logging
-from typing import Literal, TypeVar
+from typing import List, Literal, TypeVar
 
-import litellm
+from litellm.exceptions import InternalServerError
 
+from ...history import MessageHistory
 from ...providers import ModelProvider
 from ...retries import RetryApproach
+from ...tools import Tool
 from .._litellm_wrapper import LiteLLMWrapper
-
-# litellm.drop_params=True
-from .._model_exception_base import FunctionCallingNotSupportedError, ModelError
+from .._model_exception_base import ModelError
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,19 @@ class AzureAIError(ModelError):
 
 
 class AzureAILLM(LiteLLMWrapper[_TStream]):
+    """Azure Foundry LLM wrapper.
+
+    Accepts either litellm prefix:
+    - ``azure/<deployment>`` — Azure OpenAI Service route; the string after the
+      slash is the user-chosen deployment name and can be anything.
+    - ``azure_ai/<model>`` — Azure AI Foundry model-inference route; the string
+      after the slash is a model identifier from Foundry's catalog.
+
+    The model string is forwarded verbatim to litellm — no client-side validation
+    is done against a static catalog, since deployment names are user-defined and
+    can't be known ahead of time.
+    """
+
     @classmethod
     def model_gateway(cls):
         return ModelProvider.AZUREAI
@@ -38,57 +51,30 @@ class AzureAILLM(LiteLLMWrapper[_TStream]):
         """Initialize an Azure AI LLM instance.
 
         Args:
-            model_name (str): Name of the Azure AI model to use.
+            model_name (str): Full litellm model string, e.g. ``azure/my-deployment``
+                or ``azure_ai/deepseek-r1``. See the class docstring for the
+                difference between the two prefixes.
             temperature (float | None, optional): Sampling temperature for generation (e.g. 0.0–2.0).
                 If None, the provider default is used.
             **kwargs: Additional arguments passed to the parent LiteLLMWrapper.
-
-        Raises:
-            AzureAIError: If the specified model is not available or if there are issues with the Azure AI service.
         """
         super().__init__(
             model_name, temperature=temperature, retry_approach=retry_approach, **kwargs
         )
-
-        # Currently matching names to Azure models is case sensitive
-        self._available_models = [model.lower() for model in litellm.azure_ai_models]
-        self._is_model_available()
-
         self.logger = logger
 
-    def chat(self, messages, **kwargs):
+    def chat(self, messages: MessageHistory):
         try:
-            return super().chat(messages, **kwargs)
-        except litellm.InternalServerError as e:
+            return super().chat(messages)
+        except InternalServerError as e:
             raise AzureAIError(
                 reason=f"Azure AI LLM error while processing the request: {e}"
             ) from e
 
-    def chat_with_tools(self, messages, tools, **kwargs):
-        if not litellm.supports_function_calling(model=self._model_name.lower()):
-            raise FunctionCallingNotSupportedError(self._model_name)
-
+    def chat_with_tools(self, messages: MessageHistory, tools: List[Tool]):
         try:
-            return super().chat_with_tools(messages, tools, **kwargs)
-        except litellm.InternalServerError as e:
+            return super().chat_with_tools(messages, tools)
+        except InternalServerError as e:
             raise AzureAIError(
                 reason=f"Azure AI LLM error while processing the request: {e}"
             ) from e
-
-    def _is_model_available(self) -> None:
-        """Check if the model is available and supports tool calling."""
-        if self._model_name.lower() not in self._available_models:
-            raise AzureAIError(
-                reason=(
-                    f"Model '{self._model_name}' is not available. "
-                    f"Available models: {self._available_models}"
-                )
-            )
-
-    def _tool_calling_supported(self) -> bool:
-        """Check if the model supports tool calling."""
-        tool_calling_supported = [
-            (model, litellm.supports_function_calling(model=model))
-            for model in self._available_models
-        ]
-        return tool_calling_supported

--- a/packages/railtracks/tests/unit_tests/llm/models/cloud/test_azureai.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/cloud/test_azureai.py
@@ -34,10 +34,10 @@ def test_init_success():
     assert llm._model_name == TEST_CHAT_MODEL_NAME
 
 
-def test_init_model_not_available():
-    """Test initialization with a model that is not available"""
-    with pytest.raises(RTLLMError, match="Model 'non_existent_model' is not available"):
-        AzureAILLM(model_name="non_existent_model")
+def test_init_accepts_custom_deployment_name():
+    """Custom Foundry deployment names must not be rejected client-side."""
+    llm = AzureAILLM(model_name="azure/my-custom-deployment")
+    assert llm._model_name == "azure/my-custom-deployment"
 
 
 def test_chat_success(message_history):
@@ -98,9 +98,15 @@ def test_chat_with_tools_success(message_history, response, tool):
 
 
 def test_chat_with_tools_failure(message_history, tool):
-    """"""
+    """A litellm InternalServerError during chat_with_tools surfaces as RTLLMError."""
     llm = AzureAILLM(model_name=TEST_CHAT_MODEL_NAME)
 
-    with patch.object(litellm, "supports_function_calling", return_value=False):
+    with patch.object(
+        LiteLLMWrapper,
+        "chat_with_tools",
+        side_effect=litellm.InternalServerError(
+            "Internal server error", "azure_ai", MODEL_NAME
+        ),
+    ):
         with pytest.raises(RTLLMError):
             llm.chat_with_tools(message_history, [tool])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ line-length = 88
 
 format.indent-style = "space"
 format.docstring-code-format = true
+format.exclude = ["*.md"]
 
 lint.select = [
     "E",


### PR DESCRIPTION
## Summary
- Drops AzureAILLM's `litellm.azure_ai_models` allowlist and `supports_function_calling` pre-check (both unknowable for user-defined deployment names, so they rejected valid `azure/my-deployment` and `azure_ai/my-model` strings up front),
- updates docs and required env vars, 
- sets `litellm.suppress_debug_info = True` in `_litellm_wrapper`.py to quiet the two hardcoded stderr hint prints (the only two places in litellm that read the flag)


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
