### PR TITLE
failure Events updated with mix in

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/_node_builder.py
@@ -150,7 +150,7 @@ async def _observe_middleware(call: Callable, *args, **kwargs):
     try:
         result = await call(*args, **kwargs)
     except Exception as e:
-        failure_event = NodeFailure(failure=str(e))
+        failure_event = NodeFailure.from_exception(e)
         await emit(failure_event)
         raise e
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -39,9 +39,7 @@ def after_llm(fn: Callable[[Response], Response | Awaitable[Response]]):
         try:
             response = await llm_call(message_history, schema, tools)
         except Exception as e:
-            event = MiddlewareModelOutputFailureEvent(
-                exception=e,
-            )
+            event = MiddlewareModelOutputFailureEvent.from_exception(e)
             await pipe(event)
             raise e
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/wrap_llm.py
@@ -53,9 +53,7 @@ def wrap_llm(
         try:
             response = await fn(llm_call, message_history, schema, tools)
         except Exception as e:
-            event = MiddlewareModelFailureEvent(
-                exception=e,
-            )
+            event = MiddlewareModelFailureEvent.from_exception(e)
             await pipe(event)
             raise e
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -43,9 +43,8 @@ async def _llm_observe(
     try:
         response: Response = await call(message_history, schema, tools)
     except Exception as e:
-        event = LLMFailureEvent(
-            message_input=prev_message_history,
-            error_message=e,
+        event = LLMFailureEvent.from_exception(
+            e, message_input=prev_message_history
         )
         await pipe(event)
         raise e

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from railtracks.context.scope_link import ScopeLink
@@ -183,8 +185,9 @@ class FailureMixin:
     exception_message: str
 
     @classmethod
-    def from_exception(cls, exc: Exception) -> Self:
+    def from_exception(cls, exc: Exception, **kwargs) -> Self:
         return cls(
             exception_name=type(exc).__name__,
             exception_message=str(exc),
+            **kwargs,
         )

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, Self, TypeVar
 
 if TYPE_CHECKING:
     from railtracks.context.scope_link import ScopeLink
@@ -175,3 +175,16 @@ class ParentEventBase(
     @abstractmethod
     def _get_parent(self, scope: ScopeLink[ScopeEntry] | None) -> TParent:
         pass
+
+
+@dataclass(kw_only=True)
+class FailureMixin:
+    exception_name: str
+    exception_message: str
+
+    @classmethod
+    def from_exception(cls, exc: Exception) -> Self:
+        return cls(
+            exception_name=type(exc).__name__,
+            exception_message=str(exc),
+        )

--- a/packages/railtracks/src/railtracks/events/llm.py
+++ b/packages/railtracks/src/railtracks/events/llm.py
@@ -9,6 +9,7 @@ from railtracks.llm.providers import ModelProvider
 
 from ._base import (
     CreationEventBase,
+    FailureMixin,
     LLMParent,
     NodeSpatialParent,
     ParentEventBase,
@@ -56,8 +57,7 @@ class LLMResponseEvent(LLMMessageBase):
 
 
 @dataclass(kw_only=True)
-class LLMFailureEvent(LLMMessageBase):
-    error_message: Exception
+class LLMFailureEvent(LLMMessageBase, FailureMixin):
 
     def event_type(self) -> str:
         return "llm.failure"

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from railtracks.events._base import (
     UNSET,
     CreationEventBase,
+    FailureMixin,
     LLMAndMiddlewareSpatialParent,
     MiddlewareParent,
     NodeAndMiddlewareSpatialParent,
@@ -115,8 +116,8 @@ class MiddlewareGuardInputResponseEvent(MiddlewareModelEventBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareGuardInputFailureEvent(MiddlewareModelEventBase):
-    exception: Exception
+class MiddlewareGuardInputFailureEvent(MiddlewareModelEventBase, FailureMixin):
+    
 
     def event_type(self) -> str:
         return "middleware.guard.input.failure"
@@ -141,8 +142,7 @@ class MiddlewareModelOutputResponseEvent(MiddlewareModelOutputTypesBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareModelOutputFailureEvent(MiddlewareModelEventBase):
-    exception: Exception
+class MiddlewareModelOutputFailureEvent(MiddlewareModelEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "middleware.model.output.failure"
@@ -167,8 +167,7 @@ class MiddlewareOutputResponseEvent(MiddlewareOutputTypesBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareOutputFailureEvent(MiddlewareRegularEventBase):
-    exception: Exception
+class MiddlewareOutputFailureEvent(MiddlewareRegularEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "middleware.regular.output.failure"
@@ -193,8 +192,7 @@ class MiddlewareGuardOutputResponseEvent(MiddlewareModelEventBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareGuardOutputFailureEvent(MiddlewareModelEventBase):
-    exception: Exception
+class MiddlewareGuardOutputFailureEvent(MiddlewareModelEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "middleware.guard.output.failure"
@@ -219,8 +217,7 @@ class MiddlewareResponseEvent(MiddlewareGeneralEventBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareFailureEvent(MiddlewareGeneralEventBase):
-    exception: Exception
+class MiddlewareFailureEvent(MiddlewareGeneralEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "middleware.failure"
@@ -245,8 +242,7 @@ class MiddlewareModelResponseEvent(MiddlewareModelEventBase):
 
 
 @dataclass(kw_only=True)
-class MiddlewareModelFailureEvent(MiddlewareModelEventBase):
-    exception: Exception
+class MiddlewareModelFailureEvent(MiddlewareModelEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "middleware.model.failure"

--- a/packages/railtracks/src/railtracks/events/node.py
+++ b/packages/railtracks/src/railtracks/events/node.py
@@ -7,6 +7,7 @@ from railtracks.context.scope_link import ScopeLink
 from railtracks.context.session_context import ScopeEntry
 from railtracks.events._base import (
     CreationEventBase,
+    FailureMixin,
     MiddlewareSpatialParent,
     NodeParent,
     NodeSpatialParent,
@@ -52,11 +53,7 @@ class NodeInvocation(NodeEventBase):
 
 
 @dataclass(kw_only=True)
-class NodeFailure(NodeEventBase):
-    """A failure raised inside the node body. `failure` is a stringified exception
-    (payload serialization strategy is a separate follow-up)."""
-
-    failure: str
+class NodeFailure(NodeEventBase, FailureMixin):
 
     def event_type(self) -> str:
         return "node.failure"

--- a/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
@@ -81,9 +81,7 @@ class InputGuard(BaseLLMGuardrail[MessageHistory]):
                 event=event, value=message_history
             )
         except Exception as e:
-            failure_event = MiddlewareGuardInputFailureEvent(
-                exception=e,
-            )
+            failure_event = MiddlewareGuardInputFailureEvent.from_exception(e)
             await pipe(failure_event)
             raise e
 
@@ -210,9 +208,7 @@ class OutputGuard(BaseLLMGuardrail[Message]):
         try:
             new_message, traces, decision = self.run(event=event, value=result.message)
         except Exception as e:
-            failure_event = MiddlewareGuardOutputFailureEvent(
-                exception=e,
-            )
+            failure_event = MiddlewareGuardOutputFailureEvent.from_exception(e)
             await pipe(failure_event)
             raise e
 

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -44,7 +44,7 @@ def _scoped(
                 result = await wrapped(*args, **kwargs)
 
             except Exception as e:
-                event = MiddlewareFailureEvent(exception=e)
+                event = MiddlewareFailureEvent.from_exception(e)
                 await pipe(event)
                 raise e
 


### PR DESCRIPTION
## Summary

Very simple PR that adds a simple `FailureMixin` class which is inherited by all the failure classes. This is a more serializable type to work with.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
