### PR TITLE
Support bound methods and functools.partial as function_node tools (#1318/#1336)

### DIFF
--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -116,10 +116,8 @@ def _validate_and_normalize_callable(
 ) -> Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]:
     """Validate ``func`` and normalise it into a node-ready callable.
 
-    Runs dict-parameter validation, cross-checks an optional ``manifest`` against
-    the signature, resolves ``functools.partial`` metadata, wraps builtins so the
-    node type can be attached, and rejects anything that is not a supported
-    callable.
+    Resolves partial metadata, validates parameters against an optional
+    ``manifest``, wraps builtins, and rejects unsupported callables.
 
     Args:
         func: The callable to validate and normalise.
@@ -131,26 +129,19 @@ def _validate_and_normalize_callable(
     Raises:
         NodeCreationError: If ``func`` is not a supported callable type.
     """
-    # functools.partial objects carry no usable __name__/__qualname__ and only a
-    # boilerplate __doc__, both of which downstream tool-schema extraction relies
-    # on. Normalise into a copy that sources these from the wrapped callable
-    # before any further handling so the rest of the pipeline is oblivious to it.
+    # partials lack real __name__/__qualname__/__doc__; recover them onto a copy
     if isinstance(func, functools.partial):
         func = _partial_with_resolved_metadata(func)
 
-    if not isinstance(
-        func, BuiltinFunctionType
-    ):  # we don't require dict validation for builtin functions, that is handled separately.
-        validate_function(func)  # checks for dict or Dict parameters
+    # dict-parameter validation; builtins are validated separately
+    if not isinstance(func, BuiltinFunctionType):
+        validate_function(func)
 
-    # Validate tool manifest against function signature if manifest is provided
     if manifest is not None:
         validate_tool_manifest_against_function(func, manifest.parameters)
 
     if inspect.isbuiltin(func):
-        # builtin functions are written in C and do not have space for the addition of metadata like our node type.
-        # so instead we wrap them in a function that allows for the addition of the node type.
-        # this logic preserved details like the function name, docstring, and signature, but allows us to add the node type.
+        # builtins are C-level and can't hold our node-type attribute; wrap them
         return _function_preserving_metadata(func)
 
     if not (
@@ -336,33 +327,23 @@ def _partial_with_resolved_metadata(
 ) -> "functools.partial[_TOutput]":
     """Return a copy of a ``functools.partial`` with real name/qualname/doc.
 
-    A partial exposes no ``__name__``/``__qualname__`` and only the useless
-    ``"partial(func, ...)"`` boilerplate as ``__doc__``, so the tool-schema
-    extraction that reads those attributes would either raise or produce garbage
-    descriptions. This unwraps ``.func`` (recursively, so nested partials are
-    handled) to recover the underlying callable's metadata and stamps it onto a
-    fresh copy, leaving the caller's original object untouched.
-
-    The copy keeps the partial's *reduced* signature (already-bound arguments are
-    excluded), so parameter inference continues to see only the arguments the
-    caller still needs to supply.
+    Sources ``__name__``/``__qualname__``/``__doc__`` from the wrapped callable
+    (unwrapping nested partials) onto a fresh copy, leaving the caller's object
+    untouched. The copy keeps the partial's reduced signature.
 
     Args:
         func: The ``functools.partial`` to normalise.
 
     Returns:
-        A new ``functools.partial`` wrapping the same callable/arguments, with
-        ``__name__``, ``__qualname__``, and ``__doc__`` sourced from the
-        underlying callable.
+        A copy of ``func`` with metadata sourced from the underlying callable.
     """
     underlying: Callable = func
     while isinstance(underlying, functools.partial):
         underlying = underlying.func
 
+    # discard the partial's boilerplate __doc__ in favour of the underlying one
     name = getattr(underlying, "__name__", "partial")
     qualname = getattr(underlying, "__qualname__", name)
-    # Only adopt the underlying callable's docstring; the partial's own
-    # boilerplate __doc__ is deliberately discarded.
     doc = getattr(underlying, "__doc__", None)
 
     resolved: "functools.partial[_TOutput]" = functools.partial(

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -110,6 +110,65 @@ def validate_function_parameters(
         validate_tool_manifest_against_function(func, manifest.parameters)
 
 
+def _validate_and_normalize_callable(
+    func: Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput],
+    manifest: ToolManifest | None,
+) -> Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]:
+    """Validate ``func`` and normalise it into a node-ready callable.
+
+    Runs dict-parameter validation, cross-checks an optional ``manifest`` against
+    the signature, resolves ``functools.partial`` metadata, wraps builtins so the
+    node type can be attached, and rejects anything that is not a supported
+    callable.
+
+    Args:
+        func: The callable to validate and normalise.
+        manifest: Optional tool manifest to validate against ``func``'s signature.
+
+    Returns:
+        A callable equivalent to ``func`` that is safe to hand to the node builder.
+
+    Raises:
+        NodeCreationError: If ``func`` is not a supported callable type.
+    """
+    # functools.partial objects carry no usable __name__/__qualname__ and only a
+    # boilerplate __doc__, both of which downstream tool-schema extraction relies
+    # on. Normalise into a copy that sources these from the wrapped callable
+    # before any further handling so the rest of the pipeline is oblivious to it.
+    if isinstance(func, functools.partial):
+        func = _partial_with_resolved_metadata(func)
+
+    if not isinstance(
+        func, BuiltinFunctionType
+    ):  # we don't require dict validation for builtin functions, that is handled separately.
+        validate_function(func)  # checks for dict or Dict parameters
+
+    # Validate tool manifest against function signature if manifest is provided
+    if manifest is not None:
+        validate_tool_manifest_against_function(func, manifest.parameters)
+
+    if inspect.isbuiltin(func):
+        # builtin functions are written in C and do not have space for the addition of metadata like our node type.
+        # so instead we wrap them in a function that allows for the addition of the node type.
+        # this logic preserved details like the function name, docstring, and signature, but allows us to add the node type.
+        return _function_preserving_metadata(func)
+
+    if not (
+        asyncio.iscoroutinefunction(func)
+        or inspect.isfunction(func)
+        or inspect.ismethod(func)  # bound (and class) methods
+        or isinstance(func, functools.partial)
+    ):
+        raise NodeCreationError(
+            message=f"The provided function is not a valid coroutine or sync function it is {type(func)}.",
+            notes=[
+                "You must provide a valid function or coroutine function to make a node.",
+            ],
+        )
+
+    return func
+
+
 def _single_function_node(
     func: Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput],
     /,
@@ -139,40 +198,7 @@ def _single_function_node(
     ):
         return func
 
-    # functools.partial objects carry no usable __name__/__qualname__ and only a
-    # boilerplate __doc__, both of which downstream tool-schema extraction relies
-    # on. Normalise into a copy that sources these from the wrapped callable
-    # before any further handling so the rest of the pipeline is oblivious to it.
-    if isinstance(func, functools.partial):
-        func = _partial_with_resolved_metadata(func)
-
-    if not isinstance(
-        func, BuiltinFunctionType
-    ):  # we don't require dict validation for builtin functions, that is handled separately.
-        validate_function(func)  # checks for dict or Dict parameters
-
-    # Validate tool manifest against function signature if manifest is provided
-    if manifest is not None:
-        validate_tool_manifest_against_function(func, manifest.parameters)
-
-    if inspect.isbuiltin(func):
-        # builtin functions are written in C and do not have space for the addition of metadata like our node type.
-        # so instead we wrap them in a function that allows for the addition of the node type.
-        # this logic preserved details like the function name, docstring, and signature, but allows us to add the node type.
-        func = _function_preserving_metadata(func)
-
-    elif not (
-        asyncio.iscoroutinefunction(func)
-        or inspect.isfunction(func)
-        or inspect.ismethod(func)  # bound (and class) methods
-        or isinstance(func, functools.partial)
-    ):
-        raise NodeCreationError(
-            message=f"The provided function is not a valid coroutine or sync function it is {type(func)}.",
-            notes=[
-                "You must provide a valid function or coroutine function to make a node.",
-            ],
-        )
+    func = _validate_and_normalize_callable(func, manifest)
 
     unwrapped_func: Callable[_P, Coroutine[None, None, _TOutput]]
     is_sync = False

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -139,6 +139,13 @@ def _single_function_node(
     ):
         return func
 
+    # functools.partial objects carry no usable __name__/__qualname__ and only a
+    # boilerplate __doc__, both of which downstream tool-schema extraction relies
+    # on. Normalise into a copy that sources these from the wrapped callable
+    # before any further handling so the rest of the pipeline is oblivious to it.
+    if isinstance(func, functools.partial):
+        func = _partial_with_resolved_metadata(func)
+
     if not isinstance(
         func, BuiltinFunctionType
     ):  # we don't require dict validation for builtin functions, that is handled separately.
@@ -154,7 +161,12 @@ def _single_function_node(
         # this logic preserved details like the function name, docstring, and signature, but allows us to add the node type.
         func = _function_preserving_metadata(func)
 
-    elif not asyncio.iscoroutinefunction(func) and not inspect.isfunction(func):
+    elif not (
+        asyncio.iscoroutinefunction(func)
+        or inspect.isfunction(func)
+        or inspect.ismethod(func)  # bound (and class) methods
+        or isinstance(func, functools.partial)
+    ):
         raise NodeCreationError(
             message=f"The provided function is not a valid coroutine or sync function it is {type(func)}.",
             notes=[
@@ -289,3 +301,44 @@ def _function_preserving_metadata(
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def _partial_with_resolved_metadata(
+    func: "functools.partial[_TOutput]",
+) -> "functools.partial[_TOutput]":
+    """Return a copy of a ``functools.partial`` with real name/qualname/doc.
+
+    A partial exposes no ``__name__``/``__qualname__`` and only the useless
+    ``"partial(func, ...)"`` boilerplate as ``__doc__``, so the tool-schema
+    extraction that reads those attributes would either raise or produce garbage
+    descriptions. This unwraps ``.func`` (recursively, so nested partials are
+    handled) to recover the underlying callable's metadata and stamps it onto a
+    fresh copy, leaving the caller's original object untouched.
+
+    The copy keeps the partial's *reduced* signature (already-bound arguments are
+    excluded), so parameter inference continues to see only the arguments the
+    caller still needs to supply.
+
+    Args:
+        func: The ``functools.partial`` to normalise.
+
+    Returns:
+        A new ``functools.partial`` wrapping the same callable/arguments, with
+        ``__name__``, ``__qualname__``, and ``__doc__`` sourced from the
+        underlying callable.
+    """
+    underlying: Callable = func
+    while isinstance(underlying, functools.partial):
+        underlying = underlying.func
+
+    resolved: "functools.partial[_TOutput]" = functools.partial(
+        func.func, *func.args, **func.keywords
+    )
+    resolved.__name__ = getattr(underlying, "__name__", "partial")  # type: ignore[attr-defined]
+    resolved.__qualname__ = getattr(  # type: ignore[attr-defined]
+        underlying, "__qualname__", resolved.__name__
+    )
+    # Only adopt the underlying callable's docstring; the partial's own
+    # boilerplate __doc__ is deliberately discarded.
+    resolved.__doc__ = getattr(underlying, "__doc__", None)
+    return resolved

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -204,9 +204,11 @@ def _single_function_node(
     is_sync = False
     if not asyncio.iscoroutinefunction(func):
         is_sync = True
+        # narrowed: the guard above means `func` returns _TOutput, not a coroutine
+        sync_func = cast(Callable[_P, _TOutput], func)
 
         async def wrapped_function(*args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
-            return await asyncio.to_thread(func, *args, **kwargs)
+            return await asyncio.to_thread(sync_func, *args, **kwargs)
 
         functools.update_wrapper(wrapped_function, func)
         unwrapped_func = wrapped_function
@@ -357,14 +359,16 @@ def _partial_with_resolved_metadata(
     while isinstance(underlying, functools.partial):
         underlying = underlying.func
 
+    name = getattr(underlying, "__name__", "partial")
+    qualname = getattr(underlying, "__qualname__", name)
+    # Only adopt the underlying callable's docstring; the partial's own
+    # boilerplate __doc__ is deliberately discarded.
+    doc = getattr(underlying, "__doc__", None)
+
     resolved: "functools.partial[_TOutput]" = functools.partial(
         func.func, *func.args, **func.keywords
     )
-    resolved.__name__ = getattr(underlying, "__name__", "partial")  # type: ignore[attr-defined]
-    resolved.__qualname__ = getattr(  # type: ignore[attr-defined]
-        underlying, "__qualname__", resolved.__name__
-    )
-    # Only adopt the underlying callable's docstring; the partial's own
-    # boilerplate __doc__ is deliberately discarded.
-    resolved.__doc__ = getattr(underlying, "__doc__", None)
+    resolved.__name__ = name  # type: ignore[attr-defined]
+    resolved.__qualname__ = qualname  # type: ignore[attr-defined]
+    resolved.__doc__ = doc
     return resolved

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -110,6 +110,21 @@ def validate_function_parameters(
         validate_tool_manifest_against_function(func, manifest.parameters)
 
 
+# intentional overload overlap, as in `function_node` above: async is checked first
+@overload
+def _validate_and_normalize_callable(  # pyright: ignore[reportOverlappingOverload]
+    func: Callable[_P, Coroutine[None, None, _TOutput]],
+    manifest: ToolManifest | None,
+) -> Callable[_P, Coroutine[None, None, _TOutput]]: ...
+
+
+@overload
+def _validate_and_normalize_callable(
+    func: Callable[_P, _TOutput],
+    manifest: ToolManifest | None,
+) -> Callable[_P, _TOutput]: ...
+
+
 def _validate_and_normalize_callable(
     func: Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput],
     manifest: ToolManifest | None,
@@ -117,7 +132,8 @@ def _validate_and_normalize_callable(
     """Validate ``func`` and normalise it into a node-ready callable.
 
     Resolves partial metadata, validates parameters against an optional
-    ``manifest``, wraps builtins, and rejects unsupported callables.
+    ``manifest``, wraps builtins, and rejects unsupported callables. Overloaded so
+    the sync/async character of ``func`` is preserved in the return type.
 
     Args:
         func: The callable to validate and normalise.
@@ -189,7 +205,11 @@ def _single_function_node(
     ):
         return func
 
-    func = _validate_and_normalize_callable(func, manifest)
+    # `func` is an un-narrowed union here, so restate it; narrowed just below
+    func = cast(
+        "Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]",
+        _validate_and_normalize_callable(func, manifest),
+    )
 
     unwrapped_func: Callable[_P, Coroutine[None, None, _TOutput]]
     is_sync = False

--- a/packages/railtracks/src/railtracks/built_nodes/function/node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node_builder.py
@@ -55,10 +55,6 @@ class FunctionNodeBuilder(NodeBuilder):
         resolved_tool = (
             tool_info
             if tool_info is not None
-            # Forward `name` so the LLM-facing tool name honors the override.
-            # Without it, Tool.from_function falls back to function.__name__, which
-            # leaves distinct nodes (e.g. two functools.partial of the same parent)
-            # sharing one tool name and colliding at tool-dispatch time.
             else Tool.from_function(
                 function, name=name, details=tool_details, params=tool_params
             )

--- a/packages/railtracks/src/railtracks/built_nodes/function/node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node_builder.py
@@ -55,7 +55,13 @@ class FunctionNodeBuilder(NodeBuilder):
         resolved_tool = (
             tool_info
             if tool_info is not None
-            else Tool.from_function(function, details=tool_details, params=tool_params)
+            # Forward `name` so the LLM-facing tool name honors the override.
+            # Without it, Tool.from_function falls back to function.__name__, which
+            # leaves distinct nodes (e.g. two functools.partial of the same parent)
+            # sharing one tool name and colliding at tool-dispatch time.
+            else Tool.from_function(
+                function, name=name, details=tool_details, params=tool_params
+            )
         )
         casted_instance._tool_info = lambda: resolved_tool
 

--- a/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
@@ -146,7 +146,7 @@ async def test_function_node_bound_method_executes():
 
 
 # ---------------------------------------------------------------------------
-# functools.partial (issue #1318)
+# functools.partial
 # ---------------------------------------------------------------------------
 def _greet(greeting: str, name: str) -> str:
     """Greet someone.

--- a/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
@@ -89,7 +89,7 @@ def test_function_preserving_metadata():
 
 
 # ---------------------------------------------------------------------------
-# Bound methods (issue #1318)
+# Bound methods test
 # ---------------------------------------------------------------------------
 class _Calculator:
     def add(self, a: int, b: int) -> int:

--- a/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
@@ -1,9 +1,12 @@
 
+import functools
+
 import pytest
 from railtracks.built_nodes.function.node import (
     CallableAsyncRTFunction,
     CallableSyncRTFunction,
     _function_preserving_metadata,
+    _partial_with_resolved_metadata,
     function_node,
 )
 
@@ -83,3 +86,134 @@ def test_function_preserving_metadata():
     wrapped = _function_preserving_metadata(f)
     assert wrapped.__name__ == f.__name__
     assert wrapped(2) == 3
+
+
+# ---------------------------------------------------------------------------
+# Bound methods (issue #1318)
+# ---------------------------------------------------------------------------
+class _Calculator:
+    def add(self, a: int, b: int) -> int:
+        """Add two numbers.
+
+        Args:
+            a: first addend
+            b: second addend
+        """
+        return a + b
+
+    async def amultiply(self, a: int, b: int) -> int:
+        """Multiply two numbers asynchronously.
+
+        Args:
+            a: first factor
+            b: second factor
+        """
+        return a * b
+
+
+def test_function_node_sync_bound_method():
+    calc = _Calculator()
+    node = function_node(calc.add)
+    assert isinstance(node, CallableSyncRTFunction)
+    # bound methods already carry the correct metadata
+    assert node.__name__ == "add"
+    assert node.__doc__.startswith("Add two numbers.")
+    tool_info = node.node_type.tool_info()
+    assert tool_info.name == "add"
+    assert tool_info.detail == "Add two numbers."
+    # `self` must not leak into the tool parameters
+    assert sorted(p.name for p in tool_info.parameters) == ["a", "b"]
+
+
+def test_function_node_async_bound_method():
+    calc = _Calculator()
+    node = function_node(calc.amultiply)
+    assert isinstance(node, CallableAsyncRTFunction)
+    assert node.__name__ == "amultiply"
+    tool_info = node.node_type.tool_info()
+    assert sorted(p.name for p in tool_info.parameters) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_function_node_bound_method_executes():
+    import railtracks as rt
+
+    calc = _Calculator()
+    add_node = function_node(calc.add)
+    amul_node = function_node(calc.amultiply)
+    assert await rt.call(add_node, 2, 3) == 5
+    assert await rt.call(amul_node, 2, 4) == 8
+
+
+# ---------------------------------------------------------------------------
+# functools.partial (issue #1318)
+# ---------------------------------------------------------------------------
+def _greet(greeting: str, name: str) -> str:
+    """Greet someone.
+
+    Args:
+        greeting: the greeting word
+        name: who to greet
+    """
+    return f"{greeting}, {name}!"
+
+
+async def _apower(base: int, exp: int) -> int:
+    """Raise base to exp.
+
+    Args:
+        base: the base
+        exp: the exponent
+    """
+    return base**exp
+
+
+def test_partial_with_resolved_metadata_sources_from_underlying():
+    partial = functools.partial(_greet, "Hello")
+    resolved = _partial_with_resolved_metadata(partial)
+    # metadata comes from the wrapped callable, not the boilerplate partial
+    assert resolved.__name__ == "_greet"
+    assert resolved.__qualname__ == _greet.__qualname__
+    assert resolved.__doc__ == _greet.__doc__
+    # the original partial is left untouched
+    assert not hasattr(partial, "__name__")
+    # the reduced signature is preserved (greeting already bound)
+    assert resolved("World") == "Hello, World!"
+
+
+def test_partial_with_resolved_metadata_unwraps_nested_partials():
+    nested = functools.partial(functools.partial(_greet, "Hi"), name="There")
+    resolved = _partial_with_resolved_metadata(nested)
+    assert resolved.__name__ == "_greet"
+    assert resolved.__doc__ == _greet.__doc__
+
+
+def test_function_node_sync_partial():
+    partial = functools.partial(_greet, "Hello")
+    node = function_node(partial)
+    assert isinstance(node, CallableSyncRTFunction)
+    assert node.__name__ == "_greet"
+    tool_info = node.node_type.tool_info()
+    assert tool_info.name == "_greet"
+    assert tool_info.detail == "Greet someone."
+    # `greeting` is already bound, so only `name` remains as a tool parameter
+    assert [p.name for p in tool_info.parameters] == ["name"]
+
+
+def test_function_node_async_partial():
+    partial = functools.partial(_apower, exp=2)
+    node = function_node(partial)
+    assert isinstance(node, CallableAsyncRTFunction)
+    assert node.__name__ == "_apower"
+    tool_info = node.node_type.tool_info()
+    assert tool_info.detail == "Raise base to exp."
+
+
+@pytest.mark.asyncio
+async def test_function_node_partial_executes():
+    import railtracks as rt
+
+    greet_node = function_node(functools.partial(_greet, "Hello"))
+    power_node = function_node(functools.partial(_apower, exp=2))
+    assert await rt.call(greet_node, name="World") == "Hello, World!"
+    assert await rt.call(power_node, base=3) == 9

--- a/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/function/test_function.py
@@ -217,3 +217,48 @@ async def test_function_node_partial_executes():
     power_node = function_node(functools.partial(_apower, exp=2))
     assert await rt.call(greet_node, name="World") == "Hello, World!"
     assert await rt.call(power_node, base=3) == 9
+
+
+# ---------------------------------------------------------------------------
+# `name=` override propagates to the LLM-facing tool name (issues #1 & #2)
+# ---------------------------------------------------------------------------
+def test_function_node_name_override_sets_tool_name():
+    def square(x: int) -> int:
+        """Square a number.
+
+        Args:
+            x: the number
+        """
+        return x * x
+
+    node = function_node(square, name="my_custom_name")
+    # the override must reach the tool the LLM sees, not just the node id
+    assert node.node_type.tool_info().name == "my_custom_name"
+
+
+def test_function_node_name_override_defaults_to_function_name():
+    def square(x: int) -> int:
+        """Square a number.
+
+        Args:
+            x: the number
+        """
+        return x * x
+
+    node = function_node(square)
+    assert node.node_type.tool_info().name == "square"
+
+
+def test_partials_of_same_parent_get_distinct_tool_names():
+    from railtracks.built_nodes.llm.llm_helpers import get_node_from_name
+
+    sq = function_node(functools.partial(_apower, exp=2), name="square")
+    cb = function_node(functools.partial(_apower, exp=3), name="cube")
+
+    # without the name override both would collapse to "_apower" and collide
+    assert sq.node_type.tool_info().name == "square"
+    assert cb.node_type.tool_info().name == "cube"
+
+    nodes = [sq.node_type, cb.node_type]
+    assert get_node_from_name("square", nodes) is sq.node_type
+    assert get_node_from_name("cube", nodes) is cb.node_type


### PR DESCRIPTION
## Summary

Closes #1318, #1336.

`function_node` previously accepted only plain functions and coroutine functions. Passing a **bound method** or a **`functools.partial`** raised `NodeCreationError` (for the sync cases) or blew up later on missing metadata. This PR makes both first-class tool sources, and fixes a related naming bug that surfaced immediately once partials worked.

## What changed

**1. Accept bound methods and `functools.partial` (`built_nodes/function/node.py`)**

- Relaxed the callable guard so `inspect.ismethod` (bound/class methods) and `functools.partial` are accepted alongside plain functions and coroutines. Bound methods already carry correct `__name__`/`__qualname__`/`__doc__`, so they only needed the guard opened up.
- Added `_partial_with_resolved_metadata`: a `functools.partial` exposes no `__name__`/`__qualname__` and only a boilerplate `"partial(func, ...)"` `__doc__`, which the tool-schema extractor reads and would either crash on or turn into garbage. The helper unwraps `.func` (recursively, for nested partials) to recover the real metadata and stamps it onto a **fresh copy**, leaving the caller's object untouched. The copy keeps the partial's **reduced signature**, so already-bound *positional* args are correctly excluded from the inferred tool parameters.
- Extracted the validation + normalization block into `_validate_and_normalize_callable` (partial resolution, dict-parameter validation, manifest cross-check, builtin wrapping, and the callable-type guard), keeping `_single_function_node` under the mccabe complexity limit and isolating the accepted-callable policy in one place.

**2. Forward the `name=` override to the LLM-facing tool name (`built_nodes/function/node_builder.py`)**

`FunctionNodeBuilder.function` set the node id and class name from `name=`, but always derived the **tool** name from `function.__name__` — so `name=` renamed the node without renaming the tool the LLM dispatches on. This left distinct nodes sharing one tool name; most visibly, two partials of the same parent both collapsed to the parent's `__name__` and **collided at tool-dispatch time** (`get_node_from_name`), an error unreachable by any static check. Fixed by passing `name` into `Tool.from_function` so the override reaches the tool name and such nodes can be disambiguated.

## Note
- **Keyword-bound partial args still appear in the tool schema.** `inspect.signature` drops *positionally*-bound args but keeps *keyword*-bound ones (e.g. `partial(power, exp=2)` still lists `exp` as an optional param). Dropping those would mean explicitly filtering names in `partial.keywords`; left for a follow-up so this PR stays focused on making bound methods/partials work and the naming collision go away.
- **No static uniqueness check** across independently-created nodes, tool-name collisions still surface only at dispatch. Broader change touching the LLM node; out of scope here. Ie multiple partials always trigger #1337.
