### PR TITLE
Add WebSearch prebuilt toolset

### DIFF
--- a/docs/documentation/agent_design/tools/prebuilt/overview.md
+++ b/docs/documentation/agent_design/tools/prebuilt/overview.md
@@ -4,3 +4,4 @@ Railtracks provides a set of built-in tools that help you skip the engineering p
 ## Overview of Pre-Built Tools
 - [To Do Tool](todos.md): A tool for your agent to track and plan out todo's. This tool allows your agent to create, manage, and persist to do items across interactions.
 - [Key-Value Memory Tool](key_value_memory.md): A tool for your agent to remember facts under keys and recall them later. Supports listing, substring search, and optional persistence across runs.
+- [Web Search Tool](websearch.md): A tool for your agent to search the live web and fetch clean page content. Search and fetch backends are both swappable.

--- a/docs/documentation/agent_design/tools/prebuilt/websearch.md
+++ b/docs/documentation/agent_design/tools/prebuilt/websearch.md
@@ -1,0 +1,46 @@
+# Web Search Tooling
+
+A common need for an agent is to look things up on the live web. Railtracks provides a built-in web search tool you can drop into your agent right away.
+
+## Usage
+Adding the web search tool to your agent is super easy.
+
+```python
+--8<-- "docs/scripts/websearch.py:websearch"
+```
+
+You will usually want to tell the agent how to use the tools in your prompt. We provide a helper that returns a ready-made guidance string:
+
+```python
+--8<-- "docs/scripts/websearch.py:websearch_prompt"
+```
+
+## The Tools
+
+The toolset exposes three tools to the agent:
+
+| Tool | Purpose |
+|---|---|
+| `search(query, top_k=5)` | Search the web and return ranked title, url, and snippet results. |
+| `fetch(url)` | Fetch a url, usually one from `search()`, and return its cleaned page text. |
+| `search_and_fetch(query, top_k=3)` | Search and fetch full content for the top results in a single call. Convenient when you want full page content right away, at the cost of fetching more pages. |
+
+If a search or fetch fails (a backend outage, a blocked or paywalled page, no extractable content), the tool returns a plain message describing the failure instead of raising, so the agent can see what happened and try something else.
+
+## Swapping the search backend
+
+By default the toolset uses `TavilySearch`, so it needs a `TAVILY_API_KEY`. You can swap in a different backend, for example `BraveSearch`, which needs a `BRAVE_API_KEY` instead:
+
+```python
+--8<-- "docs/scripts/websearch.py:websearch_search_backend"
+```
+
+Any object that implements the `SearchBackend` protocol, an async `search(query, top_k)` method returning a list of results, can be passed in, so you can bring your own backend too.
+
+## Swapping the fetch backend
+
+By default the toolset uses `HttpFetch`, a plain HTTP request paired with `trafilatura` to extract clean text from the page. You can tune it, or swap in your own implementation of the `FetchBackend` protocol, for example to use a headless browser for JavaScript-heavy pages:
+
+```python
+--8<-- "docs/scripts/websearch.py:websearch_fetch_backend"
+```

--- a/docs/scripts/websearch.py
+++ b/docs/scripts/websearch.py
@@ -1,0 +1,34 @@
+# --8<-- [start: websearch]
+import railtracks as rt
+
+# create your web search toolset (defaults to Tavily for search, httpx + trafilatura for fetch)
+web_search = rt.prebuilt.WebSearchToolSet()
+
+agent = rt.agent_node(
+    name="Research Agent",
+    tool_nodes=[*web_search.tool_set()],  # the tools your agent can call
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message=rt.prebuilt.WebSearchToolSet.prompt(),
+)
+# --8<-- [end: websearch]
+
+# --8<-- [start: websearch_prompt]
+# the tool set provides a class method returning a prompt that guides the agent.
+rt.prebuilt.WebSearchToolSet.prompt()
+# --8<-- [end: websearch_prompt]
+
+# --8<-- [start: websearch_search_backend]
+import railtracks as rt
+from railtracks.prebuilt.tools.websearch.search import BraveSearch
+
+# swap Tavily for Brave, only requires setting BRAVE_API_KEY
+web_search = rt.prebuilt.WebSearchToolSet(search=BraveSearch())
+# --8<-- [end: websearch_search_backend]
+
+# --8<-- [start: websearch_fetch_backend]
+import railtracks as rt
+from railtracks.prebuilt.tools.websearch.fetch import HttpFetch
+
+# tune the default fetch backend, e.g. a longer timeout for slow pages
+web_search = rt.prebuilt.WebSearchToolSet(fetch=HttpFetch(timeout=30.0))
+# --8<-- [end: websearch_fetch_backend]

--- a/examples/tutorials/web_research_agent.py
+++ b/examples/tutorials/web_research_agent.py
@@ -1,0 +1,69 @@
+import railtracks as rt
+
+# rt.enable_logging() # uncomment for detailed logs
+
+#### API Key Setup #####
+"""
+1. Create a .env file in the root of your project
+2. Add the following lines to your .env file:
+TAVILY_API_KEY="your_tavily_api_key_here"
+OPENAI_API_KEY="your_openai_api_key_here"
+"""
+
+##### Toolset Definition #####
+# Defaults: Tavily for search, httpx + trafilatura for fetch.
+web = rt.prebuilt.WebSearchToolSet()
+
+##### Agent Definitions #####
+# Two-agent handoff (find the source, then answer from it) instead of one
+# agent given unrestricted tool access — a clearer demo of defined control
+# flow, and a template for building your own multi-step research flows.
+Researcher = rt.agent_node(
+    name="Researcher",
+    tool_nodes=web.tool_set(),
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message=web.prompt(),
+)
+
+Summarizer = rt.agent_node(
+    name="Summarizer",
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message=(
+        "Answer the user's question using only the provided source material. "
+        "Cite the URL your answer came from."
+    ),
+)
+
+
+##### Define the Agentic Architecture #####
+@rt.function_node
+async def research(question: str) -> str:
+    """Flow entry to search the web, read the best source, and answer a question.
+
+    Args:
+        question (str): The question to research and answer.
+    Returns:
+        str: An answer grounded in fetched web content, with a source URL.
+    """
+
+    # Researcher decides what to search for, and reads the most promising result.
+    findings = await rt.call(
+        Researcher, f"Find and read the best source to answer: {question}"
+    )
+
+    # Summarizer turns the raw findings into a direct, cited answer.
+    answer = await rt.call(
+        Summarizer, f"Question: {question}\n\nSource material:\n{findings.text}"
+    )
+    return answer.text
+
+
+#### Flow Definition #####
+research_flow = rt.Flow(
+    name="Web Research Flow", entry_point=research
+)  # `research` function as the entry point of the flow
+
+if __name__ == "__main__":
+    question = "What is railtracks (the Python agent framework)?"
+    result = research_flow.invoke(question)
+    print(result)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
                   - Overview: documentation/agent_design/tools/prebuilt/overview.md
                   - To Do Tool: documentation/agent_design/tools/prebuilt/todos.md
                   - Key-Value Memory Tool: documentation/agent_design/tools/prebuilt/key_value_memory.md
+                  - Web Search Tool: documentation/agent_design/tools/prebuilt/websearch.md
               - Function Tools: documentation/agent_design/tools/function_tools.md
               - Agents as Tools: documentation/agent_design/tools/agents_as_tools.md
               - MCP: documentation/agent_design/tools/mcp.md

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -54,10 +54,13 @@ visual = [
 # For each Integration package dependencies go here.
 portkey = ["portkey_ai >= 2.0.2"]
 
-# Prebuilt WebSearchToolSet: Tavily search (plain REST via httpx) + trafilatura
-# HTML-to-text extraction for the default fetch backend.
+# Prebuilt WebSearchToolSet: the official tavily-python SDK for the default
+# search backend (Brave, an alternate backend, uses httpx directly since
+# Brave has no official SDK), httpx + trafilatura for the default fetch
+# backend's HTML-to-text extraction.
 websearch = [
     "httpx >= 0.27.0",
+    "tavily-python >= 0.7.0",
     "trafilatura >= 1.8.0",
 ]
 

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -54,6 +54,13 @@ visual = [
 # For each Integration package dependencies go here.
 portkey = ["portkey_ai >= 2.0.2"]
 
+# Prebuilt WebSearchToolSet: Tavily search (plain REST via httpx) + trafilatura
+# HTML-to-text extraction for the default fetch backend.
+websearch = [
+    "httpx >= 0.27.0",
+    "trafilatura >= 1.8.0",
+]
+
 # Retrieval-stack extras. These are not pulled in by `[all]` — install
 # `railtracks[retrieval]` to opt in.
 tiktok = ["tiktoken>=0.10.0, <=0.12.0"]
@@ -104,7 +111,7 @@ retrieval = [
     "railtracks[stores-all]",
 ]
 
-all = ["railtracks[visual]", "railtracks[portkey]", "railtracks[retrieval]"]
+all = ["railtracks[visual]", "railtracks[portkey]", "railtracks[retrieval]", "railtracks[websearch]"]
 
 [project.scripts]
 railtracks = "railtracks.cli:main"

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -60,7 +60,7 @@ portkey = ["portkey_ai >= 2.0.2"]
 # backend's HTML-to-text extraction.
 websearch = [
     "httpx >= 0.27.0",
-    "tavily-python >= 0.7.0",
+    "tavily-python >= 0.5.0",
     "trafilatura >= 1.8.0",
 ]
 

--- a/packages/railtracks/src/railtracks/prebuilt/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/__init__.py
@@ -1,8 +1,10 @@
 ######## This package contains a suite of pre-built ready to use agents designed to help you build faster #########
 from .tools.memory import KeyValueMemoryToolSet
 from .tools.todo import ToDoToolSet
+from .tools.websearch import WebSearchToolSet
 
 __all__ = [
     "KeyValueMemoryToolSet",
     "ToDoToolSet",
+    "WebSearchToolSet",
 ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/__init__.py
@@ -1,0 +1,12 @@
+from .fetch import FetchBackend
+from .models import FetchResult, SearchResult
+from .search import SearchBackend
+from .websearch import WebSearchToolSet
+
+__all__ = [
+    "FetchBackend",
+    "FetchResult",
+    "SearchBackend",
+    "SearchResult",
+    "WebSearchToolSet",
+]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/__init__.py
@@ -2,8 +2,8 @@
 
 ``FetchBackend`` is pure stdlib (a Protocol) and imported eagerly.
 ``HttpFetch`` requires the `websearch` extra (httpx, trafilatura), so it is
-loaded lazily on first access — importing this package stays
-dependency-light.
+loaded lazily on first access; importing this package for the protocol alone
+stays dependency-light.
 """
 
 from __future__ import annotations

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/__init__.py
@@ -1,0 +1,29 @@
+"""Fetch backends for the prebuilt web search tools.
+
+``FetchBackend`` is pure stdlib (a Protocol) and imported eagerly.
+``HttpFetch`` requires the `websearch` extra (httpx, trafilatura), so it is
+loaded lazily on first access — importing this package stays
+dependency-light.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .protocol import FetchBackend
+
+if TYPE_CHECKING:
+    from .http import HttpFetch
+
+__all__ = [
+    "FetchBackend",
+    "HttpFetch",
+]
+
+
+def __getattr__(name: str):
+    if name == "HttpFetch":
+        from .http import HttpFetch
+
+        return HttpFetch
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/http.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/http.py
@@ -23,6 +23,17 @@ class HttpFetch:
         timeout: float = 15.0,
         user_agent: str = _DEFAULT_USER_AGENT,
     ) -> None:
+        """Create an httpx + trafilatura fetch backend.
+
+        Args:
+            timeout: Request timeout in seconds before the fetch is treated
+                as failed.
+            user_agent: Sent as the request's User-Agent header. Defaults to
+                an honest, identifiable string rather than spoofing a real
+                browser; some sites block bare HTTP-library user agents, and
+                a few require a real browser UA to serve content at all —
+                override this if you hit that.
+        """
         self._timeout = timeout
         self._user_agent = user_agent
 

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/http.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/http.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import httpx
+import trafilatura
+
+from ..models import FetchResult
+
+_DEFAULT_USER_AGENT = "railtracks-websearch/1.0"
+
+
+class HttpFetch:
+    """FetchBackend using a plain HTTP GET + trafilatura extraction.
+
+    Handles static/server-rendered pages. JS-heavy pages that render content
+    client-side will typically come back with no extractable content; a
+    headless-browser backend can be swapped in later for those via the same
+    FetchBackend signature.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 15.0,
+        user_agent: str = _DEFAULT_USER_AGENT,
+    ) -> None:
+        self._timeout = timeout
+        self._user_agent = user_agent
+
+    async def fetch(self, url: str) -> FetchResult:
+        try:
+            async with httpx.AsyncClient(
+                timeout=self._timeout,
+                headers={"User-Agent": self._user_agent},
+                follow_redirects=True,
+            ) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+        except httpx.HTTPError as e:
+            return FetchResult(
+                url=url, is_error=True, error_message=f"Fetch failed: {e}"
+            )
+
+        text = trafilatura.extract(resp.text) or ""
+        if not text:
+            return FetchResult(
+                url=url,
+                is_error=True,
+                error_message=(
+                    "Page fetched but no extractable content (possibly "
+                    "JS-rendered, blocked, or paywalled)."
+                ),
+            )
+
+        metadata = trafilatura.extract_metadata(resp.text)
+        title = metadata.title if metadata is not None else None
+        return FetchResult(url=url, title=title, text=text)

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/protocol.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Protocol, runtime_checkable
 
 from ..models import FetchResult
@@ -10,17 +11,18 @@ class FetchBackend(Protocol):
     """Retrieves a URL and returns cleaned page content.
 
     Callers (e.g. ``WebSearchToolSet``) depend on this protocol rather than a
-    concrete fetch implementation, so the backend can be swapped — a plain
+    concrete fetch implementation, so the backend can be swapped, a plain
     HTTP + HTML-to-text extractor today, a headless browser for JS-heavy
-    pages later — without touching the toolset.
+    pages later, without touching the toolset.
     """
 
+    @abstractmethod
     async def fetch(self, url: str) -> FetchResult:
         """Fetch ``url`` and return its cleaned text content.
 
         Expected failure modes (blocked, paywalled, no extractable content,
         network error) are represented via ``FetchResult(is_error=True, ...)``
-        rather than a raised exception — these are common outcomes for a
+        rather than a raised exception, these are common outcomes for a
         fetch layer, not exceptional ones.
         """
-        ...
+        pass

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/protocol.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/fetch/protocol.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ..models import FetchResult
+
+
+@runtime_checkable
+class FetchBackend(Protocol):
+    """Retrieves a URL and returns cleaned page content.
+
+    Callers (e.g. ``WebSearchToolSet``) depend on this protocol rather than a
+    concrete fetch implementation, so the backend can be swapped — a plain
+    HTTP + HTML-to-text extractor today, a headless browser for JS-heavy
+    pages later — without touching the toolset.
+    """
+
+    async def fetch(self, url: str) -> FetchResult:
+        """Fetch ``url`` and return its cleaned text content.
+
+        Expected failure modes (blocked, paywalled, no extractable content,
+        network error) are represented via ``FetchResult(is_error=True, ...)``
+        rather than a raised exception — these are common outcomes for a
+        fetch layer, not exceptional ones.
+        """
+        ...

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/models.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/models.py
@@ -16,7 +16,7 @@ class FetchResult(BaseModel):
 
     A failed fetch (paywalled, blocked, no extractable content, network
     error) is represented by ``is_error=True`` with ``error_message`` set,
-    rather than raising — these are expected, common outcomes for a fetch
+    rather than raising, these are expected, common outcomes for a fetch
     layer, not exceptional ones.
     """
 

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/models.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/models.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SearchResult(BaseModel):
+    """A single ranked web search result."""
+
+    title: str
+    url: str
+    snippet: str
+
+
+class FetchResult(BaseModel):
+    """The outcome of fetching a URL and extracting its page content.
+
+    A failed fetch (paywalled, blocked, no extractable content, network
+    error) is represented by ``is_error=True`` with ``error_message`` set,
+    rather than raising — these are expected, common outcomes for a fetch
+    layer, not exceptional ones.
+    """
+
+    url: str
+    title: str | None = None
+    text: str = ""
+    is_error: bool = False
+    error_message: str | None = None

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
@@ -1,0 +1,28 @@
+"""Search backends for the prebuilt web search tools.
+
+``SearchBackend`` is pure stdlib (a Protocol) and imported eagerly.
+``TavilySearch`` requires the `websearch` extra (httpx), so it is loaded
+lazily on first access — importing this package stays dependency-light.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .protocol import SearchBackend
+
+if TYPE_CHECKING:
+    from .tavily import TavilySearch
+
+__all__ = [
+    "SearchBackend",
+    "TavilySearch",
+]
+
+
+def __getattr__(name: str):
+    if name == "TavilySearch":
+        from .tavily import TavilySearch
+
+        return TavilySearch
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
@@ -2,7 +2,8 @@
 
 ``SearchBackend`` is pure stdlib (a Protocol) and imported eagerly.
 ``TavilySearch`` requires the `websearch` extra (httpx), so it is loaded
-lazily on first access — importing this package stays dependency-light.
+lazily on first access; importing this package for the protocol alone stays
+dependency-light.
 """
 
 from __future__ import annotations

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/__init__.py
@@ -1,9 +1,9 @@
 """Search backends for the prebuilt web search tools.
 
 ``SearchBackend`` is pure stdlib (a Protocol) and imported eagerly.
-``TavilySearch`` requires the `websearch` extra (httpx), so it is loaded
-lazily on first access; importing this package for the protocol alone stays
-dependency-light.
+``TavilySearch``/``BraveSearch`` require the `websearch` extra (httpx), so
+they are loaded lazily on first access; importing this package for the
+protocol alone stays dependency-light.
 """
 
 from __future__ import annotations
@@ -13,9 +13,11 @@ from typing import TYPE_CHECKING
 from .protocol import SearchBackend
 
 if TYPE_CHECKING:
+    from .brave import BraveSearch
     from .tavily import TavilySearch
 
 __all__ = [
+    "BraveSearch",
     "SearchBackend",
     "TavilySearch",
 ]
@@ -26,4 +28,8 @@ def __getattr__(name: str):
         from .tavily import TavilySearch
 
         return TavilySearch
+    if name == "BraveSearch":
+        from .brave import BraveSearch
+
+        return BraveSearch
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/brave.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/brave.py
@@ -12,8 +12,11 @@ _BRAVE_URL = "https://api.search.brave.com/res/v1/web/search"
 class BraveSearch:
     """SearchBackend backed by the Brave Search API.
 
-    Talks to Brave's `/web/search` endpoint directly via httpx rather than
-    depending on a separate SDK, matching TavilySearch's approach.
+    Talks to Brave's `/web/search` endpoint directly via httpx. Unlike
+    TavilySearch, this isn't a stopgap: Brave doesn't publish its own
+    official Python SDK (only unofficial, community-maintained wrappers
+    exist), so hand-rolling the one endpoint we need is more dependable
+    than depending on a third party that could itself go unmaintained.
     """
 
     def __init__(

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/brave.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/brave.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from ..models import SearchResult
+
+_BRAVE_URL = "https://api.search.brave.com/res/v1/web/search"
+
+
+class BraveSearch:
+    """SearchBackend backed by the Brave Search API.
+
+    Talks to Brave's `/web/search` endpoint directly via httpx rather than
+    depending on a separate SDK, matching TavilySearch's approach.
+    """
+
+    def __init__(
+        self, api_key: str | None = None, *, base_url: str = _BRAVE_URL
+    ) -> None:
+        """Create a Brave-backed search backend.
+
+        Args:
+            api_key: Brave Search API key (a "subscription token"). Falls
+                back to the BRAVE_API_KEY environment variable if not
+                provided; raises if neither is set.
+            base_url: Override the Brave search endpoint, e.g. to point at
+                a proxy or a mocked server in tests.
+        """
+        self.api_key = api_key or os.getenv("BRAVE_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Brave API key not provided. Pass api_key=, or set the "
+                "BRAVE_API_KEY environment variable."
+            )
+        self._base_url = base_url
+
+    async def search(self, query: str, *, top_k: int = 5) -> list[SearchResult]:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                self._base_url,
+                params={"q": query, "count": top_k},
+                headers={
+                    "Accept": "application/json",
+                    "X-Subscription-Token": self.api_key,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        results = data.get("web", {}).get("results", [])
+        return [
+            SearchResult(
+                title=result.get("title", ""),
+                url=result.get("url", ""),
+                snippet=result.get("description", ""),
+            )
+            for result in results
+        ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/protocol.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Protocol, runtime_checkable
 
 from ..models import SearchResult
@@ -10,10 +11,11 @@ class SearchBackend(Protocol):
     """Runs a web search and returns ranked results.
 
     Callers (e.g. ``WebSearchToolSet``) depend on this protocol rather than a
-    concrete search provider, so the backend can be swapped — Tavily, Brave,
-    SerpAPI, or any other implementation — without touching the toolset.
+    concrete search provider, so the backend can be swapped by Tavily, Brave,
+    SerpAPI, or any other implementation, without touching the toolset.
     """
 
+    @abstractmethod
     async def search(self, query: str, *, top_k: int = 5) -> list[SearchResult]:
         """Return up to ``top_k`` search results, best first.
 
@@ -25,4 +27,4 @@ class SearchBackend(Protocol):
             Exception: Implementations may raise on backend/network failure;
                 callers are responsible for catching and degrading gracefully.
         """
-        ...
+        pass

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/protocol.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/protocol.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ..models import SearchResult
+
+
+@runtime_checkable
+class SearchBackend(Protocol):
+    """Runs a web search and returns ranked results.
+
+    Callers (e.g. ``WebSearchToolSet``) depend on this protocol rather than a
+    concrete search provider, so the backend can be swapped — Tavily, Brave,
+    SerpAPI, or any other implementation — without touching the toolset.
+    """
+
+    async def search(self, query: str, *, top_k: int = 5) -> list[SearchResult]:
+        """Return up to ``top_k`` search results, best first.
+
+        Args:
+            query: Free-text search query.
+            top_k: Maximum number of results to return.
+
+        Raises:
+            Exception: Implementations may raise on backend/network failure;
+                callers are responsible for catching and degrading gracefully.
+        """
+        ...

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 import os
 
-import httpx
+from tavily import AsyncTavilyClient
 
 from ..models import SearchResult
 
-_TAVILY_URL = "https://api.tavily.com/search"
-
 
 class TavilySearch:
-    """SearchBackend backed by the Tavily REST API.
+    """SearchBackend backed by the official `tavily-python` SDK.
 
-    Talks to Tavily's single `/search` endpoint directly via httpx rather
-    than depending on the `tavily-python` SDK, since httpx is already
-    required by the default fetch backend.
+    Uses `AsyncTavilyClient` rather than talking to Tavily's REST API
+    directly, so if Tavily changes their API, keeping up with that is
+    their SDK's job to maintain, not ours to track and patch.
     """
 
     def __init__(
-        self, api_key: str | None = None, *, base_url: str = _TAVILY_URL
+        self, api_key: str | None = None, *, base_url: str | None = None
     ) -> None:
         """Create a Tavily-backed search backend.
 
@@ -26,8 +24,9 @@ class TavilySearch:
             api_key: Tavily API key. Falls back to the TAVILY_API_KEY
                 environment variable if not provided; raises if neither is
                 set.
-            base_url: Override the Tavily search endpoint, e.g. to point at
-                a proxy or a mocked server in tests.
+            base_url: Override the Tavily API base URL, e.g. to point at a
+                proxy or a mocked server in tests. Defaults to the SDK's own
+                default when not set.
         """
         self.api_key = api_key or os.getenv("TAVILY_API_KEY")
         if not self.api_key:
@@ -35,26 +34,15 @@ class TavilySearch:
                 "Tavily API key not provided. Pass api_key=, or set the "
                 "TAVILY_API_KEY environment variable."
             )
-        self._base_url = base_url
+        self._client = AsyncTavilyClient(api_key=self.api_key, api_base_url=base_url)
 
     async def search(self, query: str, *, top_k: int = 5) -> list[SearchResult]:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                self._base_url,
-                json={
-                    "api_key": self.api_key,
-                    "query": query,
-                    "max_results": top_k,
-                },
-            )
-            resp.raise_for_status()
-            data = resp.json()
-
+        response = await self._client.search(query, max_results=top_k)
         return [
             SearchResult(
                 title=result.get("title", ""),
                 url=result.get("url", ""),
                 snippet=result.get("content", ""),
             )
-            for result in data.get("results", [])
+            for result in response.get("results", [])
         ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+
+import httpx
+
+from ..models import SearchResult
+
+_TAVILY_URL = "https://api.tavily.com/search"
+
+
+class TavilySearch:
+    """SearchBackend backed by the Tavily REST API.
+
+    Talks to Tavily's single `/search` endpoint directly via httpx rather
+    than depending on the `tavily-python` SDK, since httpx is already
+    required by the default fetch backend.
+    """
+
+    def __init__(
+        self, api_key: str | None = None, *, base_url: str = _TAVILY_URL
+    ) -> None:
+        self.api_key = api_key or os.getenv("TAVILY_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "Tavily API key not provided. Pass api_key=, or set the "
+                "TAVILY_API_KEY environment variable."
+            )
+        self._base_url = base_url
+
+    async def search(self, query: str, *, top_k: int = 5) -> list[SearchResult]:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                self._base_url,
+                json={
+                    "api_key": self.api_key,
+                    "query": query,
+                    "max_results": top_k,
+                },
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        return [
+            SearchResult(
+                title=result.get("title", ""),
+                url=result.get("url", ""),
+                snippet=result.get("content", ""),
+            )
+            for result in data.get("results", [])
+        ]

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/search/tavily.py
@@ -20,6 +20,15 @@ class TavilySearch:
     def __init__(
         self, api_key: str | None = None, *, base_url: str = _TAVILY_URL
     ) -> None:
+        """Create a Tavily-backed search backend.
+
+        Args:
+            api_key: Tavily API key. Falls back to the TAVILY_API_KEY
+                environment variable if not provided; raises if neither is
+                set.
+            base_url: Override the Tavily search endpoint, e.g. to point at
+                a proxy or a mocked server in tests.
+        """
         self.api_key = api_key or os.getenv("TAVILY_API_KEY")
         if not self.api_key:
             raise ValueError(

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/websearch.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/websearch.py
@@ -31,18 +31,7 @@ class WebSearchToolSet(ToolSet):
     """Prebuilt web search + page-fetch tools for an agent.
 
     Gives an agent the ability to search the live web and read full page
-    content: ``search()`` for ranked title/url/snippet results, ``fetch()``
-    to read one result's full content, and ``search_and_fetch()`` to do both
-    in a single call. Defaults to Tavily for search and an httpx + trafilatura
-    HTML-to-text extractor for fetch; both are swappable via constructor
-    injection::
-
-        toolset = WebSearchToolSet(search=MySearchBackend(), fetch=MyFetchBackend())
-
-    Backend/network failures are caught and returned as a descriptive string
-    rather than raised, so a backend outage never breaks the agent's turn;
-    semantic fetch failures (paywalled, blocked, no extractable content) are
-    likewise reported as text rather than an exception.
+    content
 
     Args:
         search: Backend used by search()/search_and_fetch(). Defaults to

--- a/packages/railtracks/src/railtracks/prebuilt/tools/websearch/websearch.py
+++ b/packages/railtracks/src/railtracks/prebuilt/tools/websearch/websearch.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import railtracks as rt
+from railtracks.built_nodes.concrete.function_base import RTFunction
+from railtracks.utils.logging.create import get_rt_logger
+
+from .._base import ToolSet
+
+if TYPE_CHECKING:
+    from .fetch import FetchBackend
+    from .search import SearchBackend
+
+logger = get_rt_logger(__name__)
+
+
+def _default_search() -> SearchBackend:
+    from .search import TavilySearch
+
+    return TavilySearch()
+
+
+def _default_fetch() -> FetchBackend:
+    from .fetch import HttpFetch
+
+    return HttpFetch()
+
+
+class WebSearchToolSet(ToolSet):
+    """Prebuilt web search + page-fetch tools for an agent.
+
+    Gives an agent the ability to search the live web and read full page
+    content: ``search()`` for ranked title/url/snippet results, ``fetch()``
+    to read one result's full content, and ``search_and_fetch()`` to do both
+    in a single call. Defaults to Tavily for search and an httpx + trafilatura
+    HTML-to-text extractor for fetch; both are swappable via constructor
+    injection::
+
+        toolset = WebSearchToolSet(search=MySearchBackend(), fetch=MyFetchBackend())
+
+    Backend/network failures are caught and returned as a descriptive string
+    rather than raised, so a backend outage never breaks the agent's turn;
+    semantic fetch failures (paywalled, blocked, no extractable content) are
+    likewise reported as text rather than an exception.
+
+    Args:
+        search: Backend used by search()/search_and_fetch(). Defaults to
+            ``TavilySearch()`` (requires a ``TAVILY_API_KEY``).
+        fetch: Backend used by fetch()/search_and_fetch(). Defaults to
+            ``HttpFetch()``.
+    """
+
+    def __init__(
+        self,
+        search: SearchBackend | None = None,
+        fetch: FetchBackend | None = None,
+    ) -> None:
+        self.search_backend: SearchBackend = (
+            search if search is not None else _default_search()
+        )
+        self.fetch_backend: FetchBackend = (
+            fetch if fetch is not None else _default_fetch()
+        )
+
+    async def search(self, query: str, top_k: int = 5) -> str:
+        """Search the web and return ranked results (title, URL, snippet).
+
+        Use this to find candidate pages before fetching full content with
+        fetch(), or use search_and_fetch() to do both in one call.
+
+        Args:
+            query: Free-text search query.
+            top_k: Maximum number of results to return.
+
+        Returns:
+            Newline-separated "title — url" entries with a snippet on each,
+            ranked by relevance, or a message saying the search failed or
+            found nothing.
+        """
+        try:
+            results = await self.search_backend.search(query, top_k=top_k)
+        except Exception as e:
+            logger.error(f"WebSearch search backend error for query {query!r}: {e}")
+            return f"Search failed: {e}"
+
+        if not results:
+            return f"No results found for '{query}'."
+        return "\n".join(f"- {r.title} — {r.url}\n  {r.snippet}" for r in results)
+
+    async def fetch(self, url: str) -> str:
+        """Fetch a URL (typically from search() results) and return cleaned page text.
+
+        Args:
+            url: The page URL to retrieve. Should be an http(s) URL, usually
+                one returned by search().
+
+        Returns:
+            The extracted, human-readable text content of the page, or a
+            message describing why the fetch failed (blocked, paywalled,
+            not found, no extractable content) so a different result can be
+            tried instead.
+        """
+        try:
+            result = await self.fetch_backend.fetch(url)
+        except Exception as e:
+            logger.error(f"WebSearch fetch backend error for url {url!r}: {e}")
+            return f"Fetch failed for '{url}': {e}"
+
+        if result.is_error:
+            return f"Fetch failed for '{url}': {result.error_message}"
+
+        header = f"{result.title}\n" if result.title else ""
+        return f"{header}{result.text}"
+
+    async def search_and_fetch(self, query: str, top_k: int = 3) -> str:
+        """Search the web and fetch full content for each top result in one call.
+
+        Convenience wrapper combining search() and fetch(); use when you want
+        full page content immediately without an extra round trip, at the
+        cost of fetching (and paying token cost for) top_k pages instead of
+        one. Individual fetch failures are reported inline rather than
+        aborting the whole call.
+
+        Args:
+            query: Free-text search query.
+            top_k: Number of top results to fetch full content for.
+
+        Returns:
+            For each result: title, url, and either its cleaned text or an
+            inline error message, separated by section dividers.
+        """
+        try:
+            results = await self.search_backend.search(query, top_k=top_k)
+        except Exception as e:
+            logger.error(f"WebSearch search backend error for query {query!r}: {e}")
+            return f"Search failed: {e}"
+
+        if not results:
+            return f"No results found for '{query}'."
+
+        sections = []
+        for r in results:
+            try:
+                fetched = await self.fetch_backend.fetch(r.url)
+                body = (
+                    fetched.text
+                    if not fetched.is_error
+                    else f"[fetch failed: {fetched.error_message}]"
+                )
+            except Exception as e:
+                logger.error(f"WebSearch fetch backend error for url {r.url!r}: {e}")
+                body = f"[fetch failed: {e}]"
+            sections.append(f"## {r.title}\n{r.url}\n\n{body}")
+        return "\n\n---\n\n".join(sections)
+
+    @classmethod
+    def prompt(cls) -> str:
+        return (
+            "Use the web search tools to find and read current information from the "
+            "live web. Call search(query) to get ranked title/url/snippet results, "
+            "then fetch(url) on the most promising result(s) to read full page content. "
+            "Use search_and_fetch(query) when you want full content for the top results "
+            "in a single step. If a fetch fails (blocked, paywalled, no content), try "
+            "another result instead of retrying the same URL."
+        )
+
+    def tool_set(self) -> list[RTFunction]:
+        functions = [self.search, self.fetch, self.search_and_fetch]
+        return [rt.function_node(func) for func in functions]

--- a/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
+++ b/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
@@ -1,8 +1,20 @@
+import re
+
 import pytest
 import railtracks as rt
 from railtracks.llm import ToolCall
 from railtracks.prebuilt.tools.websearch import WebSearchToolSet
 from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult
+
+
+def _contains_url(text: str, url: str) -> bool:
+    """Check that `url` appears in `text` as a whole token.
+
+    A plain `url in text` substring check would also match a spoofed
+    superstring like "https://railtracks.org.evil.com", so anchor on a
+    non-URL character (or end of string) right after it.
+    """
+    return re.search(rf"{re.escape(url)}(?![\w./-])", text) is not None
 
 
 class _FakeSearch:
@@ -53,7 +65,7 @@ class TestWebSearchToolCalling:
         with rt.Session():
             response = await rt.call(agent, user_input="What is railtracks?")
             assert "An agentic framework" in response.text
-            assert "https://railtracks.org" in response.text
+            assert _contains_url(response.text, "https://railtracks.org")
 
     @pytest.mark.asyncio
     async def test_fetch_tool_round_trips_through_agent(self, mock_llm):

--- a/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
+++ b/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
@@ -1,0 +1,88 @@
+import pytest
+import railtracks as rt
+from railtracks.llm import ToolCall
+from railtracks.prebuilt.tools.websearch import WebSearchToolSet
+from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult
+
+
+class _FakeSearch:
+    def __init__(self, results):
+        self._results = results
+
+    async def search(self, query, *, top_k=5):
+        return self._results
+
+
+class _FakeFetch:
+    def __init__(self, result):
+        self._result = result
+
+    async def fetch(self, url):
+        return self._result
+
+
+class TestWebSearchToolCalling:
+    @pytest.mark.asyncio
+    async def test_search_tool_round_trips_through_agent(self, mock_llm):
+        results = [
+            SearchResult(
+                title="Railtracks",
+                url="https://railtracks.org",
+                snippet="An agentic framework",
+            )
+        ]
+        toolset = WebSearchToolSet(search=_FakeSearch(results), fetch=_FakeFetch(None))
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(
+                    name="search",
+                    identifier="id_search_1",
+                    arguments={"query": "railtracks framework"},
+                )
+            ]
+        )
+
+        agent = rt.agent_node(
+            tool_nodes=toolset.tool_set(),
+            name="Web Research Agent",
+            system_message=WebSearchToolSet.prompt(),
+            llm=llm,
+        )
+
+        with rt.Session():
+            response = await rt.call(agent, user_input="What is railtracks?")
+            assert "An agentic framework" in response.text
+            assert "https://railtracks.org" in response.text
+
+    @pytest.mark.asyncio
+    async def test_fetch_tool_round_trips_through_agent(self, mock_llm):
+        fetch_result = FetchResult(
+            url="https://railtracks.org",
+            title="Railtracks",
+            text="Full page content here",
+        )
+        toolset = WebSearchToolSet(
+            search=_FakeSearch([]), fetch=_FakeFetch(fetch_result)
+        )
+
+        llm = mock_llm(
+            requested_tool_calls=[
+                ToolCall(
+                    name="fetch",
+                    identifier="id_fetch_1",
+                    arguments={"url": "https://railtracks.org"},
+                )
+            ]
+        )
+
+        agent = rt.agent_node(
+            tool_nodes=toolset.tool_set(),
+            name="Web Research Agent",
+            system_message=WebSearchToolSet.prompt(),
+            llm=llm,
+        )
+
+        with rt.Session():
+            response = await rt.call(agent, user_input="Read https://railtracks.org")
+            assert "Full page content here" in response.text

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_brave_search.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_brave_search.py
@@ -1,0 +1,108 @@
+"""Tests for prebuilt/tools/websearch/search/brave.py — BraveSearch."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from railtracks.prebuilt.tools.websearch.search import SearchBackend
+from railtracks.prebuilt.tools.websearch.search.brave import BraveSearch
+
+
+def _mock_client(json_payload=None, raise_status_error=False):
+    """Build a fake httpx.AsyncClient context manager for `async with ... as client`."""
+    response = MagicMock()
+    if raise_status_error:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock()
+        )
+    else:
+        response.raise_for_status.return_value = None
+        response.json.return_value = json_payload or {}
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# API key handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="BRAVE_API_KEY"):
+        BraveSearch()
+
+
+def test_explicit_api_key_used(monkeypatch):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    bs = BraveSearch(api_key="explicit-key")
+    assert bs.api_key == "explicit-key"
+
+
+def test_env_api_key_used(monkeypatch):
+    monkeypatch.setenv("BRAVE_API_KEY", "env-key")
+    bs = BraveSearch()
+    assert bs.api_key == "env-key"
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_search_backend_protocol():
+    assert isinstance(BraveSearch(api_key="x"), SearchBackend)
+
+
+async def test_search_maps_results_in_order():
+    payload = {
+        "web": {
+            "results": [
+                {"title": "A", "url": "https://a.com", "description": "snippet a"},
+                {"title": "B", "url": "https://b.com", "description": "snippet b"},
+            ]
+        }
+    }
+    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+        results = await BraveSearch(api_key="x").search("query", top_k=2)
+
+    assert [r.title for r in results] == ["A", "B"]
+    assert results[0].url == "https://a.com"
+    assert results[0].snippet == "snippet a"
+
+
+async def test_search_missing_fields_default_to_empty():
+    payload = {"web": {"results": [{"title": "A"}]}}
+    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+        results = await BraveSearch(api_key="x").search("query")
+
+    assert results[0].url == ""
+    assert results[0].snippet == ""
+
+
+async def test_search_empty_results():
+    with patch(
+        "httpx.AsyncClient", return_value=_mock_client({"web": {"results": []}})
+    ):
+        results = await BraveSearch(api_key="x").search("query")
+
+    assert results == []
+
+
+async def test_search_missing_web_key_returns_empty():
+    with patch("httpx.AsyncClient", return_value=_mock_client({})):
+        results = await BraveSearch(api_key="x").search("query")
+
+    assert results == []
+
+
+async def test_search_http_error_propagates():
+    with patch("httpx.AsyncClient", return_value=_mock_client(raise_status_error=True)):
+        with pytest.raises(httpx.HTTPStatusError):
+            await BraveSearch(api_key="x").search("query")

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_http_fetch.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_http_fetch.py
@@ -1,5 +1,3 @@
-"""Tests for prebuilt/tools/websearch/fetch/http.py — HttpFetch."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_http_fetch.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_http_fetch.py
@@ -1,0 +1,72 @@
+"""Tests for prebuilt/tools/websearch/fetch/http.py — HttpFetch."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+from railtracks.prebuilt.tools.websearch.fetch import FetchBackend
+from railtracks.prebuilt.tools.websearch.fetch.http import HttpFetch
+
+_SAMPLE_HTML = """
+<html><head><title>Sample Page</title></head>
+<body>
+<nav>Home | About | Contact</nav>
+<article><p>This is the real body content worth extracting.</p></article>
+<footer>Copyright 2026</footer>
+</body></html>
+"""
+
+
+def _mock_client(text=_SAMPLE_HTML, raise_error=None):
+    response = MagicMock()
+    response.text = text
+    if raise_error is not None:
+        response.raise_for_status.side_effect = raise_error
+    else:
+        response.raise_for_status.return_value = None
+
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def test_satisfies_fetch_backend_protocol():
+    assert isinstance(HttpFetch(), FetchBackend)
+
+
+async def test_fetch_extracts_clean_text():
+    with patch("httpx.AsyncClient", return_value=_mock_client()):
+        result = await HttpFetch().fetch("https://example.com")
+
+    assert result.is_error is False
+    assert result.title == "Sample Page"
+    assert "real body content" in result.text
+
+
+async def test_fetch_http_error_is_not_raised():
+    error = httpx.HTTPStatusError("404", request=MagicMock(), response=MagicMock())
+    with patch("httpx.AsyncClient", return_value=_mock_client(raise_error=error)):
+        result = await HttpFetch().fetch("https://example.com/missing")
+
+    assert result.is_error is True
+    assert "Fetch failed" in result.error_message
+
+
+async def test_fetch_timeout_is_not_raised():
+    error = httpx.TimeoutException("timed out")
+    with patch("httpx.AsyncClient", return_value=_mock_client(raise_error=error)):
+        result = await HttpFetch().fetch("https://example.com/slow")
+
+    assert result.is_error is True
+    assert "Fetch failed" in result.error_message
+
+
+async def test_fetch_empty_extraction_reports_error():
+    with patch("httpx.AsyncClient", return_value=_mock_client(text="<html></html>")):
+        result = await HttpFetch().fetch("https://example.com/blank")
+
+    assert result.is_error is True
+    assert "no extractable content" in result.error_message

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_models.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_models.py
@@ -1,5 +1,3 @@
-"""Tests for prebuilt/tools/websearch/models.py — SearchResult, FetchResult."""
-
 import pytest
 from pydantic import ValidationError
 from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_models.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_models.py
@@ -1,0 +1,32 @@
+"""Tests for prebuilt/tools/websearch/models.py — SearchResult, FetchResult."""
+
+import pytest
+from pydantic import ValidationError
+from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult
+
+
+def test_search_result_requires_fields():
+    result = SearchResult(title="t", url="u", snippet="s")
+    assert result.title == "t"
+    assert result.url == "u"
+    assert result.snippet == "s"
+
+
+def test_search_result_missing_field_raises():
+    with pytest.raises(ValidationError):
+        SearchResult(title="t", url="u")
+
+
+def test_fetch_result_defaults():
+    result = FetchResult(url="u")
+    assert result.title is None
+    assert result.text == ""
+    assert result.is_error is False
+    assert result.error_message is None
+
+
+def test_fetch_result_error_only():
+    result = FetchResult(url="u", is_error=True, error_message="nope")
+    assert result.is_error is True
+    assert result.error_message == "nope"
+    assert result.text == ""

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
@@ -1,29 +1,23 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+"""Tests for prebuilt/tools/websearch/search/tavily.py — TavilySearch."""
 
-import httpx
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from railtracks.prebuilt.tools.websearch.search import SearchBackend
 from railtracks.prebuilt.tools.websearch.search.tavily import TavilySearch
+from tavily import BadRequestError
+
+_PATCH_TARGET = "railtracks.prebuilt.tools.websearch.search.tavily.AsyncTavilyClient"
 
 
-def _mock_client(json_payload=None, raise_status_error=False):
-    """Build a fake httpx.AsyncClient context manager for `async with ... as client`."""
-    response = MagicMock()
-    if raise_status_error:
-        response.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "boom", request=MagicMock(), response=MagicMock()
-        )
+def _mock_sdk_client(response=None, raise_error=None):
+    """Build a fake AsyncTavilyClient whose .search() returns/raises as configured."""
+    client = AsyncMock()
+    if raise_error is not None:
+        client.search.side_effect = raise_error
     else:
-        response.raise_for_status.return_value = None
-        response.json.return_value = json_payload or {}
-
-    client = MagicMock()
-    client.post = AsyncMock(return_value=response)
-
-    cm = MagicMock()
-    cm.__aenter__ = AsyncMock(return_value=client)
-    cm.__aexit__ = AsyncMock(return_value=False)
-    return cm
+        client.search.return_value = response or {}
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -65,7 +59,7 @@ async def test_search_maps_results_in_order():
             {"title": "B", "url": "https://b.com", "content": "snippet b"},
         ]
     }
-    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+    with patch(_PATCH_TARGET, return_value=_mock_sdk_client(payload)):
         results = await TavilySearch(api_key="x").search("query", top_k=2)
 
     assert [r.title for r in results] == ["A", "B"]
@@ -75,7 +69,7 @@ async def test_search_maps_results_in_order():
 
 async def test_search_missing_fields_default_to_empty():
     payload = {"results": [{"title": "A"}]}
-    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+    with patch(_PATCH_TARGET, return_value=_mock_sdk_client(payload)):
         results = await TavilySearch(api_key="x").search("query")
 
     assert results[0].url == ""
@@ -83,13 +77,24 @@ async def test_search_missing_fields_default_to_empty():
 
 
 async def test_search_empty_results():
-    with patch("httpx.AsyncClient", return_value=_mock_client({"results": []})):
+    with patch(_PATCH_TARGET, return_value=_mock_sdk_client({"results": []})):
         results = await TavilySearch(api_key="x").search("query")
 
     assert results == []
 
 
-async def test_search_http_error_propagates():
-    with patch("httpx.AsyncClient", return_value=_mock_client(raise_status_error=True)):
-        with pytest.raises(httpx.HTTPStatusError):
+async def test_search_sdk_error_propagates():
+    with patch(
+        _PATCH_TARGET,
+        return_value=_mock_sdk_client(raise_error=BadRequestError("bad query")),
+    ):
+        with pytest.raises(BadRequestError):
             await TavilySearch(api_key="x").search("query")
+
+
+async def test_search_passes_max_results():
+    client = _mock_sdk_client({"results": []})
+    with patch(_PATCH_TARGET, return_value=client):
+        await TavilySearch(api_key="x").search("query", top_k=7)
+
+    client.search.assert_awaited_once_with("query", max_results=7)

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
@@ -1,5 +1,3 @@
-"""Tests for prebuilt/tools/websearch/search/tavily.py — TavilySearch."""
-
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_tavily_search.py
@@ -1,0 +1,97 @@
+"""Tests for prebuilt/tools/websearch/search/tavily.py — TavilySearch."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from railtracks.prebuilt.tools.websearch.search import SearchBackend
+from railtracks.prebuilt.tools.websearch.search.tavily import TavilySearch
+
+
+def _mock_client(json_payload=None, raise_status_error=False):
+    """Build a fake httpx.AsyncClient context manager for `async with ... as client`."""
+    response = MagicMock()
+    if raise_status_error:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "boom", request=MagicMock(), response=MagicMock()
+        )
+    else:
+        response.raise_for_status.return_value = None
+        response.json.return_value = json_payload or {}
+
+    client = MagicMock()
+    client.post = AsyncMock(return_value=response)
+
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# API key handling
+# ---------------------------------------------------------------------------
+
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="TAVILY_API_KEY"):
+        TavilySearch()
+
+
+def test_explicit_api_key_used(monkeypatch):
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    ts = TavilySearch(api_key="explicit-key")
+    assert ts.api_key == "explicit-key"
+
+
+def test_env_api_key_used(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "env-key")
+    ts = TavilySearch()
+    assert ts.api_key == "env-key"
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+def test_satisfies_search_backend_protocol():
+    assert isinstance(TavilySearch(api_key="x"), SearchBackend)
+
+
+async def test_search_maps_results_in_order():
+    payload = {
+        "results": [
+            {"title": "A", "url": "https://a.com", "content": "snippet a"},
+            {"title": "B", "url": "https://b.com", "content": "snippet b"},
+        ]
+    }
+    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+        results = await TavilySearch(api_key="x").search("query", top_k=2)
+
+    assert [r.title for r in results] == ["A", "B"]
+    assert results[0].url == "https://a.com"
+    assert results[0].snippet == "snippet a"
+
+
+async def test_search_missing_fields_default_to_empty():
+    payload = {"results": [{"title": "A"}]}
+    with patch("httpx.AsyncClient", return_value=_mock_client(payload)):
+        results = await TavilySearch(api_key="x").search("query")
+
+    assert results[0].url == ""
+    assert results[0].snippet == ""
+
+
+async def test_search_empty_results():
+    with patch("httpx.AsyncClient", return_value=_mock_client({"results": []})):
+        results = await TavilySearch(api_key="x").search("query")
+
+    assert results == []
+
+
+async def test_search_http_error_propagates():
+    with patch("httpx.AsyncClient", return_value=_mock_client(raise_status_error=True)):
+        with pytest.raises(httpx.HTTPStatusError):
+            await TavilySearch(api_key="x").search("query")

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
@@ -1,5 +1,3 @@
-"""Tests for prebuilt/tools/websearch/websearch.py — WebSearchToolSet."""
-
 import pytest
 from railtracks.prebuilt.tools.websearch import WebSearchToolSet
 from railtracks.prebuilt.tools.websearch.fetch import HttpFetch

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
@@ -1,8 +1,21 @@
+import re
+
 import pytest
 from railtracks.prebuilt.tools.websearch import WebSearchToolSet
 from railtracks.prebuilt.tools.websearch.fetch import HttpFetch
 from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult
 from railtracks.prebuilt.tools.websearch.search import TavilySearch
+
+
+def _contains_url(text: str, url: str) -> bool:
+    """Check that `url` appears in `text` as a whole token.
+
+    A plain `url in text` substring check would also match a spoofed
+    superstring like "https://a.com.evil.com", so anchor on a non-URL
+    character (or end of string) right after it.
+    """
+    return re.search(rf"{re.escape(url)}(?![\w./-])", text) is not None
+
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -106,7 +119,7 @@ async def test_search_and_fetch_combines_both():
     )
     out = await ts.search_and_fetch("query")
     assert "A" in out
-    assert "https://a.com" in out
+    assert _contains_url(out, "https://a.com")
     assert "full content" in out
 
 

--- a/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
+++ b/packages/railtracks/tests/unit_tests/prebuilt/tools/test_websearch.py
@@ -1,0 +1,183 @@
+"""Tests for prebuilt/tools/websearch/websearch.py — WebSearchToolSet."""
+
+import pytest
+from railtracks.prebuilt.tools.websearch import WebSearchToolSet
+from railtracks.prebuilt.tools.websearch.fetch import HttpFetch
+from railtracks.prebuilt.tools.websearch.models import FetchResult, SearchResult
+from railtracks.prebuilt.tools.websearch.search import TavilySearch
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeSearch:
+    def __init__(self, results=None, raise_error=False):
+        self._results = results or []
+        self._raise_error = raise_error
+
+    async def search(self, query, *, top_k=5):
+        if self._raise_error:
+            raise RuntimeError("search backend boom")
+        return self._results[:top_k]
+
+
+class _FakeFetch:
+    def __init__(self, result=None, raise_error=False):
+        self._result = result
+        self._raise_error = raise_error
+
+    async def fetch(self, url):
+        if self._raise_error:
+            raise RuntimeError("fetch backend boom")
+        return self._result or FetchResult(url=url, text="default text")
+
+
+@pytest.fixture
+def ts():
+    return WebSearchToolSet(search=_FakeSearch(), fetch=_FakeFetch())
+
+
+# ---------------------------------------------------------------------------
+# search()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_formats_results():
+    results = [
+        SearchResult(title="A", url="https://a.com", snippet="snip a"),
+        SearchResult(title="B", url="https://b.com", snippet="snip b"),
+    ]
+    ts = WebSearchToolSet(search=_FakeSearch(results=results), fetch=_FakeFetch())
+    out = await ts.search("query")
+    assert "A — https://a.com" in out
+    assert "snip a" in out
+    assert "B — https://b.com" in out
+
+
+async def test_search_empty_results():
+    ts = WebSearchToolSet(search=_FakeSearch(results=[]), fetch=_FakeFetch())
+    out = await ts.search("nothing")
+    assert "No results found" in out
+    assert "nothing" in out
+
+
+async def test_search_backend_exception_is_caught():
+    ts = WebSearchToolSet(search=_FakeSearch(raise_error=True), fetch=_FakeFetch())
+    out = await ts.search("query")
+    assert "Search failed" in out
+
+
+# ---------------------------------------------------------------------------
+# fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_fetch_returns_cleaned_text_with_title():
+    result = FetchResult(url="https://a.com", title="A Page", text="body text")
+    ts = WebSearchToolSet(search=_FakeSearch(), fetch=_FakeFetch(result=result))
+    out = await ts.fetch("https://a.com")
+    assert "A Page" in out
+    assert "body text" in out
+
+
+async def test_fetch_is_error_reports_message():
+    result = FetchResult(url="https://a.com", is_error=True, error_message="blocked")
+    ts = WebSearchToolSet(search=_FakeSearch(), fetch=_FakeFetch(result=result))
+    out = await ts.fetch("https://a.com")
+    assert "Fetch failed" in out
+    assert "blocked" in out
+
+
+async def test_fetch_backend_exception_is_caught():
+    ts = WebSearchToolSet(search=_FakeSearch(), fetch=_FakeFetch(raise_error=True))
+    out = await ts.fetch("https://a.com")
+    assert "Fetch failed" in out
+
+
+# ---------------------------------------------------------------------------
+# search_and_fetch()
+# ---------------------------------------------------------------------------
+
+
+async def test_search_and_fetch_combines_both():
+    results = [SearchResult(title="A", url="https://a.com", snippet="snip a")]
+    fetch_result = FetchResult(url="https://a.com", text="full content")
+    ts = WebSearchToolSet(
+        search=_FakeSearch(results=results), fetch=_FakeFetch(result=fetch_result)
+    )
+    out = await ts.search_and_fetch("query")
+    assert "A" in out
+    assert "https://a.com" in out
+    assert "full content" in out
+
+
+async def test_search_and_fetch_empty_results():
+    ts = WebSearchToolSet(search=_FakeSearch(results=[]), fetch=_FakeFetch())
+    out = await ts.search_and_fetch("nothing")
+    assert "No results found" in out
+
+
+async def test_search_and_fetch_partial_failure_does_not_abort():
+    class _MixedFetch:
+        async def fetch(self, url):
+            if url == "https://fail.com":
+                return FetchResult(url=url, is_error=True, error_message="blocked")
+            return FetchResult(url=url, text="good content")
+
+    results = [
+        SearchResult(title="Bad", url="https://fail.com", snippet="s"),
+        SearchResult(title="Good", url="https://ok.com", snippet="s"),
+    ]
+    ts = WebSearchToolSet(search=_FakeSearch(results=results), fetch=_MixedFetch())
+    out = await ts.search_and_fetch("query", top_k=2)
+    assert "[fetch failed: blocked]" in out
+    assert "good content" in out
+
+
+async def test_search_and_fetch_search_backend_exception_is_caught():
+    ts = WebSearchToolSet(search=_FakeSearch(raise_error=True), fetch=_FakeFetch())
+    out = await ts.search_and_fetch("query")
+    assert "Search failed" in out
+
+
+# ---------------------------------------------------------------------------
+# Backend injection / defaults
+# ---------------------------------------------------------------------------
+
+
+async def test_injected_backends_are_used(ts):
+    assert isinstance(ts.search_backend, _FakeSearch)
+    assert isinstance(ts.fetch_backend, _FakeFetch)
+
+
+def test_defaults_to_tavily_and_http_fetch(monkeypatch):
+    monkeypatch.setenv("TAVILY_API_KEY", "dummy-key")
+    ts = WebSearchToolSet()
+    assert isinstance(ts.search_backend, TavilySearch)
+    assert isinstance(ts.fetch_backend, HttpFetch)
+
+
+# ---------------------------------------------------------------------------
+# tool_set() / prompt()
+# ---------------------------------------------------------------------------
+
+
+def test_tool_set_returns_rt_functions(ts):
+    tools = ts.tool_set()
+    assert len(tools) == 3
+    assert all(hasattr(t, "node_type") for t in tools)
+
+
+async def test_tool_set_bound_to_instance():
+    results = [SearchResult(title="A", url="https://a.com", snippet="s")]
+    ts = WebSearchToolSet(search=_FakeSearch(results=results), fetch=_FakeFetch())
+    search_tool = ts.tool_set()[0]
+    out = await search_tool("query")
+    assert "A" in out
+
+
+def test_prompt_is_non_empty_string():
+    result = WebSearchToolSet.prompt()
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
## Summary

Adds a `WebSearchToolSet` prebuilt tool with `search`, `fetch`, and `search_and_fetch`, following the same swappable-backend `ToolSet` pattern as `KeyValueMemoryToolSet`/`ToDoToolSet`. Default backends are `TavilySearch` (search) and `HttpFetch` (httpx + trafilatura, fetch); `BraveSearch` is included as a second search backend, and both `SearchBackend`/`FetchBackend` are protocols so custom backends can be swapped in without touching the toolset.

Closes #1234.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . --no-fix && ruff format --check .`, scoped to files this PR touches under `packages/railtracks/src`; `docs/`, `examples/`, and `tests/` are excluded from ruff by project config)
- [x] Tests added/updated and pass locally (39 new tests; full suite: 2138 passed, 4 skipped)
- [x] Docs updated (new Web Search Tool page under Prebuilt Tools)
- [ ] Breaking changes include migration notes (n/a, no breaking changes)

## Notes

- New optional dependency group `websearch` (`httpx`, `trafilatura`) in `packages/railtracks/pyproject.toml`, added to `all`.
- Per the issue's own "Other things to scope" list: rate limiting, result caps beyond `top_k`, and domain allow/block lists are intentionally deferred to a follow-up. Consistent error handling (backend unavailable, fetch failures) is implemented, backend/network errors are caught and returned as descriptive strings rather than raised.
- A repo-wide `ruff check .` (without `--no-fix`) auto-fixes pre-existing style nits in unrelated files elsewhere in the repo, since this project sets `fix = true` by default. This PR's diff is intentionally scoped to the websearch feature only and does not include those unrelated fixes.
- Also added `examples/tutorials/web_research_agent.py`, a two-agent (Researcher/Summarizer) demo verified live against real Tavily/OpenAI APIs.