### PR TITLE
flattening structure

### DIFF
--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -129,6 +129,9 @@ class Session:
             rt_publisher=self.publisher,
             executor_config=self.executor_config,
             global_context_vars=context,
+            flow_name=self.flow_name,
+            flow_id=self.flow_id,
+            session_name=self.name,
         )
 
         self._start_time = time.time()

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -42,9 +42,7 @@ async def _llm_observe(
     try:
         response: Response = await call(message_history, schema, tools)
     except Exception as e:
-        event = LLMFailureEvent.from_exception(
-            e, message_input=prev_message_history
-        )
+        event = LLMFailureEvent.from_exception(e, message_input=prev_message_history)
         await emit(event)
         raise e
 

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -110,6 +110,37 @@ def get_session_id() -> str | None:
     return context.session_context.session_id
 
 
+SessionIdentity = NamedTuple(
+    "SessionIdentity",
+    [
+        ("session_id", str),
+        ("flow_name", str | None),
+        ("flow_id", str | None),
+        ("session_name", str | None),
+    ],
+)
+
+
+def get_session_identity() -> SessionIdentity:
+    """
+    Get the full identity of the active session: its id plus the flow/session names it
+    was created with.
+
+    Returns:
+        SessionIdentity: The identity of the currently active session.
+
+    Raises:
+        ContextError: If the global variables have not been registered.
+    """
+    context = safe_get_runner_context().session_context
+    return SessionIdentity(
+        session_id=context.session_id,
+        flow_name=context.flow_name,
+        flow_id=context.flow_id,
+        session_name=context.session_name,
+    )
+
+
 def get_parent_id() -> str | None:
     """
     Get the id of the currently active node (walks up the scope chain to the
@@ -217,6 +248,9 @@ def restore_scope(scope: ScopeLink[ScopeEntry] | None, run_id: str | None):
         publisher=ctx.session_context.publisher,
         scope=scope,
         executor_config=ctx.session_context.executor_config,
+        flow_name=ctx.session_context.flow_name,
+        flow_id=ctx.session_context.flow_id,
+        session_name=ctx.session_context.session_name,
     )
     new_ctx = RunnerContextVars(
         session_context=new_session_context,
@@ -235,6 +269,9 @@ def register_globals(
     rt_publisher: RTPublisher | None,
     executor_config: ExecutorConfig,
     global_context_vars: dict[str, Any],
+    flow_name: str | None = None,
+    flow_id: str | None = None,
+    session_name: str | None = None,
 ):
     """
     Register the global variables for the current thread.
@@ -243,6 +280,9 @@ def register_globals(
         publisher=rt_publisher,
         session_id=session_id,
         executor_config=executor_config,
+        flow_name=flow_name,
+        flow_id=flow_id,
+        session_name=session_name,
     )
     e_c = MutableExternalContext(global_context_vars)
 

--- a/packages/railtracks/src/railtracks/context/session_context.py
+++ b/packages/railtracks/src/railtracks/context/session_context.py
@@ -45,12 +45,18 @@ class SessionContext:
         publisher: RTPublisher | None = None,
         scope: ScopeLink[ScopeEntry] | None = None,
         executor_config: ExecutorConfig,
+        flow_name: str | None = None,
+        flow_id: str | None = None,
+        session_name: str | None = None,
     ):
         self._scope: ScopeLink[ScopeEntry] | None = scope
         self._publisher: RTPublisher | None = publisher
         self._session_id: str = session_id
         self._run_id: str | None = run_id
         self._executor_config: ExecutorConfig = executor_config
+        self._flow_name: str | None = flow_name
+        self._flow_id: str | None = flow_id
+        self._session_name: str | None = session_name
 
     @property
     def executor_config(self) -> ExecutorConfig:
@@ -131,6 +137,18 @@ class SessionContext:
     def run_id(self) -> str | None:
         return self._run_id
 
+    @property
+    def flow_name(self) -> str | None:
+        return self._flow_name
+
+    @property
+    def flow_id(self) -> str | None:
+        return self._flow_id
+
+    @property
+    def session_name(self) -> str | None:
+        return self._session_name
+
     def with_scope_pushed(
         self, entry: ScopeEntry, *, run_id: str | None = None
     ) -> SessionContext:
@@ -144,4 +162,7 @@ class SessionContext:
             publisher=self._publisher,
             scope=new_scope,
             executor_config=self._executor_config,
+            flow_name=self._flow_name,
+            flow_id=self._flow_id,
+            session_name=self._session_name,
         )

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from typing_extensions import Self
@@ -39,6 +39,9 @@ class SpatialParent:
             raise ValueError(
                 f"SpatialParent subclass {self.__class__.__name__} must define a 'spatial_type' field."
             )
+        
+    def encode(self):
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -84,6 +87,9 @@ class Parent:
                 f"Parent subclass {self.__class__.__name__} must define a 'parent_type' field."
             )
 
+    def encode(self):
+        return asdict(self)
+
 
 @dataclass(frozen=True)
 class NodeParent(Parent):
@@ -111,7 +117,7 @@ TParent = TypeVar("TParent", bound=Parent)
 
 @dataclass(kw_only=True)
 class SessionEventBase(ABC, Generic[TSpatialParent]):
-    spatial_parent: TSpatialParent | Unset = field(init=False, default=UNSET)
+    spatial_parent: TSpatialParent | Unset = field(init=False, default=UNSET, metadata={"flatten": True})
 
     timestamp: datetime.datetime = field(
         init=False,
@@ -153,6 +159,22 @@ class SessionEventBase(ABC, Generic[TSpatialParent]):
         """
         ...
 
+    def encode(self):
+        encoded_json = {}
+        for f in fields(self):
+            if f.metadata.get("flatten", False):
+                inner_dict = getattr(self, f.name).encode()
+                for inner_key, inner_value in inner_dict.items():
+                    name = f"{f.name}_{inner_key}"
+                    encoded_json[name] = inner_value
+            else:
+                encoded_json[f.name] = getattr(self, f.name)
+        return encoded_json
+             
+
+
+            
+
 
 @dataclass(kw_only=True)
 class CreationEventBase(SessionEventBase[NoSpatialParent]):
@@ -170,7 +192,7 @@ class ParentEventBase(
     """A parent event is emitted after the created entity enters its own scope,
     so its parent resolves from the caller's ambient chain (no self-skip)."""
 
-    parent: TParent | Unset = field(init=False, default=UNSET)
+    parent: TParent | Unset = field(init=False, default=UNSET, metadata={"flatten": True})
 
     def resolve_relationships(self, scope: ScopeLink[ScopeEntry] | None):
         """Resolve the event's spatial parent and parent from the current scope chain.

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -39,7 +39,7 @@ class SpatialParent:
             raise ValueError(
                 f"SpatialParent subclass {self.__class__.__name__} must define a 'spatial_type' field."
             )
-        
+
     def encode(self):
         return asdict(self)
 
@@ -117,7 +117,9 @@ TParent = TypeVar("TParent", bound=Parent)
 
 @dataclass(kw_only=True)
 class SessionEventBase(ABC, Generic[TSpatialParent]):
-    spatial_parent: TSpatialParent | Unset = field(init=False, default=UNSET, metadata={"flatten": True})
+    spatial_parent: TSpatialParent | Unset = field(
+        init=False, default=UNSET, metadata={"flatten": True}
+    )
 
     timestamp: datetime.datetime = field(
         init=False,
@@ -170,10 +172,6 @@ class SessionEventBase(ABC, Generic[TSpatialParent]):
             else:
                 encoded_json[f.name] = getattr(self, f.name)
         return encoded_json
-             
-
-
-            
 
 
 @dataclass(kw_only=True)
@@ -192,7 +190,9 @@ class ParentEventBase(
     """A parent event is emitted after the created entity enters its own scope,
     so its parent resolves from the caller's ambient chain (no self-skip)."""
 
-    parent: TParent | Unset = field(init=False, default=UNSET, metadata={"flatten": True})
+    parent: TParent | Unset = field(
+        init=False, default=UNSET, metadata={"flatten": True}
+    )
 
     def resolve_relationships(self, scope: ScopeLink[ScopeEntry] | None):
         """Resolve the event's spatial parent and parent from the current scope chain.

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -44,7 +44,6 @@ _T = TypeVar("_T", bound=NodeAndMiddlewareSpatialParent | LLMAndMiddlewareSpatia
 
 @dataclass(kw_only=True)
 class MiddlewareEventBase(ParentEventBase[_T, MiddlewareParent], Generic[_T]):
-    parent: MiddlewareParent | Unset = UNSET
 
     def verify(self) -> None:
         super().verify()

--- a/packages/railtracks/src/railtracks/events/middleware.py
+++ b/packages/railtracks/src/railtracks/events/middleware.py
@@ -13,7 +13,6 @@ from railtracks.events._base import (
     MiddlewareParent,
     NodeAndMiddlewareSpatialParent,
     ParentEventBase,
-    Unset,
 )
 from railtracks.events._resolve import (
     middleware_parent,
@@ -44,7 +43,6 @@ _T = TypeVar("_T", bound=NodeAndMiddlewareSpatialParent | LLMAndMiddlewareSpatia
 
 @dataclass(kw_only=True)
 class MiddlewareEventBase(ParentEventBase[_T, MiddlewareParent], Generic[_T]):
-
     def verify(self) -> None:
         super().verify()
         assert self.parent != UNSET, (

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import asdict
-
 from railtracks.context.central import get_current_scope
 from railtracks.events._base import (
     SessionEventBase,

--- a/packages/railtracks/src/railtracks/events/send.py
+++ b/packages/railtracks/src/railtracks/events/send.py
@@ -36,4 +36,4 @@ async def pipe(event: SessionEventBase) -> None:
     event.resolve_relationships(get_current_scope())
     event.verify()
 
-    await publish_event(make_session_event(event.event_type(), asdict(event)))
+    await publish_event(make_session_event(event.event_type(), event.encode()))

--- a/packages/railtracks/src/railtracks/events/session.py
+++ b/packages/railtracks/src/railtracks/events/session.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+from railtracks.context.scope_link import ScopeLink
+from railtracks.context.session_context import ScopeEntry
+
+from ._base import (
+    NoSpatialParent,
+    SessionEventBase,
+)
+
+SessionStatus = Literal["success", "failure"]
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def format_error(error: BaseException) -> str:
+    """Stringify an exception for an event payload."""
+    return _ANSI_ESCAPE.sub("", str(error))
+
+
+@dataclass(kw_only=True)
+class SessionEventFamilyBase(SessionEventBase[NoSpatialParent]):
+    """A session event is the root of the event tree.
+
+    It is emitted outside of any node/middleware/llm scope, so there is nothing above
+    it in the chain to resolve: neither a spatial parent nor a parent.
+    """
+
+    session_id: str
+
+    def _get_spatial_parent(self, scope: ScopeLink[ScopeEntry] | None):
+        return NoSpatialParent()
+
+
+@dataclass(kw_only=True)
+class SessionStarted(SessionEventFamilyBase):
+    """A top-level run has begun. Carries the session identity plus the effective
+    configuration the run will execute under."""
+
+    flow_name: str | None
+    flow_id: str | None
+    session_name: str | None
+    entry_point_name: str
+    timeout: float | None
+    end_on_error: bool
+    save_state: bool
+
+    def event_type(self) -> str:
+        return "session.started"
+
+
+@dataclass(kw_only=True)
+class SessionCompleted(SessionEventFamilyBase):
+    """A top-level run has finished, successfully or otherwise. `error` is a
+    stringified exception and is only set when `status` is `"failure"`."""
+
+    status: SessionStatus
+    error: str | None
+    duration_seconds: float
+
+    def event_type(self) -> str:
+        return "session.completed"

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -18,9 +19,12 @@ from railtracks.context.central import (
     get_parent_id,
     get_publisher,
     get_run_id,
+    get_session_identity,
     is_context_active,
     is_context_present,
 )
+from railtracks.events.send import emit
+from railtracks.events.session import SessionCompleted, SessionStarted, format_error
 from railtracks.exceptions import GlobalTimeOutError
 from railtracks.nodes.utils import extract_node_from_function
 from railtracks.observability.configure import ensure_started, shutdown
@@ -148,6 +152,23 @@ async def _start(
     await ensure_started()
     await activate_publisher()
 
+    config = get_local_config()
+    identity = get_session_identity()
+
+    await emit(
+        SessionStarted(
+            session_id=identity.session_id,
+            flow_name=identity.flow_name,
+            flow_id=identity.flow_id,
+            session_name=identity.session_name,
+            entry_point_name=node.name() if hasattr(node, "name") else "Unknown",
+            timeout=config.timeout,
+            end_on_error=config.end_on_error,
+            save_state=config.save_state,
+        )
+    )
+    start_time = time.perf_counter()
+
     # there is a really funny edge case that we need to handle here to prevent if the user itself throws an timeout
     #  exception. It should be handled differently then the global timeout exception.
     #  Yes I am aware that is a bit of a hack but this is the best way to handle this specific case.
@@ -160,22 +181,36 @@ async def _start(
             timeout_exception_flag["value"] = True
             raise error
 
-    timeout = get_local_config().timeout
+    timeout = config.timeout
     fut = _execute(
         node, args=args, kwargs=kwargs, message_filter=_top_level_message_filter
     )
-    # Here we wait the completion of the future with timeouts.
+
+    error: BaseException | None = None
     try:
-        result = await asyncio.wait_for(wrapped_fut(fut), timeout=timeout)
-    except asyncio.TimeoutError as e:
-        # if the internal flag is set then the coroutine itself raised a timeout error and it was not the wait
-        #  for function.
-        if timeout_exception_flag["value"]:
-            raise e
+        # Here we wait the completion of the future with timeouts.
+        try:
+            result = await asyncio.wait_for(wrapped_fut(fut), timeout=timeout)
+        except asyncio.TimeoutError as e:
+            # if the internal flag is set then the coroutine itself raised a timeout error and it was not the wait
+            #  for function.
+            if timeout_exception_flag["value"]:
+                raise e
 
-        raise GlobalTimeOutError(timeout=timeout)
-
-    await shutdown()
+            raise GlobalTimeOutError(timeout=timeout)
+    except BaseException as e:
+        error = e
+        raise
+    finally:
+        await emit(
+            SessionCompleted(
+                session_id=identity.session_id,
+                status="success" if error is None else "failure",
+                error=None if error is None else format_error(error),
+                duration_seconds=time.perf_counter() - start_time,
+            )
+        )
+        await shutdown()
 
     return result
 

--- a/packages/railtracks/tests/unit_tests/events/test_hot_path.py
+++ b/packages/railtracks/tests/unit_tests/events/test_hot_path.py
@@ -2,11 +2,13 @@
 
 Unlike `test_send.py` (which drives `pipe` directly against a synthetic scope), this runs
 `rt.call` end-to-end and checks that the emission sites in `nodes.py`,
-`execution_strategy.py`, and `state.py` fire with the right lifecycle and parents.
+`_node_builder.py`, and `state.py` fire with the right lifecycle and relationships.
+
+Only `node.creation` carries the node's name/id; the running events identify themselves
+through the resolved `parent` (which, for a node event, is the node itself).
 """
 
 import railtracks as rt
-from railtracks.events._base import NodeParent, NoParent
 from railtracks.observability import Event, configure_writers
 
 
@@ -24,12 +26,29 @@ class _Collecting:
         pass
 
 
-def _by_name(events, name):
-    return [e for e in events if e.payload["name"] == name]
+def _node_events(events):
+    return [e for e in events if e.event_type.startswith("node.")]
 
 
-def _types(events):
-    return [e.event_type for e in events]
+def _ids_by_name(events):
+    """node name -> node_id, read off the creation events."""
+    return {
+        e.payload["name"]: e.payload["node_id"]
+        for e in events
+        if e.event_type == "node.creation"
+    }
+
+
+def _lifecycle(events, *, name, node_id):
+    """The ordered event types belonging to one node."""
+    out = []
+    for e in _node_events(events):
+        if e.event_type == "node.creation":
+            if e.payload["name"] == name:
+                out.append(e.event_type)
+        elif e.payload["parent"]["node_id"] == node_id:
+            out.append(e.event_type)
+    return out
 
 
 async def test_parent_child_lifecycle_and_parents():
@@ -50,30 +69,28 @@ async def test_parent_child_lifecycle_and_parents():
         result = await rt.call(outer, 10)
     assert result == 11
 
-    outer_events = _by_name(writer.events, "outer")
-    inner_events = _by_name(writer.events, "inner")
+    ids = _ids_by_name(writer.events)
+    assert set(ids) == {"outer", "inner"}
 
     # every node runs its full lifecycle
-    for events in (outer_events, inner_events):
-        assert _types(events) == [
+    for name, node_id in ids.items():
+        assert _lifecycle(writer.events, name=name, node_id=node_id) == [
             "node.creation",
             "node.invocation",
             "node.response",
             "node.destruction",
         ]
 
-    # self-id is stable across an invocation's lifecycle (pairs invocation with response)
-    outer_id = {e.payload["node_id"] for e in outer_events}
-    inner_id = {e.payload["node_id"] for e in inner_events}
-    assert len(outer_id) == 1
-    assert len(inner_id) == 1
-    (outer_id,) = outer_id
-
-    # the root node has no parent; the child is parented on the caller node (no LLM, no mw)
-    for e in outer_events:
-        assert e.payload["parent"] == NoParent()
-    for e in inner_events:
-        assert e.payload["parent"] == NodeParent(node_id=outer_id, middleware_id=None)
+    # the root node has no enclosing node; the child is nested inside the caller
+    running = [
+        e for e in _node_events(writer.events) if e.event_type != "node.creation"
+    ]
+    for e in running:
+        enclosing = e.payload["spatial_parent"]["node_id"]
+        if e.payload["parent"]["node_id"] == ids["outer"]:
+            assert enclosing is None
+        else:
+            assert enclosing == ids["outer"]
 
 
 async def test_failure_emits_node_failure_and_no_response():
@@ -91,8 +108,15 @@ async def test_failure_emits_node_failure_and_no_response():
         except Exception:
             pass
 
-    boom_events = _by_name(writer.events, "boom")
-    # failure short-circuits: creation + invocation + failure, never response/destruction
-    assert _types(boom_events) == ["node.creation", "node.invocation", "node.failure"]
-    failure = boom_events[-1]
+    ids = _ids_by_name(writer.events)
+    lifecycle = _lifecycle(writer.events, name="boom", node_id=ids["boom"])
+    # failure replaces the response; destruction still fires as the node unwinds
+    assert lifecycle == [
+        "node.creation",
+        "node.invocation",
+        "node.failure",
+        "node.destruction",
+    ]
+
+    failure = [e for e in writer.events if e.event_type == "node.failure"][0]
     assert "kaboom" in failure.payload["failure"]

--- a/packages/railtracks/tests/unit_tests/events/test_node_events.py
+++ b/packages/railtracks/tests/unit_tests/events/test_node_events.py
@@ -2,7 +2,7 @@
 
 from railtracks.context.scope_link import ScopeLink
 from railtracks.context.session_context import ScopeEntry, ScopeKind
-from railtracks.events._base import NodeParent, NoParent
+from railtracks.events._base import NodeParent, NodeSpatialParent, NoSpatialParent
 from railtracks.events.node import (
     NodeCreation,
     NodeDestruction,
@@ -20,41 +20,36 @@ def chain(*entries: tuple[ScopeKind, str]) -> ScopeLink[ScopeEntry] | None:
     return link
 
 
-def _node_kwargs():
-    return {"name": "Agent", "node_id": "1", "node_type": "agent"}
-
-
 def test_event_type_strings():
-    assert NodeCreation(**_node_kwargs()).event_type() == "node.creation"
     assert (
-        NodeInvocation(**_node_kwargs(), args=(), kwargs={}).event_type()
-        == "node.invocation"
+        NodeCreation(node_id="1", name="Agent", node_type="agent").event_type()
+        == "node.creation"
     )
-    assert NodeResponse(**_node_kwargs(), response="r").event_type() == "node.response"
-    assert NodeFailure(**_node_kwargs(), failure="boom").event_type() == "node.failure"
-    assert (
-        NodeDestruction(**_node_kwargs(), response="r").event_type()
-        == "node.destruction"
-    )
+    assert NodeInvocation(args=(), kwargs={}).event_type() == "node.invocation"
+    assert NodeResponse(response="r").event_type() == "node.response"
+    assert NodeFailure(failure="boom").event_type() == "node.failure"
+    assert NodeDestruction(response="r").event_type() == "node.destruction"
 
 
-def test_runtime_node_event_resolves_via_node_parent():
-    # node "1" running under the caller's body → caller is the parent
+def test_runtime_node_event_resolves_self_and_enclosing_node():
+    # node "1" running under the caller's body → self is "1", nested inside "caller"
     scope = chain(
         (ScopeKind.NODE, "caller"),
         (ScopeKind.NODE_BODY, "caller"),
         (ScopeKind.NODE, "1"),
     )
-    ev = NodeInvocation(**_node_kwargs(), args=(), kwargs={})
-    assert ev._get_spatial_parent(scope) == NodeParent(node_id="caller", middleware_id=None)
+    ev = NodeInvocation(args=(), kwargs={})
+    ev.resolve_relationships(scope)
+
+    assert ev.parent == NodeParent(node_id="1")
+    assert ev.spatial_parent == NodeSpatialParent(node_id="caller")
+    ev.verify()
 
 
-def test_node_creation_resolves_via_creation_parent():
-    # self ("1") is NOT on the chain; caller's body is ambient (no self-skip)
-    scope = chain((ScopeKind.NODE, "caller"), (ScopeKind.NODE_BODY, "caller"))
-    ev = NodeCreation(**_node_kwargs())
-    assert ev._get_spatial_parent(scope) == NodeParent(node_id="caller", middleware_id=None)
-
-
-def test_root_node_creation_has_no_parent():
-    assert NodeCreation(**_node_kwargs())._get_spatial_parent(None) == NoParent()
+def test_node_creation_has_no_spatial_parent():
+    # a creation event is emitted before the node enters its own scope
+    ev = NodeCreation(node_id="1", name="Agent", node_type="agent")
+    assert ev._get_spatial_parent(None) == NoSpatialParent()
+    assert (
+        ev._get_spatial_parent(chain((ScopeKind.NODE, "caller"))) == NoSpatialParent()
+    )

--- a/packages/railtracks/tests/unit_tests/events/test_resolve.py
+++ b/packages/railtracks/tests/unit_tests/events/test_resolve.py
@@ -1,18 +1,21 @@
-"""Parent resolver tests — synthetic scope chains, one per design decision.
+"""Parent resolver tests — synthetic scope chains.
 
 Chains are written bottom (root) → top, mirroring how the runtime pushes them
 (`enter_node` first, `enter_node_body`/`enter_middleware`/`enter_llm_call` on top).
+
+Two identities come off the chain: the **spatial parent** (what the emitting entity is
+nested inside) and the **parent** (the emitting entity's own entry — for a node event
+that is the node itself).
 """
 
 import pytest
 from railtracks.context.scope_link import ScopeLink
 from railtracks.context.session_context import ScopeEntry, ScopeKind
-from railtracks.events._base import LLMParent, NodeParent, NoParent
+from railtracks.events._base import LLMParent, NodeParent, NodeSpatialParent
 from railtracks.events._resolve import (
+    llm_parent,
     llm_spatial_parent,
-    middleware_parent,
-    model_middleware_parent,
-    node_creation_spatial_parent,
+    node_parent,
     node_spatial_parent,
 )
 
@@ -22,109 +25,95 @@ MW = ScopeKind.MIDDLEWARE
 LLM = ScopeKind.LLM
 
 
-def chain(*entries: tuple[ScopeKind, str]) -> ScopeLink[ScopeEntry] | None:
-    """Build a chain from (kind, id) pairs given bottom (root) → top."""
+def chain(*entries: tuple[ScopeKind, str] | tuple[ScopeKind, str, str]):
+    """Build a chain from (kind, id[, type_id]) tuples given bottom (root) → top."""
     link: ScopeLink[ScopeEntry] | None = None
-    for kind, id_ in entries:
-        e = ScopeEntry(kind, id_)
+    for entry in entries:
+        e = ScopeEntry(*entry)
         link = ScopeLink(value=e) if link is None else link.pushed(e)
     return link
 
 
-# ── Node events (node_parent) ────────────────────────────────────────────────
+# ── Node events: spatial parent (the enclosing node, two hops up) ─────────────
 
 
-def test_root_node_has_no_parent():
+def test_root_node_has_no_enclosing_node():
     # A is the root; nothing below its NODE entry
-    assert node_spatial_parent(chain((N, "A"), (NB, "A"))) == NoParent()
+    assert node_spatial_parent(chain((N, "A"), (NB, "A"))) == NodeSpatialParent(
+        node_id=None
+    )
+
+
+def test_no_scope_at_all_has_no_enclosing_node():
+    assert node_spatial_parent(None) == NodeSpatialParent(node_id=None)
 
 
 def test_nested_node_resolves_to_caller_node():
     # B called from A's body
     scope = chain((N, "A"), (NB, "A"), (N, "B"), (NB, "B"))
-    assert node_spatial_parent(scope) == NodeParent(node_id="A", middleware_id=None)
+    assert node_spatial_parent(scope) == NodeSpatialParent(node_id="A")
 
 
-def test_node_called_from_a_middleware_collapses_to_nodeparent_with_mw():
-    # B spawned from middleware m on A → NodeParent(A, mw=m), not MiddlewareParent
-    scope = chain((N, "A"), (NB, "A"), (MW, "m"), (N, "B"), (NB, "B"))
-    assert node_spatial_parent(scope) == NodeParent(node_id="A", middleware_id="m")
+def test_node_called_from_a_middleware_still_anchors_on_the_owning_node():
+    # B spawned from middleware m on A → A is the enclosing node (a middleware never
+    # stands on its own; it always runs "on" a node)
+    scope = chain((N, "A"), (NB, "A"), (MW, "m", "mw-type"), (N, "B"), (NB, "B"))
+    assert node_spatial_parent(scope) == NodeSpatialParent(node_id="A")
 
 
-def test_nodes_own_middleware_does_not_leak_into_its_parent():
-    # B's own middleware (bm) sits above NODE(B); it must not become the parent's mw hop
-    scope = chain((N, "A"), (NB, "A"), (N, "B"), (MW, "bm"), (NB, "B"))
-    assert node_spatial_parent(scope) == NodeParent(node_id="A", middleware_id=None)
+def test_nodes_own_middleware_does_not_shift_its_enclosing_node():
+    # B's own middleware (bm) sits above NODE(B); it must not change what B is nested in
+    scope = chain((N, "A"), (NB, "A"), (N, "B"), (MW, "bm", "mw-type"), (NB, "B"))
+    assert node_spatial_parent(scope) == NodeSpatialParent(node_id="A")
 
 
 def test_node_with_llm_in_ancestry_skips_llm_and_anchors_on_node():
-    # C spawned by a model-middleware while A's LLM call is open.
-    # chain bottom→top: NODE(A), NODE_BODY(A), LLM(l), MW(model-mw), NODE(C), NODE_BODY(C)
+    # C spawned by a model-middleware while A's LLM call is open: the LLM entry is
+    # transparent to a node event.
     scope = chain(
-        (N, "A"), (NB, "A"), (LLM, "l"), (MW, "model-mw"), (N, "C"), (NB, "C")
+        (N, "A"),
+        (NB, "A"),
+        (LLM, "l", "llm-type"),
+        (MW, "model-mw", "mw-type"),
+        (N, "C"),
+        (NB, "C"),
     )
-    parent = node_spatial_parent(scope)
-    assert parent == NodeParent(node_id="A", middleware_id="model-mw")
-    assert not isinstance(parent, LLMParent)  # LLM entry is transparent to a node event
+    assert node_spatial_parent(scope) == NodeSpatialParent(node_id="A")
+
+
+# ── Node events: parent (self) ───────────────────────────────────────────────
+
+
+def test_node_parent_is_self():
+    scope = chain((N, "A"), (NB, "A"), (N, "B"), (NB, "B"))
+    assert node_parent(scope) == NodeParent(node_id="B")
 
 
 def test_node_parent_raises_when_self_node_absent():
     # bad state: a node event with no NODE entry on the chain
-    with pytest.raises(ValueError):
-        node_spatial_parent(chain((MW, "m")))
-    with pytest.raises(ValueError):
-        node_spatial_parent(None)
+    with pytest.raises(AssertionError):
+        node_parent(chain((MW, "m", "mw-type")))
+    with pytest.raises(AssertionError):
+        node_parent(None)
 
 
-# ── General middleware events (middleware_parent) ────────────────────────────
+# ── LLM events ───────────────────────────────────────────────────────────────
 
 
-def test_middleware_parent_is_node_with_immediate_wrapper():
-    # mw2 wraps mw1 on A → NodeParent(A, mw=mw1) (the middleware directly below self)
-    scope = chain((N, "A"), (MW, "mw1"), (MW, "mw2"))
-    assert middleware_parent(scope) == NodeParent(node_id="A", middleware_id="mw1")
+def test_llm_event_is_nested_in_the_enclosing_node():
+    scope = chain((N, "A"), (NB, "A"), (LLM, "l", "llm-type"))
+    assert llm_spatial_parent(scope) == NodeSpatialParent(node_id="A")
 
 
-def test_single_middleware_parent_has_no_intervening_mw():
-    scope = chain((N, "A"), (MW, "mw1"))
-    assert middleware_parent(scope) == NodeParent(node_id="A", middleware_id=None)
-
-
-# ── Model-middleware events (model_middleware_parent) — anchor = LLM ─────────
-
-
-def test_model_middleware_anchors_on_the_llm_call():
-    scope = chain((N, "A"), (NB, "A"), (LLM, "l"), (MW, "model-mw"))
-    assert model_middleware_parent(scope) == LLMParent(llm_id="l", middleware_id=None)
-
-
-def test_nested_model_middleware_keeps_immediate_wrapper():
-    scope = chain((N, "A"), (NB, "A"), (LLM, "l"), (MW, "mm1"), (MW, "mm2"))
-    assert model_middleware_parent(scope) == LLMParent(llm_id="l", middleware_id="mm1")
-
-
-# ── LLM events (llm_parent) ──────────────────────────────────────────────────
-
-
-def test_llm_event_resolves_to_enclosing_node():
-    scope = chain((N, "A"), (NB, "A"), (LLM, "l"))
-    assert llm_spatial_parent(scope) == NodeParent(node_id="A", middleware_id=None)
-
-
-# ── NodeCreation (node_creation_parent) — self not on chain ──────────────────
-
-
-def test_node_creation_from_body_resolves_to_creating_node():
-    # caller (A) chain is ambient; the new node is NOT on it
-    assert node_creation_spatial_parent(chain((N, "A"), (NB, "A"))) == NodeParent(
-        node_id="A", middleware_id=None
+def test_llm_parent_is_the_open_llm_call():
+    scope = chain((N, "A"), (NB, "A"), (LLM, "call-1", "model-abc"))
+    assert llm_parent(scope) == LLMParent(
+        llm_type_id="model-abc", llm_invoke_id="call-1"
     )
 
 
-def test_node_creation_at_root_has_no_parent():
-    assert node_creation_spatial_parent(None) == NoParent()
-
-
-def test_node_creation_from_middleware_records_the_middleware():
-    scope = chain((N, "A"), (NB, "A"), (MW, "m"))
-    assert node_creation_spatial_parent(scope) == NodeParent(node_id="A", middleware_id="m")
+def test_llm_resolvers_raise_without_the_expected_entry():
+    with pytest.raises(AssertionError):
+        llm_spatial_parent(chain((LLM, "l", "llm-type")))  # no enclosing node
+    with pytest.raises(AssertionError):
+        llm_parent(chain((N, "A"), (NB, "A")))  # no open llm call

--- a/packages/railtracks/tests/unit_tests/events/test_send.py
+++ b/packages/railtracks/tests/unit_tests/events/test_send.py
@@ -1,9 +1,8 @@
-"""End-to-end emit path: pipe(event) -> resolve parent -> publish -> writer."""
+"""End-to-end emit path: pipe(event) -> resolve relationships -> publish -> writer."""
 
 import datetime
 
 import railtracks.context.central as central
-from railtracks.events._base import NodeParent, NoParent
 from railtracks.events.node import NodeInvocation
 from railtracks.events.send import pipe
 from railtracks.observability import (
@@ -47,22 +46,14 @@ async def _emit(event):
     return writer.events
 
 
-async def test_pipe_resolves_parent_and_publishes_raw_payload():
+async def test_pipe_resolves_relationships_and_publishes_payload():
     _register("sess-1")
     manager = central.ContextVarScopeManager()
 
     with manager.enter_node("caller"):
         with manager.enter_node_body():
             with manager.enter_node("n1"):
-                events = await _emit(
-                    NodeInvocation(
-                        name="Agent",
-                        node_id="n1",
-                        node_type="agent",
-                        args=(1,),
-                        kwargs={"x": 2},
-                    )
-                )
+                events = await _emit(NodeInvocation(args=(1,), kwargs={"x": 2}))
 
     assert len(events) == 1
     ev = events[0]
@@ -71,26 +62,22 @@ async def test_pipe_resolves_parent_and_publishes_raw_payload():
     assert ev.scope_id == "sess-1"
 
     p = ev.payload
-    assert p["node_id"] == "n1"
-    assert p["name"] == "Agent"
-    assert p["node_type"] == "agent"
-    # parent is the resolved Parent object (serialization is deferred to the writers)
-    assert p["parent"] == NodeParent(node_id="caller", middleware_id=None)
+    # the resolved relationships: self is n1, nested inside the caller
+    assert p["parent"] == {"parent_type": "node", "node_id": "n1"}
+    assert p["spatial_parent"] == {"spatial_type": "node", "node_id": "caller"}
     # payload values are passed through untouched: tuple stays tuple, datetime stays datetime
     assert p["args"] == (1,)
     assert p["kwargs"] == {"x": 2}
     assert isinstance(p["timestamp"], datetime.datetime)
 
 
-async def test_pipe_root_node_has_noparent():
+async def test_pipe_root_node_has_no_enclosing_node():
     _register("sess-2")
     manager = central.ContextVarScopeManager()
 
     with manager.enter_node("root"):
-        events = await _emit(
-            NodeInvocation(
-                name="Root", node_id="root", node_type="agent", args=(), kwargs={}
-            )
-        )
+        events = await _emit(NodeInvocation(args=(), kwargs={}))
 
-    assert events[0].payload["parent"] == NoParent()
+    p = events[0].payload
+    assert p["parent"] == {"parent_type": "node", "node_id": "root"}
+    assert p["spatial_parent"] == {"spatial_type": "node", "node_id": None}

--- a/packages/railtracks/tests/unit_tests/events/test_session_events.py
+++ b/packages/railtracks/tests/unit_tests/events/test_session_events.py
@@ -1,0 +1,187 @@
+"""Session events: the classes themselves, and the hot-path emission in `_call.py::_start`.
+
+The hot-path tests run a real graph through `Flow`/`Session` and assert that
+`session.started` opens the run and `session.completed` closes it, on both the success
+and the failure path.
+"""
+
+import asyncio
+
+import pytest
+import railtracks as rt
+from railtracks.events._base import NoSpatialParent
+from railtracks.events.session import (
+    SessionCompleted,
+    SessionStarted,
+    format_error,
+)
+from railtracks.exceptions import GlobalTimeOutError
+from railtracks.observability import Event, configure, configure_writers
+
+
+class _Collecting:
+    def __init__(self):
+        self.events: list[Event] = []
+
+    async def start(self):
+        pass
+
+    async def write(self, event: Event):
+        self.events.append(event)
+
+    async def shutdown(self):
+        pass
+
+
+@pytest.fixture
+def writer():
+    """A collecting writer registered on a fresh observer.
+
+    `_start` shuts the singleton observer down at the end of every top-level call, so a
+    test that runs a second flow needs a fresh one; that is what `reset_for_tests` in the
+    package `conftest` gives us between tests.
+    """
+    w = _Collecting()
+    configure_writers([w])
+    return w
+
+
+def _of_type(events, event_type):
+    return [e for e in events if e.event_type == event_type]
+
+
+def _session_events(events):
+    return [e for e in events if e.event_type.startswith("session.")]
+
+
+@rt.function_node
+def add_one(x: int) -> int:
+    """Adds one."""
+    return x + 1
+
+
+@rt.function_node
+def boom(x: int) -> int:
+    """Explodes."""
+    raise ValueError("kaboom")
+
+
+# ── The event classes ────────────────────────────────────────────────────────
+
+
+def _started_kwargs():
+    return {
+        "session_id": "sess-1",
+        "flow_name": "flow",
+        "flow_id": "fid",
+        "session_name": None,
+        "entry_point_name": "Agent",
+        "timeout": 150.0,
+        "end_on_error": False,
+        "save_state": True,
+    }
+
+
+def test_event_type_strings():
+    assert SessionStarted(**_started_kwargs()).event_type() == "session.started"
+    assert (
+        SessionCompleted(
+            session_id="sess-1", status="success", error=None, duration_seconds=0.1
+        ).event_type()
+        == "session.completed"
+    )
+
+
+def test_session_events_are_the_root_of_the_tree():
+    # a session event is emitted outside every node/middleware/llm scope, so there is
+    # nothing above it to resolve — with or without an ambient chain.
+    ev = SessionStarted(**_started_kwargs())
+    assert ev._get_spatial_parent(None) == NoSpatialParent()
+
+    ev.resolve_relationships(None)
+    assert ev.spatial_parent == NoSpatialParent()
+    ev.verify()  # every field populated: nothing left UNSET
+
+
+def test_format_error_strips_terminal_colors():
+    # RT's own exceptions colorize __str__; the payload should stay clean text
+    assert format_error(GlobalTimeOutError(timeout=0.5)) == (
+        "Execution timed out after 0.5 seconds"
+    )
+    assert format_error(ValueError("kaboom")) == "kaboom"
+
+
+# ── Hot path ─────────────────────────────────────────────────────────────────
+
+
+async def test_success_run_is_bracketed_by_session_events(writer):
+    result = await rt.Flow("my-flow", add_one).ainvoke(10)
+    assert result == 11
+
+    # the pair brackets the whole run: nothing is emitted before started or after completed
+    assert writer.events[0].event_type == "session.started"
+    assert writer.events[-1].event_type == "session.completed"
+    assert len(_session_events(writer.events)) == 2
+
+    started = writer.events[0]
+    completed = writer.events[-1]
+
+    # the event is scoped to the session, and carries that identity in the payload too
+    assert started.scope_type == "session"
+    assert started.payload["session_id"] == started.scope_id
+    assert completed.payload["session_id"] == started.scope_id
+
+    assert started.payload["flow_name"] == "my-flow"
+    assert started.payload["flow_id"] is not None
+    assert started.payload["session_name"] is None
+    assert started.payload["entry_point_name"] == "add_one"
+    # the effective config the run executed under
+    assert started.payload["end_on_error"] is False
+
+    assert completed.payload["status"] == "success"
+    assert completed.payload["error"] is None
+    assert completed.payload["duration_seconds"] >= 0
+
+
+async def test_session_name_and_flow_name_come_from_a_bare_session(writer):
+    with rt.Session(flow_name="f", name="named-session"):
+        await rt.call(add_one, 1)
+
+    started = _of_type(writer.events, "session.started")[0]
+    assert started.payload["flow_name"] == "f"
+    assert started.payload["session_name"] == "named-session"
+    # flow_id is only set by Flow
+    assert started.payload["flow_id"] is None
+
+
+async def test_failed_run_still_reports_completed(writer):
+    with rt.Session(flow_name="f"):
+        with pytest.raises(ValueError):
+            await rt.call(boom, 1)
+
+    completed = _of_type(writer.events, "session.completed")
+    assert len(completed) == 1
+    assert completed[0].payload["status"] == "failure"
+    assert completed[0].payload["error"] == "kaboom"
+
+    # the observer is torn down on the failure path too, so writers get drained
+    assert configure.observer._running is False
+
+
+async def test_global_timeout_reports_the_timeout_error(writer):
+    @rt.function_node
+    async def slow(x: int) -> int:
+        """Takes too long."""
+        await asyncio.sleep(5)
+        return x
+
+    with rt.Session(flow_name="f", timeout=0.2):
+        with pytest.raises(GlobalTimeOutError):
+            await rt.call(slow, 1)
+
+    started = _of_type(writer.events, "session.started")[0]
+    assert started.payload["timeout"] == 0.2
+
+    completed = _of_type(writer.events, "session.completed")[0]
+    assert completed.payload["status"] == "failure"
+    assert "timed out" in completed.payload["error"]

--- a/packages/railtracks/tests/unit_tests/interaction/conftest.py
+++ b/packages/railtracks/tests/unit_tests/interaction/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 
+from railtracks.context.central import SessionIdentity
+
 @pytest.fixture
 def mock_publisher():
     """Fixture providing a mock publisher with async methods."""
@@ -28,12 +30,20 @@ def mock_context_functions():
          patch('railtracks.interaction._call.get_parent_id') as get_parent, \
          patch('railtracks.interaction._call.get_run_id') as get_run, \
          patch('railtracks.interaction._call.get_current_scope') as get_scope, \
+         patch('railtracks.interaction._call.get_session_identity') as get_identity, \
          patch('railtracks.interaction._call.get_local_config') as get_config:
 
         # Set default return values
         get_parent.return_value = "parent_123"
         get_run.return_value = "run_456"
         get_scope.return_value = None
+        # _start emits the session events, so it needs an identity to stamp them with
+        get_identity.return_value = SessionIdentity(
+            session_id="sess_789",
+            flow_name="mock-flow",
+            flow_id=None,
+            session_name=None,
+        )
 
         yield {
             'is_context_present': present,
@@ -43,6 +53,7 @@ def mock_context_functions():
             'get_parent_id': get_parent,
             'get_run_id': get_run,
             'get_current_scope': get_scope,
+            'get_session_identity': get_identity,
             'get_local_config': get_config
         }
 


### PR DESCRIPTION
## Summary

Very simple PR that automatically flattens `spatial_parent` and `parent`. It builds on the work of Encoder protocol built before

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
