### PR TITLE
1206 V4 streaming (queue): per-call astream queue, remove bus streaming

### DIFF
--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -11,6 +11,8 @@ Streaming is requested at the call site rather than baked into the agent, so the
 - `rt.call(agent, ...)` runs buffered, with no streaming overhead and no chunks.
 - `rt.astream(agent, ...)` streams the agent's LLM response chunk by chunk as it runs.
 
+`rt.astream` targets **agent nodes only** — the thing being streamed is an agent's LLM tokens. Passing a `@function_node` (or any non-agent node) raises an error; run those with `rt.call` and reach for `rt.astream` on the agent inside them.
+
 `rt.astream` returns a `Stream`, an async iterator that yields only the `str` chunks. The final result is kept separate and read from `.result` once the stream is exhausted, so a chunk is never confused with the final value:
 
 ```python
@@ -28,21 +30,16 @@ A `Stream` is also awaitable. Awaiting it consumes the stream to completion and 
 
 A few details worth knowing:
 
-- **Frame-local.** Only the node you invoke streams its LLM response. Nested `rt.call` children, such as agents used as tools, run buffered.
+- **Frame-local.** Only the agent you invoke streams its LLM response. Nested `rt.call` children, such as agents used as tools, run buffered.
 - **Errors.** If the node fails mid-stream, the exception is raised out of the `async for` loop (or the `await`), just as it is with `rt.call`.
 - **Early exit.** Breaking out of the loop does not cancel the run; it finishes in the background. Await the stream afterwards to collect the final result.
 - **Timeouts.** The session `timeout` applies to the whole streamed run as a wall-clock limit.
 - **Tool calling.** Token streaming with tool calling is currently supported on OpenAI models only. On other providers a streamed tool-calling run falls back to a buffered model call (with a logged warning), and the final result is unaffected.
 
-### Two callback lanes: `broadcast_callback` and `stream_callback`
+### Streaming inside a `@function_node`
 
-Streaming shares the same pubsub bus as `rt.broadcast`, but the two kinds of traffic travel on separate lanes so a listener never receives the wrong kind:
-
-- **`stream_callback`** is a passive, session-wide listener for stream chunks, meaning the `rt.broadcast_stream` productions that carry LLM tokens. It is the callback form of consuming tokens, where `rt.astream` is the pull form.
-- **`broadcast_callback`** is a passive, session-wide listener for one-off events sent with `rt.broadcast`, such as progress notes or tool events. It never receives token chunks, even while a run streams.
-
-Both are set on the `Flow` or globally with `rt.set_config`, and neither one turns streaming on. Only `rt.astream` does that.
+Because `rt.astream` targets an agent, the natural pattern is to stream the agent from inside a `@function_node` and drive that outer node with `rt.call`. The chunks are delivered straight to your handle — there are no channels or callbacks to wire up, and concurrent streams stay isolated simply by being separate handles:
 
 ```python
---8<-- "docs/scripts/streaming.py:stream_callback"
+--8<-- "docs/scripts/streaming.py:astream_nested"
 ```

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -11,7 +11,7 @@ Streaming is requested at the call site rather than baked into the agent, so the
 - `rt.call(agent, ...)` runs buffered, with no streaming overhead and no chunks.
 - `rt.astream(agent, ...)` streams the agent's LLM response chunk by chunk as it runs.
 
-`rt.astream` targets **agent nodes only** — the thing being streamed is an agent's LLM tokens. Passing a `@function_node` (or any non-agent node) raises an error; run those with `rt.call` and reach for `rt.astream` on the agent inside them.
+`rt.astream` targets **agent nodes only**. Passing a `@function_node` (or any non-agent node) raises an error; run those with `rt.call` and reach for `rt.astream` on the agent inside them.
 
 `rt.astream` returns a `Stream`, an async iterator that yields only the `str` chunks. The final result is kept separate and read from `.result` once the stream is exhausted, so a chunk is never confused with the final value:
 
@@ -38,7 +38,7 @@ A few details worth knowing:
 
 ### Streaming inside a `@function_node`
 
-Because `rt.astream` targets an agent, the natural pattern is to stream the agent from inside a `@function_node` and drive that outer node with `rt.call`. The chunks are delivered straight to your handle — there are no channels or callbacks to wire up, and concurrent streams stay isolated simply by being separate handles:
+Because `rt.astream` targets an agent, the natural pattern is to stream the agent from inside a `@function_node` and drive that outer node with `rt.call`. The chunks are delivered straight to your handl.
 
 ```python
 --8<-- "docs/scripts/streaming.py:astream_nested"

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -28,7 +28,7 @@ async def main_await():
 # --8<-- [start: astream_nested]
 # rt.astream targets an agent node; use it inside a @function_node and drive the
 # outer node with rt.call. Each stream is independent, so concurrent streams simply
-# have their own handles — no channels needed.
+# have their own handles.
 @rt.function_node
 async def head(prompt: str) -> str:
     stream = rt.astream(agent, user_input=prompt)

--- a/docs/scripts/streaming.py
+++ b/docs/scripts/streaming.py
@@ -25,20 +25,19 @@ async def main_await():
 # --8<-- [end: astream_await]
 
 
-# --8<-- [start: stream_callback]
-# Passive session-wide listeners — neither enables streaming (only rt.astream does):
-#   stream_callback    -> chunks from rt.broadcast_stream (LLM tokens included)
-#   broadcast_callback -> one-off events from rt.broadcast (progress notes, ...)
-observed_flow = rt.Flow(
-    name="poet_observed",
-    entry_point=agent,
-    stream_callback=lambda chunk: print(chunk, end="", flush=True),
-    broadcast_callback=lambda event: print(f"[event] {event}"),
-)
+# --8<-- [start: astream_nested]
+# rt.astream targets an agent node; use it inside a @function_node and drive the
+# outer node with rt.call. Each stream is independent, so concurrent streams simply
+# have their own handles — no channels needed.
+@rt.function_node
+async def head(prompt: str) -> str:
+    stream = rt.astream(agent, user_input=prompt)
+    async for chunk in stream:
+        print(chunk, end="", flush=True)
+    return stream.result.text
 
 
-async def main_observed():
-    # tokens flow to stream_callback while the run streams; the broadcast_callback
-    # only ever sees explicit rt.broadcast events (never the token chunks)
-    final = await observed_flow.ainvoke("Write a short poem about rain.")
-# --8<-- [end: stream_callback]
+async def main_nested():
+    # the function node is buffered (rt.call); only the agent inside it streams
+    text = await rt.call(head, "Write a short poem about rain.")
+# --8<-- [end: astream_nested]

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -19,7 +19,7 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .pubsub import RTPublisher, stream_subscriber
+from .pubsub import RTPublisher, event_subscriber
 from .state.info import (
     ExecutionInfo,
 )
@@ -49,7 +49,6 @@ class Session:
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
     - `broadcast_callback`: None (no event listener)
-    - `stream_callback`: None (no stream-chunk listener)
     - `prompt_injection`: True (the prompt will be automatically injected from context variables)
     - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
 
@@ -61,8 +60,7 @@ class Session:
         flow_id (str | None, optional): The unique identifier of the flow this session is associated with.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. Stream chunks go to `stream_callback` instead.
-        stream_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for stream chunks published through `rt.broadcast_stream` (LLM token streams included). It never enables streaming — only `rt.astream` does.
+        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
@@ -77,9 +75,6 @@ class Session:
         timeout: float | None = None,
         end_on_error: bool | None = None,
         broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
-        stream_callback: (
             Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
         ) = None,
         prompt_injection: bool | None = None,
@@ -98,7 +93,6 @@ class Session:
             timeout=timeout,
             end_on_error=end_on_error,
             broadcast_callback=broadcast_callback,
-            stream_callback=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -148,9 +142,6 @@ class Session:
         prompt_injection: bool | None,
         save_state: bool | None,
         payload_callback: Callable[[dict[str, Any]], None] | None,
-        stream_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
     ) -> ExecutorConfig:
         """
         Uses the following precedence order to determine the configuration parameters:
@@ -164,7 +155,6 @@ class Session:
             timeout=timeout,
             end_on_error=end_on_error,
             subscriber=broadcast_callback,
-            stream_callback=stream_callback,
             prompt_injection=prompt_injection,
             save_state=save_state,
             payload_callback=payload_callback,
@@ -225,21 +215,15 @@ class Session:
 
     def _setup_subscriber(self):
         """
-        Prepares and attaches the saved callbacks to the publisher attached to this runner:
-        `broadcast_callback` listens on the event lane (`rt.broadcast`), `stream_callback` on
-        the stream-chunk lane (`rt.broadcast_stream` / LLM token streaming).
+        Prepares and attaches the saved `broadcast_callback` to the publisher: it listens on
+        the event lane for one-off `rt.broadcast` items. (LLM token streaming does not flow
+        through the bus — it is consumed directly by the `rt.astream` handle.)
         """
 
         if self.executor_config.subscriber is not None:
             self.publisher.subscribe(
-                stream_subscriber(self.executor_config.subscriber, kind="event"),
+                event_subscriber(self.executor_config.subscriber),
                 name="Broadcast Callback Subscriber",
-            )
-
-        if self.executor_config.stream_callback is not None:
-            self.publisher.subscribe(
-                stream_subscriber(self.executor_config.stream_callback, kind="stream"),
-                name="Stream Callback Subscriber",
             )
 
     def _close(self):
@@ -336,9 +320,6 @@ def session(
     broadcast_callback: (
         Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
     ) = None,
-    stream_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-    ) = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ) -> Callable[
@@ -377,9 +358,6 @@ def session(
     timeout: float | None = None,
     end_on_error: bool | None = None,
     broadcast_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-    ) = None,
-    stream_callback: (
         Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
     ) = None,
     prompt_injection: bool | None = None,
@@ -442,7 +420,6 @@ def session(
                 timeout=timeout,
                 end_on_error=end_on_error,
                 broadcast_callback=broadcast_callback,
-                stream_callback=stream_callback,
                 name=name,
                 prompt_injection=prompt_injection,
                 save_state=save_state,

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -60,7 +60,7 @@ class Session:
         flow_id (str | None, optional): The unique identifier of the flow this session is associated with.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
+        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
@@ -216,8 +216,7 @@ class Session:
     def _setup_subscriber(self):
         """
         Prepares and attaches the saved `broadcast_callback` to the publisher: it listens on
-        the event lane for one-off `rt.broadcast` items. (LLM token streaming does not flow
-        through the bus — it is consumed directly by the `rt.astream` handle.)
+        the event lane for one-off `rt.broadcast` items.
         """
 
         if self.executor_config.subscriber is not None:

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -151,9 +151,8 @@ class ModelInvoker:
             tools: list[Tool] | None,
         ) -> Response:
             # Streaming path: consume the model stream here, forwarding each chunk directly to
-            # the rt.astream handle's per-call queue, and hand the complete Response back
-            # through the middleware chain — exit middleware (e.g. output guardrails) operates
-            # on the buffered final response.
+            # the rt.astream handle's per-call queue, and back
+            # through the middleware chain.
             stream_queue = _stream_queue_if_enabled(model, tools)
             if stream_queue is not None:
                 if tools is not None and len(tools) > 0:

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from copy import deepcopy
-from typing import Awaitable, Callable
+from typing import Any, AsyncIterator, Awaitable, Callable
 
 from pydantic import BaseModel
 
@@ -10,8 +10,8 @@ from railtracks.built_nodes._types import ModelSource
 from railtracks.built_nodes.llm.middleware.core import ModelMiddleware
 from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
 from railtracks.built_nodes.llm.request_details import RequestDetails
-from railtracks.context.central import is_streaming_enabled
-from railtracks.interaction.broadcast_ import broadcast_stream
+from railtracks.context.central import get_stream_queue
+from railtracks.exceptions.errors import LLMError
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.model import ModelBase
 from railtracks.llm.providers import TOOL_CALLING_STREAMING_BLACKLIST
@@ -23,17 +23,20 @@ from railtracks.utils.logging import get_rt_logger
 logger = get_rt_logger(__name__)
 
 
-def _should_stream(model: ModelBase, tools: list[Tool] | None) -> bool:
+def _stream_queue_if_enabled(
+    model: ModelBase, tools: list[Tool] | None
+) -> asyncio.Queue[Any] | None:
     """
     Frame-level streaming decision for a single model call.
 
-    Streaming is requested at the call site (`rt.astream`) and is frame-local, so this
-    returns True only for the entry frame of a streamed invocation. Tool-calling requests
-    against blacklisted providers fall back to a buffered call (with a warning) instead of
-    erroring.
+    Streaming is requested at the call site (`rt.astream`), which sets a per-call queue on the
+    entry frame's context. This returns that queue only when streaming is genuinely available
+    for this call, otherwise None (the call runs buffered). Tool-calling requests against
+    blacklisted providers fall back to a buffered call (with a warning) instead of erroring.
     """
-    if not is_streaming_enabled():
-        return False
+    queue = get_stream_queue()
+    if queue is None:
+        return None
     if (
         tools is not None
         and len(tools) > 0
@@ -44,8 +47,32 @@ def _should_stream(model: ModelBase, tools: list[Tool] | None) -> bool:
             "buffered response.",
             model.model_provider(),
         )
-        return False
-    return True
+        return None
+    return queue
+
+
+async def _drain_to_queue(
+    model_stream: AsyncIterator[str | Response],
+    queue: asyncio.Queue[Any],
+) -> Response:
+    """
+    Consumes a model token stream, forwarding each `str` chunk onto the astream queue and
+    returning the terminal `Response`.
+
+    Mirrors the buffered call's fail-fast contract: if the stream ends without producing a
+    `Response`, an `LLMError` is raised rather than returning a partial result.
+    """
+    final: Any = None
+    async for item in model_stream:
+        if isinstance(item, str):
+            queue.put_nowait(("chunk", item))
+        else:
+            final = item
+
+    if not isinstance(final, Response):
+        raise LLMError(reason="The stream did not yield a final Response object.")
+
+    return final
 
 
 @wrap_llm
@@ -123,11 +150,12 @@ class ModelInvoker:
             schema: type[BaseModel] | None,
             tools: list[Tool] | None,
         ) -> Response:
-            # Streaming path: consume the model stream here, broadcasting each chunk to the
-            # run's consumer (rt.astream), and hand the complete Response back through the
-            # middleware chain — exit middleware (e.g. output guardrails) operates on the
-            # buffered final response.
-            if _should_stream(model, tools):
+            # Streaming path: consume the model stream here, forwarding each chunk directly to
+            # the rt.astream handle's per-call queue, and hand the complete Response back
+            # through the middleware chain — exit middleware (e.g. output guardrails) operates
+            # on the buffered final response.
+            stream_queue = _stream_queue_if_enabled(model, tools)
+            if stream_queue is not None:
                 if tools is not None and len(tools) > 0:
                     model_stream = model.astream_chat_with_tools(messages, tools=tools)
                 elif schema is not None:
@@ -135,9 +163,9 @@ class ModelInvoker:
                 else:
                     model_stream = model.astream_chat(messages)
 
-                # broadcast_stream returns the complete Response (or raises LLMError if the
+                # _drain_to_queue returns the complete Response (or raises LLMError if the
                 # stream never produced one), mirroring the buffered branch below.
-                return await broadcast_stream(model_stream)
+                return await _drain_to_queue(model_stream, stream_queue)
 
             if tools is not None and len(tools) > 0:
                 return await asyncio.to_thread(

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -420,7 +420,6 @@ def set_config(
 
     Args:
         broadcast_callback: A passive listener for one-off events published with `rt.broadcast`.
-            (LLM token streaming is consumed directly by the `rt.astream` handle, not here.)
     """
 
     if is_context_active():

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -176,8 +176,7 @@ def get_stream_queue() -> asyncio.Queue[Any] | None:
 
     An LLM node uses this to decide whether to stream its model response token-by-token: when
     a queue is present the node writes each chunk onto it (drained by the `rt.astream` handle).
-    It is frame-local — set only on the entry frame of a streamed invocation and never
-    propagated to nested `rt.call` children — and is None when no context is present.
+    Set only on the entry frame of a streamed invocation.
     """
     context = runner_context.get()
     if context is None:

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import logging
 import warnings
@@ -34,20 +35,18 @@ class RunnerContextVars:
         self,
         new_parent_id: str,
         new_run_id: str | None = None,
-        stream: bool = False,
-        stream_id: str | None = None,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ):
         """
         Update the parent ID of the internal context.
 
-        `stream` marks the new frame as streaming-enabled (frame-local, never inherited),
-        while `stream_id` (inherited when None) tracks which stream scope the frame belongs to.
+        `stream_queue` (when set) makes the new frame the entry of a streamed invocation: its
+        LLM chunks are written onto this queue. It is frame-local and never inherited.
         """
         new_internal_context = self.internal_context.prepare_new(
             new_parent_id=new_parent_id,
             run_id=new_run_id,
-            stream=stream,
-            stream_id=stream_id,
+            stream_queue=stream_queue,
         )
 
         return RunnerContextVars(
@@ -171,30 +170,19 @@ def get_run_id() -> str | None:
     return context.internal_context.run_id
 
 
-def is_streaming_enabled() -> bool:
+def get_stream_queue() -> asyncio.Queue[Any] | None:
     """
-    Returns True when the current frame was invoked with streaming enabled (via `rt.astream`).
+    Returns the queue the current frame streams its LLM chunks onto, or None.
 
-    LLM nodes use this to decide whether to stream their model responses token-by-token.
-    The flag is frame-local: it is True only for the entry frame of a streamed invocation and
-    never propagates to nested `rt.call` children. Returns False when no context is present.
-    """
-    context = runner_context.get()
-    if context is None:
-        return False
-    return context.internal_context.stream_enabled
-
-
-def get_stream_id() -> str | None:
-    """
-    Returns the stream scope id of the current frame (the entry request id of the streamed
-    run this frame belongs to), or None when the frame is not part of a streamed run or no
-    context is present.
+    An LLM node uses this to decide whether to stream its model response token-by-token: when
+    a queue is present the node writes each chunk onto it (drained by the `rt.astream` handle).
+    It is frame-local — set only on the entry frame of a streamed invocation and never
+    propagated to nested `rt.call` children — and is None when no context is present.
     """
     context = runner_context.get()
     if context is None:
         return None
-    return context.internal_context.stream_id
+    return context.internal_context.stream_queue
 
 
 def register_globals(
@@ -309,8 +297,7 @@ def update_parent_id(
     new_parent_id: str,
     new_run_id: str | None = None,
     *,
-    stream: bool = False,
-    stream_id: str | None = None,
+    stream_queue: asyncio.Queue[Any] | None = None,
 ):
     """
     Update the parent ID of the current thread's global variables.
@@ -320,10 +307,8 @@ def update_parent_id(
     Args:
         new_parent_id: The parent id of the new frame.
         new_run_id: The run id of the new frame (defaults to the current one).
-        stream: If True, the new frame will have streaming enabled. This is frame-local:
-            child frames created afterwards will NOT inherit it.
-        stream_id: The stream scope id for the new frame. If None, the current stream id is
-            inherited.
+        stream_queue: If set, the new frame is the entry of a streamed invocation and writes
+            its LLM chunks onto this queue. Frame-local: child frames do NOT inherit it.
     """
     current_context = safe_get_runner_context()
 
@@ -335,7 +320,7 @@ def update_parent_id(
         raise RuntimeError("No global variable set")
 
     new_context = current_context.prepare_new(
-        new_parent_id, new_run_id=new_run_id, stream=stream, stream_id=stream_id
+        new_parent_id, new_run_id=new_run_id, stream_queue=stream_queue
     )
 
     runner_context.set(new_context)
@@ -425,9 +410,6 @@ def set_config(
     broadcast_callback: (
         Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
     ) = None,
-    stream_callback: (
-        Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-    ) = None,
     prompt_injection: bool | None = None,
     save_state: bool | None = None,
 ):
@@ -439,10 +421,7 @@ def set_config(
 
     Args:
         broadcast_callback: A passive listener for one-off events published with `rt.broadcast`.
-            Stream chunks go to `stream_callback` instead.
-        stream_callback: A passive listener for stream chunks published through
-            `rt.broadcast_stream` (LLM token streams included). It never enables streaming —
-            only `rt.astream` does.
+            (LLM token streaming is consumed directly by the `rt.astream` handle, not here.)
     """
 
     if is_context_active():
@@ -456,7 +435,6 @@ def set_config(
         timeout=timeout,
         end_on_error=end_on_error,
         subscriber=broadcast_callback,
-        stream_callback=stream_callback,
         prompt_injection=prompt_injection,
         save_state=save_state,
     )

--- a/packages/railtracks/src/railtracks/context/internal.py
+++ b/packages/railtracks/src/railtracks/context/internal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 from railtracks.utils.config import ExecutorConfig
 
@@ -23,16 +24,14 @@ class InternalContext:
         publisher: RTPublisher | None = None,
         parent_id: str | None = None,
         executor_config: ExecutorConfig,
-        stream_enabled: bool = False,
-        stream_id: str | None = None,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ):
         self._parent_id: str | None = parent_id
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
         self._executor_config: ExecutorConfig = executor_config
-        self._stream_enabled: bool = stream_enabled
-        self._stream_id: str | None = stream_id
+        self._stream_queue: asyncio.Queue[Any] | None = stream_queue
 
     @property
     def executor_config(self) -> ExecutorConfig:
@@ -88,29 +87,21 @@ class InternalContext:
         return self._run_id
 
     @property
-    def stream_enabled(self) -> bool:
-        """True when the frame attached to this context should stream its LLM responses.
+    def stream_queue(self) -> asyncio.Queue[Any] | None:
+        """The queue that this frame's streamed LLM chunks are written to, or None.
 
-        This flag is frame-local: it is set only on the entry frame of a streamed invocation
-        (see `rt.astream`) and is never inherited by child frames.
+        When set, the frame is the entry of a streamed invocation (see `rt.astream`): its
+        LLM node writes each token chunk directly onto this queue, which the `Stream` handle
+        on the calling side drains. It is frame-local — never inherited by child frames — so
+        only the astream'd agent streams; nested `rt.call` children run buffered.
         """
-        return self._stream_enabled
-
-    @property
-    def stream_id(self) -> str | None:
-        """The stream scope this frame belongs to (the entry request id of a streamed run).
-
-        Unlike `stream_enabled`, this id is inherited by child frames so their explicit
-        broadcasts can be routed back to the consumer attached to the entry frame.
-        """
-        return self._stream_id
+        return self._stream_queue
 
     def prepare_new(
         self,
         new_parent_id: str,
         run_id: str | None = None,
-        stream: bool = False,
-        stream_id: str | None = None,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ) -> InternalContext:
         """
         Prepares a new InternalContext with a new parent ID. If `run_id` or `session_id` are not provided, they will default to the current context's values.
@@ -120,10 +111,9 @@ class InternalContext:
         Args:
             new_parent_id: The parent id of the new frame.
             run_id: The run id of the new frame. Defaults to the current context's run id.
-            stream: Whether the new frame should have streaming enabled. Note this is
-                deliberately NOT inherited from the current context (streaming is frame-local).
-            stream_id: The stream scope id of the new frame. If None, the current context's
-                stream id is inherited (so nested broadcasts stay routed to the entry consumer).
+            stream_queue: The queue the new frame streams its LLM chunks onto (see `rt.astream`).
+                Deliberately NOT inherited from the current context: streaming is frame-local,
+                so a child frame only streams when it is itself the entry of an astream call.
         """
 
         unwrapped_run_id: str | None
@@ -138,6 +128,5 @@ class InternalContext:
             session_id=self._session_id,
             run_id=unwrapped_run_id,
             executor_config=self._executor_config,
-            stream_enabled=stream,
-            stream_id=stream_id if stream_id is not None else self._stream_id,
+            stream_queue=stream_queue,
         )

--- a/packages/railtracks/src/railtracks/context/internal.py
+++ b/packages/railtracks/src/railtracks/context/internal.py
@@ -111,8 +111,8 @@ class InternalContext:
             new_parent_id: The parent id of the new frame.
             run_id: The run id of the new frame. Defaults to the current context's run id.
             stream_queue: The queue the new frame streams its LLM chunks onto (see `rt.astream`).
-                Deliberately NOT inherited from the current context: streaming is frame-local,
-                so a child frame only streams when it is itself the entry of an astream call.
+                Frame-local and never inherited: a frame streams only when it is itself the
+                entry of an `rt.astream` call.
         """
 
         unwrapped_run_id: str | None

--- a/packages/railtracks/src/railtracks/context/internal.py
+++ b/packages/railtracks/src/railtracks/context/internal.py
@@ -92,8 +92,7 @@ class InternalContext:
 
         When set, the frame is the entry of a streamed invocation (see `rt.astream`): its
         LLM node writes each token chunk directly onto this queue, which the `Stream` handle
-        on the calling side drains. It is frame-local — never inherited by child frames — so
-        only the astream'd agent streams; nested `rt.call` children run buffered.
+        on the calling side drains. 
         """
         return self._stream_queue
 

--- a/packages/railtracks/src/railtracks/execution/task.py
+++ b/packages/railtracks/src/railtracks/execution/task.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Generic, TypeVar
 
 from railtracks.context.central import get_run_id, update_parent_id
@@ -18,30 +19,27 @@ class Task(Generic[_TOutput]):
         request_id: str,
         node: Node[..., _TOutput],
         arguments: tuple[tuple, dict[str, Any]],
-        stream: bool = False,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ):
         self.request_id = request_id
         self.node = node
         self.arguments = arguments
-        # when True the node's frame will run with streaming enabled (frame-local, see rt.astream)
-        self.stream = stream
+        # when set, this frame is the entry of a streamed invocation: its LLM node writes each
+        # token chunk onto this queue, which the rt.astream handle drains (frame-local).
+        self.stream_queue = stream_queue
 
     async def invoke(self):
         """The callable that this task is representing."""
-        # if this frame is the entry of a streamed invocation, its request id becomes the
-        # stream scope id used to route broadcast chunks back to the consumer.
-        stream_id = self.request_id if self.stream else None
-
         # if there is no parent run_id then this is the root
         if get_run_id() is None:
             # note critically that since these variables only this tree of requests will see this run_id.
             update_parent_id(
-                self.node.uuid, self.node.uuid, stream=self.stream, stream_id=stream_id
+                self.node.uuid, self.node.uuid, stream_queue=self.stream_queue
             )
 
         # otherwise we are already in a run so we just use the previous one.
         else:
-            update_parent_id(self.node.uuid, stream=self.stream, stream_id=stream_id)
+            update_parent_id(self.node.uuid, stream_queue=self.stream_queue)
 
         result = await self.node.wrapped_invoke(*self.arguments[0], **self.arguments[1])
 

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -93,7 +93,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         self._args = args
         self._kwargs = kwargs
 
-        # the request id doubles as the stream scope id used to tag every chunk of this run
+        # identifies this run so the completion subscriber can match its terminal message
         self._request_id = str(uuid4())
 
         self._queue: asyncio.Queue[tuple[str, Any]] | None = None
@@ -113,8 +113,8 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
     # ------------------------------------------------------------------ lifecycle
 
     async def _start(self) -> None:
-        """Lazily starts the run on first iteration: subscribes to the bus, then publishes
-        the entry request with streaming enabled."""
+        """Lazily starts the run on first iteration: subscribes for the run's completion,
+        then publishes the entry request with its chunk queue attached."""
         if self._started:
             return
         self._started = True

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -53,33 +53,20 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
     """
     The handle returned by `rt.astream(...)`.
 
-    A `Stream` is an async iterator over the chunks emitted during a streamed invocation. It
-    yields *only* chunks (typically `str` tokens); the node's final return value is exposed
-    separately so there is never any ambiguity between a chunk and the final result:
+    Async-iterate a `Stream` to receive the chunks (typically `str` tokens) emitted during
+    the run, then read the node's final return value from `.result`. The final result may
+    differ from the concatenation of the chunks (e.g. when output guardrails correct the
+    buffered response).
 
-    ```python
-    stream = rt.astream(agent, user_input="Write a poem.")
-    async for chunk in stream:
-        print(chunk, end="", flush=True)
-    final = stream.result  # the node's complete return value (e.g. StringResponse)
-    ```
+    A `Stream` is also awaitable: `await stream` runs it to completion (discarding unread
+    chunks) and returns the final result, which is useful when you break out of iteration
+    early but still want the result. The run always finishes; breaking does not cancel it.
 
-    The final result may legitimately differ from the concatenation of the streamed chunks —
-    for example when output guardrails gate/correct the buffered response after the raw tokens
-    were streamed.
+    If the node raises, the exception propagates out of the `async for` loop (or the
+    `await`), exactly like `rt.call`.
 
-    A `Stream` is also awaitable: `final = await stream` consumes the stream to completion
-    (discarding any unread chunks) and returns the final result. This is handy when you stop
-    iterating early (`break`) but still want the run to finish and the result to be available —
-    the underlying invocation always runs to completion; breaking out of the loop does not
-    cancel it.
-
-    Error behavior: if the invoked node raises, the exception propagates out of the `async for`
-    loop (or the `await`), exactly like `rt.call`.
-
-    Notes:
-        - Iterate (and await) a `Stream` from a single task.
-        - The stream honors the session's `timeout` as a wall-clock limit on the whole run.
+    Iterate (and await) a `Stream` from a single task. The run honors the session's
+    `timeout` as a wall-clock limit.
     """
 
     def __init__(
@@ -99,12 +86,8 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
             node: The node type to invoke.
             args: The positional arguments to pass to the node.
             kwargs: The keyword arguments to pass to the node.
-            on_start: Called once, just before the run is launched on first iteration. The
-                caller (`rt.astream`) uses this to set up the surrounding run context (e.g.
-                open a session when there is none). The `Stream` itself owns no such state.
-            on_close: Called once when the run finishes (or errors, or times out). The caller
-                uses this to tear down whatever `on_start` set up. The two are paired so a
-                `Stream` never has to know about — or reach into — a session's lifecycle.
+            on_start: Called once, just before the run is launched on first iteration.
+            on_close: Called once when the run finishes, errors, or times out.
         """
         self._node = node
         self._args = args
@@ -122,7 +105,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         self._deadline: float | None = None
         self._timeout: float | None = None
         # run-context hooks supplied by the caller (session setup/teardown lives there,
-        # not in the Stream — see rt.astream)
+        # not in the Stream. see rt.astream)
         self._on_start = on_start
         self._on_close = on_close
         self._closed = False
@@ -152,7 +135,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         request_id = self._request_id
 
         def _subscriber(message: RequestCompletionMessage) -> None:
-            # the Stream only listens for run completion here — chunk delivery bypasses the bus.
+            # the Stream only listens for run completion here
             if isinstance(message, RequestFinishedBase):
                 if message.request_id == request_id:
                     queue.put_nowait(("done", message))
@@ -181,7 +164,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
         )
 
     def _cleanup(self) -> None:
-        """Unsubscribes from the bus and hands teardown of the run context back to the caller."""
+        """Hands teardown of the run context back to the caller."""
         if self._sub_id is not None:
             try:
                 get_publisher().unsubscribe(self._sub_id)
@@ -285,29 +268,16 @@ def astream(
     **kwargs: _P.kwargs,
 ) -> Stream[_TOutput]:
     """
-    Invoke a node with streaming enabled and return a `Stream` over its emitted chunks.
+    Invoke an agent node with streaming enabled and return a `Stream` over its emitted chunks.
 
-    This is the streaming entry point of railtracks. The same node/agent object serves
-    streaming and non-streaming runs — `rt.call` runs it buffered, `rt.astream` streams it.
-    Streaming is frame-local: only the node you invoke here streams its LLM responses;
-    nested `rt.call` children run buffered.
-
-    Usage:
-    ```python
-    stream = rt.astream(agent, user_input="Write a short poem about rain.")
-    async for chunk in stream:
-        print(chunk, end="", flush=True)   # str token chunks
-    final = stream.result                  # the complete StringResponse
-    ```
-
-    When you only care about the final result of the streamed run:
-    ```python
-    final = await rt.astream(agent, user_input="...")
-    ```
+    Async-iterate the returned `Stream` for token chunks and read `.result` for the final
+    return value, or `await` it directly when you only want the result. Streaming is
+    frame-local: only the node invoked here streams its LLM responses; nested `rt.call`
+    children run buffered.
 
     Args:
-        node_: The node to invoke. This can be a node class or a function decorated with
-            `@function_node` (same as `rt.call`).
+        node_: The agent node to invoke. This can be a node class or a function decorated
+            with `@function_node` (same as `rt.call`).
         *args: The positional arguments to pass to the node.
         **kwargs: The keyword arguments to pass to the node.
 
@@ -328,7 +298,7 @@ def astream(
         node = cast("type[Node[_P, _TOutput]]", node_)
 
     # rt.astream streams an agent's LLM tokens, so it only accepts agent nodes. Anything else
-    # (a @function_node / tool node) has no token stream to surface — use rt.call instead.
+    # (a @function_node / tool node) has no token stream to surface use rt.call instead.
     node_kind = node.type() if hasattr(node, "type") else None
     if node_kind != "Agent":
         name = node.name() if hasattr(node, "name") else repr(node_)

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -12,7 +12,6 @@ from typing import (
     NoReturn,
     ParamSpec,
     TypeVar,
-    cast,
 )
 from uuid import uuid4
 
@@ -25,7 +24,6 @@ from railtracks.context.central import (
     is_context_present,
 )
 from railtracks.exceptions import GlobalTimeOutError, NodeCreationError
-from railtracks.nodes.utils import extract_node_from_function
 from railtracks.pubsub.messages import (
     FatalFailure,
     RequestCompletionMessage,
@@ -37,7 +35,6 @@ from railtracks.utils.logging import get_rt_logger
 
 if TYPE_CHECKING:
     from railtracks._session import Session
-    from railtracks.built_nodes.function.base import RTFunction
     from railtracks.nodes.nodes import Node
 
 _P = ParamSpec("_P")
@@ -263,7 +260,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
 
 
 def astream(
-    node_: type[Node[_P, _TOutput]] | RTFunction[_P, _TOutput],
+    node_: type[Node[_P, _TOutput]],
     *args: _P.args,
     **kwargs: _P.kwargs,
 ) -> Stream[_TOutput]:
@@ -276,32 +273,31 @@ def astream(
     children run buffered.
 
     Args:
-        node_: The agent node to invoke. This can be a node class or a function decorated
-            with `@function_node` (same as `rt.call`).
+        node_: The agent node class to invoke (built with `rt.agent_node(...)`). Only agent
+            nodes are accepted; a `@function_node` / tool node has no token stream to
+            surface, so use `rt.call` for those.
         *args: The positional arguments to pass to the node.
         **kwargs: The keyword arguments to pass to the node.
 
     Returns:
         Stream[_TOutput]: An async iterator over the chunks, with the final result available
             via `.result` (or by awaiting the stream).
+
+    Raises:
+        NodeCreationError: If `node_` is not an agent node.
     """
-    node: type[Node[_P, _TOutput]]
+    # local import to prevent circular import issues (mirrors rt.call)
+    from railtracks.nodes.nodes import Node
 
-    if hasattr(node_, "node_type"):
-        # local import to prevent circular import issues (mirrors rt.call)
-        from railtracks.built_nodes.function.base import RTFunction
-
-        assert isinstance(node_, RTFunction)
-        node = extract_node_from_function(node_)
-    else:
-        # not an RTFunction (no `node_type`), so it is already a Node subclass
-        node = cast("type[Node[_P, _TOutput]]", node_)
-
-    # rt.astream streams an agent's LLM tokens, so it only accepts agent nodes. Anything else
-    # (a @function_node / tool node) has no token stream to surface use rt.call instead.
-    node_kind = node.type() if hasattr(node, "type") else None
-    if node_kind != "Agent":
-        name = node.name() if hasattr(node, "name") else repr(node_)
+    # rt.astream streams an agent's LLM tokens, so it only accepts agent nodes built with
+    # rt.agent_node(...). Validate the input up front: anything that is not an agent `Node`
+    # subclass (a @function_node / tool node, or a raw value) has no token stream to surface,
+    # so it is rejected here rather than unpacked use rt.call instead.
+    is_agent_node = (
+        isinstance(node_, type) and issubclass(node_, Node) and node_.type() == "Agent"
+    )
+    if not is_agent_node:
+        name = getattr(node_, "__name__", None) or repr(node_)
         raise NodeCreationError(
             message=f"rt.astream only supports agent nodes, but {name!r} is not one.",
             notes=[
@@ -309,6 +305,7 @@ def astream(
                 "To run a function/tool node, use rt.call(...) instead.",
             ],
         )
+    node = node_
 
     # Session lifecycle is owned here, not by the Stream handle. When called outside any
     # session we open one and hold it in this closure; the Stream calls `_close` back once

--- a/packages/railtracks/src/railtracks/interaction/_astream.py
+++ b/packages/railtracks/src/railtracks/interaction/_astream.py
@@ -24,14 +24,13 @@ from railtracks.context.central import (
     get_run_id,
     is_context_present,
 )
-from railtracks.exceptions import GlobalTimeOutError
+from railtracks.exceptions import GlobalTimeOutError, NodeCreationError
 from railtracks.nodes.utils import extract_node_from_function
 from railtracks.pubsub.messages import (
     FatalFailure,
     RequestCompletionMessage,
     RequestCreation,
     RequestFinishedBase,
-    Streaming,
 )
 from railtracks.pubsub.utils import output_mapping
 from railtracks.utils.logging import get_rt_logger
@@ -144,22 +143,23 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
 
         await activate_publisher()
         publisher = get_publisher()
+        # token chunks are written onto this queue directly by the streamed frame's LLM node
+        # (via the frame-local queue carried in its context); the completion subscriber below
+        # enqueues the terminal ("done", ...) marker.
         queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         self._queue = queue
 
         request_id = self._request_id
 
         def _subscriber(message: RequestCompletionMessage) -> None:
-            if isinstance(message, Streaming):
-                if message.stream_id == request_id:
-                    queue.put_nowait(("chunk", message.streamed_object))
-            elif isinstance(message, RequestFinishedBase):
+            # the Stream only listens for run completion here — chunk delivery bypasses the bus.
+            if isinstance(message, RequestFinishedBase):
                 if message.request_id == request_id:
                     queue.put_nowait(("done", message))
             elif isinstance(message, FatalFailure):
                 queue.put_nowait(("done", message))
 
-        # subscribe BEFORE publishing the request so no chunk can be missed
+        # subscribe BEFORE publishing the request so the completion marker can't be missed
         self._sub_id = publisher.subscribe(_subscriber, name="astream subscriber")
 
         self._timeout = get_local_config().timeout
@@ -176,7 +176,7 @@ class Stream(Generic[_TOutput], AsyncIterator[Any]):
                 new_node_type=self._node,
                 args=self._args,
                 kwargs=self._kwargs,
-                stream=True,
+                stream_queue=queue,
             )
         )
 
@@ -326,6 +326,19 @@ def astream(
     else:
         # not an RTFunction (no `node_type`), so it is already a Node subclass
         node = cast("type[Node[_P, _TOutput]]", node_)
+
+    # rt.astream streams an agent's LLM tokens, so it only accepts agent nodes. Anything else
+    # (a @function_node / tool node) has no token stream to surface — use rt.call instead.
+    node_kind = node.type() if hasattr(node, "type") else None
+    if node_kind != "Agent":
+        name = node.name() if hasattr(node, "name") else repr(node_)
+        raise NodeCreationError(
+            message=f"rt.astream only supports agent nodes, but {name!r} is not one.",
+            notes=[
+                "Pass an agent built with rt.agent_node(...) to rt.astream(...).",
+                "To run a function/tool node, use rt.call(...) instead.",
+            ],
+        )
 
     # Session lifecycle is owned here, not by the Stream handle. When called outside any
     # session we open one and hold it in this closure; the Stream calls `_close` back once

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -17,7 +17,6 @@ from railtracks.context.central import (
     get_parent_id,
     get_publisher,
     get_run_id,
-    get_stream_id,
     is_context_active,
     is_context_present,
 )
@@ -202,7 +201,7 @@ async def _execute(
     request_id = str(uuid4())
 
     # Streaming is opt-in and frame-local: a regular `rt.call` NEVER streams. The only
-    # enabler is `rt.astream`, which publishes its own RequestCreation with stream=True.
+    # enabler is `rt.astream`, which publishes its own RequestCreation with a stream_queue.
 
     # note we set the listener before we publish the messages ensure that we do not miss any messages
     # I am actually a bit worried about this logic and I think there is a chance of a bug popping up here.
@@ -217,7 +216,6 @@ async def _execute(
             new_node_type=node,
             args=args,
             kwargs=kwargs,
-            current_stream_id=get_stream_id(),
         )
     )
 

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from railtracks.context.central import get_parent_id, get_publisher
-from railtracks.pubsub.messages import Streaming
+from railtracks.pubsub.messages import BroadcastEvent
 
 
 async def broadcast(item: str):
@@ -9,14 +9,12 @@ async def broadcast(item: str):
     Broadcasts a one-off **event** to the session bus.
 
     This triggers the `broadcast_callback` you have provided to the `Session` (or via
-    `rt.set_config`). Events are separate from LLM token streaming: token chunks flow directly
-    to the `rt.astream` handle and never appear here.
+    `rt.set_config`). Each broadcast is a discrete event, independent of any LLM token
+    output an agent produces.
 
     Args:
         item (str): The item you want to broadcast.
     """
     publisher = get_publisher()
 
-    await publisher.publish(
-        Streaming(node_id=get_parent_id(), streamed_object=item)
-    )
+    await publisher.publish(BroadcastEvent(node_id=get_parent_id(), item=item))

--- a/packages/railtracks/src/railtracks/interaction/broadcast_.py
+++ b/packages/railtracks/src/railtracks/interaction/broadcast_.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, AsyncIterable, Iterable, Union
-
-from railtracks.context.central import get_parent_id, get_publisher, get_stream_id
-from railtracks.exceptions.errors import LLMError
-from railtracks.llm.response import Response
+from railtracks.context.central import get_parent_id, get_publisher
 from railtracks.pubsub.messages import Streaming
 
 
@@ -12,8 +8,9 @@ async def broadcast(item: str):
     """
     Broadcasts a one-off **event** to the session bus.
 
-    This triggers the `broadcast_callback` you have already provided. Events are 
-    separate from stream callbacks.
+    This triggers the `broadcast_callback` you have provided to the `Session` (or via
+    `rt.set_config`). Events are separate from LLM token streaming: token chunks flow directly
+    to the `rt.astream` handle and never appear here.
 
     Args:
         item (str): The item you want to broadcast.
@@ -21,65 +18,5 @@ async def broadcast(item: str):
     publisher = get_publisher()
 
     await publisher.publish(
-        Streaming(node_id=get_parent_id(), streamed_object=item, kind="event")
+        Streaming(node_id=get_parent_id(), streamed_object=item)
     )
-
-
-async def broadcast_stream(
-    stream: Union[AsyncIterable[Any], Iterable[Any]],
-    channel: str = "default",
-) -> Response:
-    """
-    Forwards a model's token stream to the run's streaming consumers and returns its complete
-    `Response`.
-
-    Each `str` chunk is published on `channel` as stream traffic (`rt.astream` receives it;
-    one-off `rt.broadcast` events go to `broadcast_callback`, not here). The stream's final
-    non-`str` item is the complete `Response`, which is returned. When no consumer is attached
-    the chunks are simply dropped, so the same node works with or without streaming.
-
-    Like the buffered model call, this fails fast: if the stream ends without producing a
-    `Response`, an `LLMError` is raised rather than returning a partial result.
-
-    Args:
-        stream: An async or sync iterable (e.g. `model.astream_chat(...)`) yielding `str`
-            chunks terminated by a final `Response`.
-        channel: The named channel to emit chunks on. Defaults to `"default"`.
-
-    Returns:
-        Response: The complete response yielded at the end of the stream.
-
-    Raises:
-        LLMError: If the stream is exhausted without yielding a final `Response`.
-    """
-    final: Any = None
-    publisher = get_publisher()
-
-    async def _publish_chunk(chunk: str) -> None:
-        await publisher.publish(
-            Streaming(
-                node_id=get_parent_id(),
-                streamed_object=chunk,
-                channel=channel,
-                stream_id=get_stream_id(),
-                kind="stream",
-            )
-        )
-
-    if hasattr(stream, "__aiter__"):
-        async for item in stream:  # type: ignore[union-attr]
-            if isinstance(item, str):
-                await _publish_chunk(item)
-            else:
-                final = item
-    else:
-        for item in stream:  # type: ignore[union-attr]
-            if isinstance(item, str):
-                await _publish_chunk(item)
-            else:
-                final = item
-
-    if not isinstance(final, Response):
-        raise LLMError(reason="The stream did not yield a final Response object.")
-
-    return final

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -501,11 +501,10 @@ class LiteLLMWrapper(ModelBase, ABC):
     # ================ END Streaming Handlers ===============
 
     # ================ START Per-call Streaming LLM calls ===============
-    # These implement the ModelBase._astream_* extension points. Each one forces a streamed
-    # request (regardless of the deprecated constructor-level stream flag) and returns an async
-    # generator yielding `str` chunks followed by a single final `Response`. They ride litellm's
-    # synchronous `completion(stream=True)` API, bridged onto the event loop by
-    # `_bridge_sync_stream` (a dedicated worker thread), so the loop never blocks.
+    # These implement the ModelBase._astream_* extension points. Each one requests a streamed
+    # response and returns an async generator yielding `str` chunks followed by a single final
+    # `Response`. They ride litellm's synchronous `completion(stream=True)` API, bridged onto the
+    # event loop by `_bridge_sync_stream` (a dedicated worker thread), so the loop never blocks.
 
     async def _astream_chat(self, messages: MessageHistory):
         def _open() -> Generator[str | Response, None, Response]:

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -329,7 +329,7 @@ class LiteLLMWrapper(ModelBase, ABC):
 
         Opens, iterates, and closes the blocking stream entirely on the calling thread (so the
         network stream object is never touched from more than one thread), marshaling each item
-        — or a terminal `_STREAM_DONE` / exception — back to the loop thread via `queue`.
+        or a terminal `_STREAM_DONE` / exception  back to the loop thread via `queue`.
         """
         try:
             gen = make_stream()

--- a/packages/railtracks/src/railtracks/llm/response.py
+++ b/packages/railtracks/src/railtracks/llm/response.py
@@ -108,7 +108,7 @@ class Response:
         The plain-text content of the response message.
 
         This is a typed convenience accessor for the common case where the model returned
-        text (e.g. the final `Response` of `astream_chat` / `broadcast_stream`).
+        text (e.g. the final `Response` of `astream_chat`).
 
         Returns:
             str: The message's text content.

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -28,7 +28,7 @@ class Flow(Generic[_P, _TOutput]):
         context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
+        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -28,8 +28,7 @@ class Flow(Generic[_P, _TOutput]):
         context (dict[str, Any], optional): Context to be passed to all instantiations (or runs) of this flow. Note that the context can be overridden at invocation time.
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
-        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. Stream chunks go to `stream_callback` instead.
-        stream_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for stream chunks published through `rt.broadcast_stream` (LLM token streams included). It never enables streaming.
+        broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
         prompt_injection (bool, optional): If True, the prompt will be automatically injected from context variables.
         save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
@@ -44,9 +43,6 @@ class Flow(Generic[_P, _TOutput]):
         timeout: float | None = None,
         end_on_error: bool | None = None,
         broadcast_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
-        stream_callback: (
             Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
         ) = None,
         prompt_injection: bool | None = None,
@@ -65,7 +61,6 @@ class Flow(Generic[_P, _TOutput]):
         self._timeout = timeout
         self._end_on_error = end_on_error
         self._broadcast_callback = broadcast_callback
-        self._stream_callback = stream_callback
         self._prompt_injection = prompt_injection
         self._save_state = save_state
         self._payload_callback = payload_callback
@@ -87,7 +82,6 @@ class Flow(Generic[_P, _TOutput]):
             timeout=self._timeout,
             end_on_error=self._end_on_error,
             broadcast_callback=self._broadcast_callback,
-            stream_callback=self._stream_callback,
             prompt_injection=self._prompt_injection,
             save_state=self._save_state,
             payload_callback=self._payload_callback,

--- a/packages/railtracks/src/railtracks/pubsub/__init__.py
+++ b/packages/railtracks/src/railtracks/pubsub/__init__.py
@@ -20,9 +20,9 @@ __all__ = [
     "Streaming",
     "output_mapping",
     "RTPublisher",
-    "stream_subscriber",
+    "event_subscriber",
 ]
 
-from ._subscriber import stream_subscriber
+from ._subscriber import event_subscriber
 from .publisher import RTPublisher
 from .utils import output_mapping

--- a/packages/railtracks/src/railtracks/pubsub/__init__.py
+++ b/packages/railtracks/src/railtracks/pubsub/__init__.py
@@ -1,4 +1,5 @@
 from .messages import (
+    BroadcastEvent,
     FatalFailure,
     RequestCompletionMessage,
     RequestCreation,
@@ -6,7 +7,6 @@ from .messages import (
     RequestFailure,
     RequestFinishedBase,
     RequestSuccess,
-    Streaming,
 )
 
 __all__ = [
@@ -17,7 +17,7 @@ __all__ = [
     "RequestSuccess",
     "RequestFinishedBase",
     "FatalFailure",
-    "Streaming",
+    "BroadcastEvent",
     "output_mapping",
     "RTPublisher",
     "event_subscriber",

--- a/packages/railtracks/src/railtracks/pubsub/_subscriber.py
+++ b/packages/railtracks/src/railtracks/pubsub/_subscriber.py
@@ -1,24 +1,22 @@
 import asyncio
 from typing import Any, Callable, Coroutine, Union
 
-from .messages import RequestCompletionMessage, Streaming
+from .messages import BroadcastEvent, RequestCompletionMessage
 
 
 def event_subscriber(
     sub_callback: Callable[[Any], Union[None, Coroutine[None, None, None]]],
 ) -> Callable[[RequestCompletionMessage], Coroutine[None, None, None]]:
     """
-    Wraps a user callback into a bus handler for one-off broadcast events.
+    Wraps a user callback into a bus handler for broadcast events.
 
-    The handler fires only on `Streaming` messages (published by `rt.broadcast`), forwarding
-    the broadcast item to `sub_callback`. LLM token streaming does not flow through the bus —
-    it is consumed directly by the `rt.astream` handle — so this callback only ever sees
-    explicit `rt.broadcast` events.
+    Fires on each `BroadcastEvent` message (published by `rt.broadcast`), forwarding the
+    event to `sub_callback`. This is the only traffic `BroadcastEvent` carries.
     """
 
-    async def subscriber_handler(item: RequestCompletionMessage):
-        if isinstance(item, Streaming):
-            result = sub_callback(item.streamed_object)
+    async def subscriber_handler(message: RequestCompletionMessage):
+        if isinstance(message, BroadcastEvent):
+            result = sub_callback(message.item)
             if asyncio.iscoroutine(result):
                 await result
 

--- a/packages/railtracks/src/railtracks/pubsub/_subscriber.py
+++ b/packages/railtracks/src/railtracks/pubsub/_subscriber.py
@@ -1,28 +1,23 @@
 import asyncio
 from typing import Any, Callable, Coroutine, Union
 
-from .messages import RequestCompletionMessage, Streaming, StreamingKind
+from .messages import RequestCompletionMessage, Streaming
 
 
-def stream_subscriber(
+def event_subscriber(
     sub_callback: Callable[[Any], Union[None, Coroutine[None, None, None]]],
-    kind: StreamingKind = "event",
 ) -> Callable[[RequestCompletionMessage], Coroutine[None, None, None]]:
     """
-    Wraps a user callback into a bus handler that receives one traffic lane.
+    Wraps a user callback into a bus handler for one-off broadcast events.
 
-    The two lanes are kept separate so consumers never mix them up:
-    - `kind="event"` (default): one-off `rt.broadcast` items — this drives `broadcast_callback`.
-    - `kind="stream"`: chunks from `rt.broadcast_stream` / LLM token streaming — this drives
-      `stream_callback`.
-
-    A handler only fires on `Streaming` messages matching its `kind`, so a `broadcast_callback`
-    is never flooded with tokens when a run streams, and a `stream_callback` never sees one-off
-    broadcast events.
+    The handler fires only on `Streaming` messages (published by `rt.broadcast`), forwarding
+    the broadcast item to `sub_callback`. LLM token streaming does not flow through the bus —
+    it is consumed directly by the `rt.astream` handle — so this callback only ever sees
+    explicit `rt.broadcast` events.
     """
 
     async def subscriber_handler(item: RequestCompletionMessage):
-        if isinstance(item, Streaming) and item.kind == kind:
+        if isinstance(item, Streaming):
             result = sub_callback(item.streamed_object)
             if asyncio.iscoroutine(result):
                 await result

--- a/packages/railtracks/src/railtracks/pubsub/messages.py
+++ b/packages/railtracks/src/railtracks/pubsub/messages.py
@@ -194,29 +194,26 @@ class FatalFailure(RequestCompletionMessage):
         return f"{self.__class__.__name__}(error={self.error})"
 
 
-class Streaming(RequestCompletionMessage):
+class BroadcastEvent(RequestCompletionMessage):
     """
-    A message carrying a single one-off broadcast event published with `rt.broadcast`.
+    A message carrying a single one-off event published with `rt.broadcast`.
 
-    LLM token chunks are NOT carried here — those flow directly to the `rt.astream` handle
-    through its per-call queue. This message drives the `broadcast_callback` event lane only.
+    This drives the `broadcast_callback` lane: a user emits a discrete event from inside a
+    node and any attached callback receives it. Each event stands alone.
 
     Args:
-        streamed_object: The event item being broadcast (typically a `str`).
+        item: The event being broadcast (typically a `str`).
         node_id: The id of the node that emitted the event.
     """
 
     def __init__(
         self,
         *,
-        streamed_object: Any,
+        item: Any,
         node_id: str | None,
     ):
-        self.streamed_object = streamed_object
+        self.item = item
         self.node_id = node_id
 
     def __repr__(self):
-        return (
-            f"{self.__class__.__name__}(streamed_object={self.streamed_object}, "
-            f"node_id={self.node_id})"
-        )
+        return f"{self.__class__.__name__}(item={self.item}, node_id={self.node_id})"

--- a/packages/railtracks/src/railtracks/pubsub/messages.py
+++ b/packages/railtracks/src/railtracks/pubsub/messages.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from abc import ABC
 from typing import Any, Generic, Literal, ParamSpec, Type, TypeVar
 
@@ -143,11 +144,10 @@ class RequestCreation(RequestCompletionMessage):
         new_node_type: The node type to instantiate for this request.
         args: The positional arguments to pass to the node.
         kwargs: The keyword arguments to pass to the node.
-        stream: If True, the created node's frame will have streaming enabled (see `rt.astream`).
-            Note this flag is frame-local: it applies only to the node created by this request,
-            never to its children.
-        current_stream_id: The stream scope id of the *creating* frame. Children inherit this id so
-            their explicit broadcasts can be routed to the consumer attached to the entry frame.
+        stream_queue: When set, the created node is the entry of a streamed invocation (see
+            `rt.astream`): its LLM node writes each token chunk directly onto this queue, which
+            the `Stream` handle drains. Frame-local — it applies only to the node created by
+            this request, never to its children (nested `rt.call` children run buffered).
     """
 
     def __init__(
@@ -160,8 +160,7 @@ class RequestCreation(RequestCompletionMessage):
         new_node_type: Type[Node],
         args,
         kwargs,
-        stream: bool = False,
-        current_stream_id: str | None = None,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ):
         self.current_node_id = current_node_id
         self.current_run_id = current_run_id
@@ -170,8 +169,7 @@ class RequestCreation(RequestCompletionMessage):
         self.new_node_type = new_node_type
         self.args = args
         self.kwargs = kwargs
-        self.stream = stream
-        self.current_stream_id = current_stream_id
+        self.stream_queue = stream_queue
 
     def __repr__(self):
         return (
@@ -196,23 +194,16 @@ class FatalFailure(RequestCompletionMessage):
         return f"{self.__class__.__name__}(error={self.error})"
 
 
-# A one-off "event" versus a "stream" chunk (one piece of a continuous production, such as
-# an LLM token stream).
-StreamingKind = Literal["event", "stream"]
-
-
 class Streaming(RequestCompletionMessage):
     """
-    A message carrying a single streamed item (e.g. an LLM token chunk or a broadcast item).
+    A message carrying a single one-off broadcast event published with `rt.broadcast`.
+
+    LLM token chunks are NOT carried here — those flow directly to the `rt.astream` handle
+    through its per-call queue. This message drives the `broadcast_callback` event lane only.
 
     Args:
-        streamed_object: The item being streamed (typically a `str` chunk).
-        node_id: The id of the node that emitted the item.
-        channel: The named channel this item was emitted on. Defaults to `"default"`.
-        stream_id: The stream scope this item belongs to, or None if it was emitted outside
-            any streaming scope.
-        kind: Whether this item is a one-off `"event"` or a `"stream"` chunk (one piece of a
-            continuous production, such as an LLM token stream).
+        streamed_object: The event item being broadcast (typically a `str`).
+        node_id: The id of the node that emitted the event.
     """
 
     def __init__(
@@ -220,19 +211,12 @@ class Streaming(RequestCompletionMessage):
         *,
         streamed_object: Any,
         node_id: str | None,
-        channel: str = "default",
-        stream_id: str | None = None,
-        kind: StreamingKind = "event",
     ):
         self.streamed_object = streamed_object
         self.node_id = node_id
-        self.channel = channel
-        self.stream_id = stream_id
-        self.kind = kind
 
     def __repr__(self):
         return (
             f"{self.__class__.__name__}(streamed_object={self.streamed_object}, "
-            f"node_id={self.node_id}, channel={self.channel}, stream_id={self.stream_id}, "
-            f"kind={self.kind})"
+            f"node_id={self.node_id})"
         )

--- a/packages/railtracks/src/railtracks/state/state.py
+++ b/packages/railtracks/src/railtracks/state/state.py
@@ -90,12 +90,11 @@ class RTState:
         if isinstance(item, RequestCreation):
             previous_context = safe_get_runner_context()
             if item.current_node_id is not None:
-                # restore the creating frame's context (including its stream scope) so the
-                # task created below inherits the correct lineage.
+                # restore the creating frame's context so the task created below inherits the
+                # correct lineage.
                 update_parent_id(
                     item.current_node_id,
                     item.current_run_id,
-                    stream_id=item.current_stream_id,
                 )
 
             try:
@@ -107,7 +106,7 @@ class RTState:
                     node=item.new_node_type,
                     args=item.args,
                     kwargs=item.kwargs,
-                    stream=item.stream,
+                    stream_queue=item.stream_queue,
                 )
             finally:
                 # restore publisher context after dispatching child tasks so root calls don't inherit stale run IDs
@@ -217,7 +216,7 @@ class RTState:
         node: type[Node[_P, _TOutput]],
         args,
         kwargs,
-        stream: bool = False,
+        stream_queue: asyncio.Queue[Any] | None = None,
     ):
         """
         This function will handle the creation of the node and the subsequent running of the node returning the result.
@@ -231,7 +230,8 @@ class RTState:
             node: The node you would like to create.
             args: The arguments to pass to the node.
             kwargs: The keyword arguments to pass to the node.
-            stream: If True, the created node's frame will have streaming enabled (frame-local).
+            stream_queue: When set, the created node is the entry of a streamed invocation and
+                writes its LLM chunks onto this queue (frame-local, see `rt.astream`).
 
         Returns:
             The output of the node that was run. It will match the output type of the child node that was run.
@@ -261,7 +261,9 @@ class RTState:
             logger.exception(rfa.to_logging_msg())
             raise e
         # you have to run this in a task so it isn't blocking other completions
-        outputs = asyncio.create_task(self._run_request(request_id, stream=stream))
+        outputs = asyncio.create_task(
+            self._run_request(request_id, stream_queue=stream_queue)
+        )
 
         return outputs
 
@@ -315,7 +317,9 @@ class RTState:
 
         return request_ids
 
-    async def _run_request(self, request_id: str, stream: bool = False):
+    async def _run_request(
+        self, request_id: str, stream_queue: asyncio.Queue[Any] | None = None
+    ):
         """
         Runs the request for the given request id.
 
@@ -326,7 +330,8 @@ class RTState:
 
         Args:
             request_id: The identifier for the request you would like to run
-            stream: If True, the node's frame will have streaming enabled (frame-local).
+            stream_queue: When set, the node's frame streams its LLM chunks onto this queue
+                (frame-local, see `rt.astream`).
 
 
         """
@@ -337,7 +342,7 @@ class RTState:
                 request_id=request_id,
                 node=node,
                 arguments=self._request_heap[request_id].input,
-                stream=stream,
+                stream_queue=stream_queue,
             ),
             mode="async",
         )

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -23,7 +23,7 @@ class ExecutorConfig:
         Args:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
-            broadcast_callback (Callable or Coroutine): A passive listener for one-off **events** published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
+            broadcast_callback (Callable or Coroutine): A passive listener for one-off **events** published with `rt.broadcast`.
             prompt_injection (bool): If true, prompts can be injected with global context
             save_state (bool): If true, the state of the executor will be saved to disk.
         """

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -13,9 +13,6 @@ class ExecutorConfig:
         broadcast_callback: (
             Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
         ) = None,
-        stream_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
         prompt_injection: bool = True,
         save_state: bool = True,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -26,15 +23,13 @@ class ExecutorConfig:
         Args:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
-            broadcast_callback (Callable or Coroutine): A passive listener for one-off **events** published with `rt.broadcast`. It never receives stream chunks — see `stream_callback`.
-            stream_callback (Callable or Coroutine): A passive listener for **stream chunks** published through `rt.broadcast_stream` (LLM token streams included). It never enables streaming — only `rt.astream` does.
+            broadcast_callback (Callable or Coroutine): A passive listener for one-off **events** published with `rt.broadcast`. (LLM token streaming is consumed directly by the `rt.astream` handle, not through a callback.)
             prompt_injection (bool): If true, prompts can be injected with global context
             save_state (bool): If true, the state of the executor will be saved to disk.
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.subscriber = broadcast_callback
-        self.stream_callback = stream_callback
         self.prompt_injection = prompt_injection
         # During test runs, disable save_state by default unless RAILTRACKS_ALLOW_PERSISTENCE is set
         self._user_save_state = save_state
@@ -59,9 +54,6 @@ class ExecutorConfig:
         subscriber: (
             Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
         ) = None,
-        stream_callback: (
-            Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
-        ) = None,
         prompt_injection: bool | None = None,
         save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
@@ -77,9 +69,6 @@ class ExecutorConfig:
             broadcast_callback=subscriber
             if subscriber is not None
             else self.subscriber,
-            stream_callback=stream_callback
-            if stream_callback is not None
-            else self.stream_callback,
             prompt_injection=prompt_injection
             if prompt_injection is not None
             else self.prompt_injection,

--- a/packages/railtracks/tests/integration_tests/run/test_astream.py
+++ b/packages/railtracks/tests/integration_tests/run/test_astream.py
@@ -1,0 +1,106 @@
+import asyncio
+
+import pytest
+import railtracks as rt
+from railtracks.exceptions import NodeCreationError
+
+
+def _agent(mock_llm, response: str):
+    """Builds a terminal agent whose mocked model streams `response` char-by-char."""
+    return rt.agent_node(
+        name="Streamer",
+        system_message="stream",
+        llm=mock_llm(response),
+    )
+
+
+@pytest.mark.asyncio
+async def test_astream_yields_chunks_and_result(mock_llm):
+    """Iterating the stream yields the token chunks; .result exposes the final Response."""
+    agent = _agent(mock_llm, "Echo")
+
+    stream = rt.astream(agent, user_input="go")
+    chunks = [chunk async for chunk in stream]
+
+    # the mock model streams one character per chunk
+    assert chunks == ["E", "c", "h", "o"]
+    assert "".join(chunks) == "Echo"
+    assert stream.result.text == "Echo"
+
+
+@pytest.mark.asyncio
+async def test_astream_await_returns_result(mock_llm):
+    """Awaiting the stream (without iterating) drains it and returns the final Response."""
+    agent = _agent(mock_llm, "Hello")
+
+    final = await rt.astream(agent, user_input="go")
+
+    assert final.text == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_astream_early_break_still_resolves_result(mock_llm):
+    """Breaking out early does not cancel the run; awaiting afterwards yields the full result."""
+    agent = _agent(mock_llm, "abcdef")
+
+    stream = rt.astream(agent, user_input="go")
+    seen = []
+    async for chunk in stream:
+        seen.append(chunk)
+        break
+
+    assert seen == ["a"]
+    # the underlying run always completes; the buffered result is the whole message
+    final = await stream
+    assert final.text == "abcdef"
+
+
+@pytest.mark.asyncio
+async def test_astream_nested_in_function_node(mock_llm):
+    """rt.astream is used inside a @function_node; the outer node is driven by rt.call."""
+    agent = _agent(mock_llm, "nested")
+
+    @rt.function_node
+    async def head(prompt: str) -> str:
+        collected = []
+        stream = rt.astream(agent, user_input=prompt)
+        async for chunk in stream:
+            collected.append(chunk)
+        # the streamed chunks reconstruct the message, and .result carries the Response
+        assert "".join(collected) == stream.result.text
+        return stream.result.text
+
+    result = await rt.call(head, "go")
+    assert result == "nested"
+
+
+@pytest.mark.asyncio
+async def test_astream_two_concurrent_streams_are_isolated(mock_llm):
+    """Two concurrent streams each receive only their own chunks (queues are per-call)."""
+    agent_a = _agent(mock_llm, "AAAA")
+    agent_b = _agent(mock_llm, "BBBB")
+
+    async def drain(stream):
+        return [chunk async for chunk in stream]
+
+    with rt.Session():
+        a = rt.astream(agent_a, user_input="go")
+        b = rt.astream(agent_b, user_input="go")
+        a_chunks, b_chunks = await asyncio.gather(drain(a), drain(b))
+
+    assert a_chunks == ["A", "A", "A", "A"]
+    assert b_chunks == ["B", "B", "B", "B"]
+    assert a.result.text == "AAAA"
+    assert b.result.text == "BBBB"
+
+
+@pytest.mark.asyncio
+async def test_astream_rejects_non_agent_node():
+    """rt.astream only accepts agent nodes; a function/tool node raises before running."""
+
+    @rt.function_node
+    async def head(prompt: str) -> str:
+        return prompt
+
+    with pytest.raises(NodeCreationError, match="only supports agent nodes"):
+        rt.astream(head, "go")

--- a/packages/railtracks/tests/unit_tests/context/test_central.py
+++ b/packages/railtracks/tests/unit_tests/context/test_central.py
@@ -118,7 +118,7 @@ def test_update_parent_id(monkeypatch, make_runner_context_vars):
     monkeypatch.setattr(central, "runner_context", mock.Mock(set=mock.Mock()))
     central.update_parent_id("new-parent")
     rt.prepare_new.assert_called_with(
-        "new-parent", new_run_id=None, stream=False, stream_id=None
+        "new-parent", new_run_id=None, stream_queue=None
     )
     central.runner_context.set.assert_called_with("new_ctx")
 

--- a/packages/railtracks/tests/unit_tests/execution/test_task.py
+++ b/packages/railtracks/tests/unit_tests/execution/test_task.py
@@ -12,7 +12,7 @@ async def test_invoke_calls_update_and_node_invoke(mock_get_run_id, mock_update_
     task = Task(request_id="req-1", node=mock_node, arguments=((), {}))
     result = await task.invoke()
     mock_update_parent_id.assert_called_once_with(
-        "mock-uuid", stream=False, stream_id=None
+        "mock-uuid", stream_queue=None
     )
     mock_node.wrapped_invoke.assert_awaited_once()
     assert result == "result"
@@ -26,7 +26,7 @@ async def test_invoke_propagates_exception(mock_update_parent_id, mock_get_run_i
     with pytest.raises(RuntimeError, match="fail!"):
         await task.invoke()
     mock_update_parent_id.assert_called_once_with(
-        "mock-uuid", stream=False, stream_id=None
+        "mock-uuid", stream_queue=None
     )
     mock_node.wrapped_invoke.assert_awaited_once()
 

--- a/packages/railtracks/tests/unit_tests/interaction/test_broadcast.py
+++ b/packages/railtracks/tests/unit_tests/interaction/test_broadcast.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import AsyncMock, patch
 from railtracks.interaction.broadcast_ import broadcast
-from railtracks.pubsub.messages import Streaming
+from railtracks.pubsub.messages import BroadcastEvent
 
 
 @pytest.mark.asyncio
-async def test_stream_publishes_streaming_message():
+async def test_broadcast_publishes_event_message():
     with patch("railtracks.interaction.broadcast_.get_publisher") as mock_get_publisher, \
          patch("railtracks.interaction.broadcast_.get_parent_id") as mock_get_parent_id:
 
@@ -13,14 +13,14 @@ async def test_stream_publishes_streaming_message():
         mock_publisher = AsyncMock()
         mock_get_publisher.return_value = mock_publisher
         mock_get_parent_id.return_value = "mock_node_id"
-        
+
         # Call the function
         await broadcast("test_message")
 
         mock_publisher.publish.assert_awaited_once()
-        
-        # Extract the actual Streaming object
+
+        # Extract the actual BroadcastEvent object
         message = mock_publisher.publish.await_args.args[0]
-        assert isinstance(message, Streaming)
+        assert isinstance(message, BroadcastEvent)
         assert message.node_id == "mock_node_id"
-        assert message.streamed_object == "test_message"
+        assert message.item == "test_message"

--- a/packages/railtracks/tests/unit_tests/pubsub/test_messages.py
+++ b/packages/railtracks/tests/unit_tests/pubsub/test_messages.py
@@ -1,6 +1,6 @@
 from railtracks.pubsub.messages import (
     RequestCompletionMessage, RequestSuccess, RequestFailure, RequestCreationFailure,
-    RequestCreation, FatalFailure, Streaming, RequestFinishedBase
+    RequestCreation, FatalFailure, BroadcastEvent, RequestFinishedBase
 )
 
 # ================= START RequestCompletionMessage base tests ============
@@ -90,20 +90,20 @@ def test_fatal_failure_repr(dummy_exception):
 
 # ================ END FatalFailure tests ===============
 
-# ================= START Streaming tests ============
+# ================= START BroadcastEvent tests ============
 
-def test_streaming_repr():
-    streamed_object = object()
-    m = Streaming(streamed_object=streamed_object, node_id="Z1")
+def test_broadcast_event_repr():
+    item = object()
+    m = BroadcastEvent(item=item, node_id="Z1")
     s = repr(m)
-    assert "Streaming" in s
+    assert "BroadcastEvent" in s
     assert "node_id=Z1" in s
-    assert str(id(streamed_object)) in s or "streamed_object" in s
+    assert str(id(item)) in s or "item" in s
 
-def test_streaming_is_a_message():
-    m = Streaming(streamed_object="abc", node_id="some_id")
+def test_broadcast_event_is_a_message():
+    m = BroadcastEvent(item="abc", node_id="some_id")
     assert isinstance(m, RequestCompletionMessage)
-    assert m.streamed_object == "abc"
+    assert m.item == "abc"
     assert m.node_id == "some_id"
 
-# ================ END Streaming tests ===============
+# ================ END BroadcastEvent tests ===============

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -86,36 +86,22 @@ def test_session_name_is_taken_from_executor_config():
 def test_setup_subscriber_adds_subscriber_if_present():
     sub_subscriber = Mock()
     runner = Session(broadcast_callback=sub_subscriber)
-    runner.executor_config.stream_callback = None
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_subscriber', return_value="fake_stream_sub") as m_stream:
+    with patch('railtracks._session.event_subscriber', return_value="fake_event_sub") as m_event:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_called_once_with(
-            "fake_stream_sub", name="Broadcast Callback Subscriber"
+            "fake_event_sub", name="Broadcast Callback Subscriber"
         )
-        m_stream.assert_called_once_with(sub_subscriber, kind="event")
-
-def test_setup_subscriber_adds_stream_callback_if_present():
-    stream_cb = Mock()
-    runner = Session(stream_callback=stream_cb)
-    runner.executor_config.subscriber = None
-    runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_subscriber', return_value="fake_stream_sub") as m_stream:
-        runner._setup_subscriber()
-        runner.publisher.subscribe.assert_called_once_with(
-            "fake_stream_sub", name="Stream Callback Subscriber"
-        )
-        m_stream.assert_called_once_with(stream_cb, kind="stream")
+        m_event.assert_called_once_with(sub_subscriber)
 
 def test_setup_subscriber_noop_if_no_subscriber(mock_dependencies):
     runner = Session()
     runner.executor_config.subscriber = None
-    runner.executor_config.stream_callback = None
     runner.publisher = MagicMock()
-    with patch('railtracks._session.stream_subscriber') as m_stream:
+    with patch('railtracks._session.event_subscriber') as m_event:
         runner._setup_subscriber()
         runner.publisher.subscribe.assert_not_called()
-        m_stream.assert_not_called()
+        m_event.assert_not_called()
 
 # ================ END Session: setup_subscriber ===============
 

--- a/packages/railtracks/tests/unit_tests/utils/conftest.py
+++ b/packages/railtracks/tests/unit_tests/utils/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 from unittest.mock import patch
 from railtracks.pubsub.publisher import Publisher, RTPublisher
-from railtracks.pubsub.messages import Streaming
+from railtracks.pubsub.messages import BroadcastEvent
 
 # ================================== Pub Sub Fixtures ==================================
 @pytest.fixture
@@ -43,10 +43,10 @@ async def async_publisher():
         yield pub
 
 @pytest.fixture
-def streamed_object():
-    class DummyStream: pass
-    return DummyStream()
+def event_item():
+    class DummyItem: pass
+    return DummyItem()
 
 @pytest.fixture
-def streaming_message(streamed_object):
-    return Streaming(streamed_object=streamed_object, node_id="123")
+def broadcast_event(event_item):
+    return BroadcastEvent(item=event_item, node_id="123")

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 from railtracks.utils.publisher import Publisher, Subscriber
 
-from railtracks.pubsub._subscriber import stream_subscriber
+from railtracks.pubsub._subscriber import event_subscriber
 
 # ================= START Subscriber class tests ============
 
@@ -382,11 +382,11 @@ class TestPublisherException:
         ), "Callback should still receive messages even if one broadcast_callback throws an exception"
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_callback_exception(self, streaming_message):
+    async def test_event_subscriber_callback_exception(self, streaming_message):
         def bad(val):
             raise Exception("fail!")  # coverage for error handling
 
-        handler = stream_subscriber(bad)
+        handler = event_subscriber(bad)
         with pytest.raises(Exception):
             await handler(streaming_message)
 # ================ END Publisher exception tests ===============
@@ -499,10 +499,10 @@ class TestPublisherSanity:
 
 # ================ END Publisher advanced tests ===============
 
-# ================= START Subscriber (stream_subscriber) tests ============
-class TestSubscriberStream:
+# ================= START Subscriber (event_subscriber) tests ============
+class TestSubscriberEvent:
     @pytest.mark.asyncio
-    async def test_stream_subscriber_handles_streaming_true(
+    async def test_event_subscriber_handles_streaming_true(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -510,13 +510,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = event_subscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_skips_non_streaming(self):
+    async def test_event_subscriber_skips_non_streaming(self):
         class DummyMsg:
             pass
 
@@ -525,13 +525,13 @@ class TestSubscriberStream:
         def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = event_subscriber(cb)
         await handler(DummyMsg())
         assert results == []
 
 
     @pytest.mark.asyncio
-    async def test_stream_subscriber_supports_async_callbacks(
+    async def test_event_subscriber_supports_async_callbacks(
         self, streaming_message, streamed_object
     ):
         results = []
@@ -539,11 +539,11 @@ class TestSubscriberStream:
         async def cb(val):
             results.append(val)
 
-        handler = stream_subscriber(cb)
+        handler = event_subscriber(cb)
         await handler(streaming_message)
         assert results == [streamed_object]
 
-# ================ END Subscriber (stream_subscriber) tests ===============
+# ================ END Subscriber (event_subscriber) tests ===============
 
 # ================= START Miscellaneous corner cases ============
 class TestMisc:

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -382,13 +382,13 @@ class TestPublisherException:
         ), "Callback should still receive messages even if one broadcast_callback throws an exception"
 
     @pytest.mark.asyncio
-    async def test_event_subscriber_callback_exception(self, streaming_message):
+    async def test_event_subscriber_callback_exception(self, broadcast_event):
         def bad(val):
             raise Exception("fail!")  # coverage for error handling
 
         handler = event_subscriber(bad)
         with pytest.raises(Exception):
-            await handler(streaming_message)
+            await handler(broadcast_event)
 # ================ END Publisher exception tests ===============
 
 # ================= START Publisher listener tests ============
@@ -502,8 +502,8 @@ class TestPublisherSanity:
 # ================= START Subscriber (event_subscriber) tests ============
 class TestSubscriberEvent:
     @pytest.mark.asyncio
-    async def test_event_subscriber_handles_streaming_true(
-        self, streaming_message, streamed_object
+    async def test_event_subscriber_handles_broadcast_event(
+        self, broadcast_event, event_item
     ):
         results = []
 
@@ -511,12 +511,12 @@ class TestSubscriberEvent:
             results.append(val)
 
         handler = event_subscriber(cb)
-        await handler(streaming_message)
-        assert results == [streamed_object]
+        await handler(broadcast_event)
+        assert results == [event_item]
 
 
     @pytest.mark.asyncio
-    async def test_event_subscriber_skips_non_streaming(self):
+    async def test_event_subscriber_skips_non_event(self):
         class DummyMsg:
             pass
 
@@ -532,7 +532,7 @@ class TestSubscriberEvent:
 
     @pytest.mark.asyncio
     async def test_event_subscriber_supports_async_callbacks(
-        self, streaming_message, streamed_object
+        self, broadcast_event, event_item
     ):
         results = []
 
@@ -540,8 +540,8 @@ class TestSubscriberEvent:
             results.append(val)
 
         handler = event_subscriber(cb)
-        await handler(streaming_message)
-        assert results == [streamed_object]
+        await handler(broadcast_event)
+        assert results == [event_item]
 
 # ================ END Subscriber (event_subscriber) tests ===============
 


### PR DESCRIPTION
## Summary

Refactor streaming to a single, plain mechanism. `rt.astream(agent, ...)` streams an agent's LLM tokens through a **per-call `asyncio.Queue`** carried frame-locally in context, instead of routing chunks over the pub/sub bus. This removes the channel / callback / `stream_id` machinery that existed only to route chunks back to the right consumer across the task boundary, a per-call queue answers that by construction.

The user-facing `Stream` shape is unchanged:

```python
@rt.function_node
async def head(chunk: str, logger) -> str:
    stream = rt.astream(node1, chunk)      # node1 is an agent_node
    async for c in stream:
        logger.pipe(c)
    return stream.result.text

final = await rt.call(head, "Echo [abc]", logger)
```

Concurrent streams are just separate handles, no more channels, isolation is structural (each has its own queue):

```python
a = rt.astream(node1, "Echo [123]")
b = rt.astream(node1, chunk)
a_res, b_res = await asyncio.gather(drain(a), drain(b))
```

## What changed

**New mechanism.** The `Stream` creates a queue and passes it on `RequestCreation(stream_queue=...)`; it rides the existing plumbing (`state → call_nodes → _run_request → Task → update_parent_id`) into the agent frame's `InternalContext` (frame-local, never inherited). `ModelInvoker` drains `model.astream_*` directly onto that queue. The bus still delivers run completion; the `Stream` enqueues a `("done", ...)` marker on `RequestFinished` so the consumer knows when to resolve `.result`.

**Agent-only.** `rt.astream` now requires an agent node (`Node.type() == "Agent"`); a `@function_node`/tool node raises `NodeCreationError`. Because streaming never propagates through nested frames, `stream_id` inheritance and channels are unnecessary. One can return a generator directly.

**Removed** (all greps to zero across `src` + `tests`): `broadcast_stream`, `stream_callback` (Session / Flow / `set_config` / `ExecutorConfig`), `StreamingKind`, `Streaming.kind`/`.channel`/`.stream_id`, `get_stream_id`, `is_streaming_enabled`, `stream_id` inheritance, `RequestCreation.stream`/`.current_stream_id`.

**Kept.** The `rt.broadcast` + `broadcast_callback` (`Streaming` simplified to `{streamed_object, node_id}`; `stream_subscriber` → `event_subscriber`). Also untouched: the model-layer `astream_chat*` methods (the token source), `Response.text`, `TOOL_CALLING_STREAMING_BLACKLIST`, and `couple` (middleware).

**Docstring** Changes I own the framework from last PR

This is a clean inverse of #1262 (which wired astream onto the bus)  every symbol that PR introduced is gone, while the #1257 model-level plumbing it built on remains intact.

## Notes

- `rt.astream` remains the only public streaming entry point; `Stream` is the return type only.
- `stream_queue` carries only token *data*; results and errors still flow through the bus completion path.
