### PR TITLE
Stop pre-rejecting PDF attachments on models litellm can't identify

### DIFF
--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -110,6 +110,24 @@ def _parameters_to_json_schema(
     )
 
 
+def _model_in_litellm_catalog(model_name: str) -> bool:
+    """True if litellm has capability metadata for this model name.
+
+    Custom deployment names (Azure Foundry etc.) route through litellm but
+    have no entry in the capability catalog, so any `supports_*` probe on
+    them returns False regardless of what the underlying model can actually
+    do. This helper lets callers distinguish "litellm knows the answer is
+    False" from "litellm has no idea, don't trust the probe."
+    """
+    if model_name in litellm.model_cost:
+        return True
+    try:
+        routed_model, _, _, _ = litellm.get_llm_provider(model=model_name)
+    except Exception:
+        return False
+    return routed_model in litellm.model_cost
+
+
 def _to_litellm_tool(tool: Tool) -> Dict[str, Any]:
     """
     Convert your Tool object into the dict format for litellm.completion.
@@ -718,7 +736,15 @@ class LiteLLMWrapper(ModelBase[_TStream], ABC, Generic[_TStream]):
                     else msg_attachment.url
                 )
                 if msg_attachment.modality == "document":
-                    if not litellm.utils.supports_pdf_input(self._model_name):
+                    # Only trust litellm's PDF-support check when the model is in
+                    # litellm's capability catalog. Custom deployment names (Azure
+                    # Foundry etc.) route fine but have no capability metadata,
+                    # so supports_pdf_input returns False by default and would
+                    # falsely reject valid deployments. When the model isn't in
+                    # the catalog, skip the pre-check and let the API decide.
+                    if _model_in_litellm_catalog(
+                        self._model_name
+                    ) and not litellm.utils.supports_pdf_input(self._model_name):
                         raise ValueError(
                             f"Model {self._model_name!r} does not support PDF attachments. "
                             "Use a PDF-capable model or render the PDF pages to images first."

--- a/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
@@ -213,6 +213,28 @@ class TestHelpers:
         with pytest.raises(ValueError, match="does not support PDF attachments"):
             wrapper._to_litellm_message(message)
 
+    def test_to_litellm_message_pdf_attachment_allowed_for_unroutable_model(
+        self,
+        mock_litellm_wrapper,
+    ):
+        """
+        A custom deployment name (Azure Foundry etc.) that litellm can't identify
+        must NOT be pre-rejected — the API is the source of truth for capability
+        in that case. Regression for the AzureAILLM custom-deployment path.
+        """
+        import base64 as _b64
+
+        wrapper = mock_litellm_wrapper(model_name="azure/my-custom-deployment")
+        pdf_bytes = b"%PDF-1.4\n%fake pdf\n%%EOF"
+        b64 = _b64.b64encode(pdf_bytes).decode("utf-8")
+        data_uri = f"data:application/pdf;base64,{b64}"
+        message = UserMessage(content="Summarize this.", attachment=[data_uri])
+
+        litellm_message = wrapper._to_litellm_message(message)
+
+        file_block = litellm_message["content"][1]
+        assert file_block["type"] == "file"
+
     # =================================== END _to_litellm_message Tests ====================================
 
 


### PR DESCRIPTION
Gate the `supports_pdf_input` check on `litellm.model_cost` membership, models with no catalog entry (custom Azure Foundry deployments etc.) now skip the pre-check and let the API decide, while known text-only models still raise upfront.