### PR TITLE
Add Flow.connect() for post-run context and message history access (#1192)

### DIFF
--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -35,7 +35,7 @@ Sometimes you may want generic context items to be available across all runs of 
 Nothing about your flow or its return type has to change, and the plain `invoke`/`ainvoke` path is unaffected.
 
 ### Message Histories
-`connection.message_histories` gives you every model conversation in the run, oldest first. This includes nested agents — an `LLMResponse` carries only its own history, so a flow that delegates to sub-agents cannot surface theirs through its return value.
+`connection.message_histories` gives you every model conversation in the run, oldest first. This includes nested agents: an `LLMResponse` carries only its own history, so a flow that delegates to sub-agents cannot surface theirs through its return value.
 
 ```python
 --8<-- "docs/scripts/flows_sessions.py:connection_message_histories"
@@ -59,7 +59,8 @@ A connection handles one invocation at a time and raises if you start a second w
 
 !!! note
     A connection can be invoked repeatedly. Its accessors always describe the **most recent** invocation.
-
+    
+<!-- 
 ### Reaching Further
 `connection.session` exposes the underlying `Session` for anything without a dedicated accessor.
 
@@ -69,4 +70,4 @@ connection.session.payload() # the JSON that save_state writes
 ```
 
 !!! warning
-    `Session.info` and `Session.payload()` expose the run's state representation, whose shape is not yet stable. Prefer an accessor on `FlowConnection` where one exists.
+    `Session.info` and `Session.payload()` expose the run's state representation, whose shape is not yet stable. Prefer an accessor on `FlowConnection` where one exists. -->

--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -24,3 +24,49 @@ Sometimes you may want generic context items to be available across all runs of 
 
 !!! warning
     The context dictionaries used by Flows are passed by value. If a specific run mutates its context dictionary, those changes will not affect the original context or be passed to other runs.
+
+## Inspecting a Run
+`invoke` and `ainvoke` return only the flow's result, so anything a run built up along the way is gone once it finishes. Use `flow.connect()` when you need more than the result. It returns a `FlowConnection`, which you invoke in place of the Flow.
+
+```python
+--8<-- "docs/scripts/flows_sessions.py:connecting"
+```
+
+Nothing about your flow or its return type has to change, and the plain `invoke`/`ainvoke` path is unaffected.
+
+### Message Histories
+`connection.message_histories` gives you every model conversation in the run, oldest first. This includes nested agents — an `LLMResponse` carries only its own history, so a flow that delegates to sub-agents cannot surface theirs through its return value.
+
+```python
+--8<-- "docs/scripts/flows_sessions.py:connection_message_histories"
+```
+
+Each entry is a `NodeMessageHistory` with `node_name`, `node_id`, `request_id` and `message_history`. Nodes that made no model calls are omitted.
+
+### Failed Runs
+The accessors stay readable after an invocation raises, which is often when you most want them.
+
+```python
+--8<-- "docs/scripts/flows_sessions.py:connection_failure"
+```
+
+### Concurrency
+A connection handles one invocation at a time and raises if you start a second while the first is in flight. Open a connection per concurrent run.
+
+```python
+--8<-- "docs/scripts/flows_sessions.py:connection_concurrent"
+```
+
+!!! note
+    A connection can be invoked repeatedly. Its accessors always describe the **most recent** invocation.
+
+### Reaching Further
+`connection.session` exposes the underlying `Session` for anything without a dedicated accessor.
+
+```python
+connection.session.info      # the run graph: nodes, requests, timing
+connection.session.payload() # the JSON that save_state writes
+```
+
+!!! warning
+    `Session.info` and `Session.payload()` expose the run's state representation, whose shape is not yet stable. Prefer an accessor on `FlowConnection` where one exists.

--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -35,13 +35,13 @@ Sometimes you may want generic context items to be available across all runs of 
 Nothing about your flow or its return type has to change, and the plain `invoke`/`ainvoke` path is unaffected.
 
 ### Message Histories
-`connection.message_histories` gives you every model conversation in the run, oldest first. This includes nested agents: an `LLMResponse` carries only its own history, so a flow that delegates to sub-agents cannot surface theirs through its return value.
+`connection.message_histories()` gives you every model conversation in the run, in the order the runs were recorded. This includes nested agents: an `LLMResponse` carries only its own history, so a flow that delegates to sub-agents cannot surface theirs through its return value.
 
 ```python
 --8<-- "docs/scripts/flows_sessions.py:connection_message_histories"
 ```
 
-Each entry is a `NodeMessageHistory` with `node_name`, `node_id`, `request_id` and `message_history`. Nodes that made no model calls are omitted.
+Each entry is a `NodeMessageHistory` with `node_name`, `node_id`, `request_id` and `message_history`. Nodes that made no model calls are omitted. Nodes called concurrently have no guaranteed order between them.
 
 ### Failed Runs
 The accessors stay readable after an invocation raises, which is often when you most want them.
@@ -59,7 +59,7 @@ A connection handles one invocation at a time and raises if you start a second w
 
 !!! note
     A connection can be invoked repeatedly. Its accessors always describe the **most recent** invocation.
-    
+
 <!-- 
 ### Reaching Further
 `connection.session` exposes the underlying `Session` for anything without a dedicated accessor.

--- a/docs/scripts/flows_sessions.py
+++ b/docs/scripts/flows_sessions.py
@@ -40,3 +40,53 @@ flow = rt.Flow(
 context_injected_flow = flow.update_context({"run_specific_key": "run_specific_value"})
 response = context_injected_flow.invoke("What is the value of shared_key and run_specific_key?")
 # --8<-- [end: injecting_context]
+
+
+# --8<-- [start: connecting]
+# .connect() gives you a FlowConnection, which you invoke in place of the Flow.
+connection = flow.connect()
+response = connection.invoke("What is the capital of France?")
+
+# The run's context is still readable afterwards.
+print(connection.context.get("shared_key"))
+# --8<-- [end: connecting]
+
+
+# --8<-- [start: connection_message_histories]
+connection = flow.connect()
+response = connection.invoke("What is the capital of France?")
+
+for history in connection.message_histories:
+    print(history.node_name)
+    for message in history.message_history:
+        print(f"  {message.role}: {message.content}")
+# --8<-- [end: connection_message_histories]
+
+
+# --8<-- [start: connection_failure]
+connection = flow.connect()
+
+try:
+    connection.invoke("What is the capital of France?")
+except Exception:
+    # The context is readable even though the run raised.
+    print("failed at stage:", connection.context.get("stage", default="unknown"))
+# --8<-- [end: connection_failure]
+
+
+# --8<-- [start: connection_concurrent]
+import asyncio  # noqa: E402
+
+questions = ["Capital of France?", "Capital of Japan?", "Capital of Peru?"]
+
+
+async def ask_all():
+    # One connection per concurrent run.
+    connections = [flow.connect() for _ in questions]
+    await asyncio.gather(*(c.ainvoke(q) for c, q in zip(connections, questions)))
+    return connections
+
+
+for connection in asyncio.run(ask_all()):
+    print(connection.session_id, connection.context.get("shared_key"))
+# --8<-- [end: connection_concurrent]

--- a/docs/scripts/flows_sessions.py
+++ b/docs/scripts/flows_sessions.py
@@ -56,7 +56,7 @@ print(connection.context.get("shared_key"))
 connection = flow.connect()
 response = connection.invoke("What is the capital of France?")
 
-for history in connection.message_histories:
+for history in connection.message_histories():
     print(history.node_name)
     for message in history.message_history:
         print(f"  {message.role}: {message.content}")
@@ -77,16 +77,17 @@ except Exception:
 # --8<-- [start: connection_concurrent]
 import asyncio
 
-questions = ["Capital of France?", "Capital of Japan?", "Capital of Peru?"]
+connections = []
+futures = []
 
+# One connection per concurrent run.
+for question in ["Capital of France?", "Capital of Japan?", "Capital of Peru?"]:
+    connection = flow.connect()
+    connections.append(connection)
+    futures.append(connection.ainvoke(question))
 
-async def ask_all():
-    # One connection per concurrent run.
-    connections = [flow.connect() for _ in questions]
-    await asyncio.gather(*(c.ainvoke(q) for c, q in zip(connections, questions)))
-    return connections
+results = await asyncio.gather(*futures)
 
-
-for connection in asyncio.run(ask_all()):
+for connection in connections:
     print(connection.session_id, connection.context.get("shared_key"))
 # --8<-- [end: connection_concurrent]

--- a/docs/scripts/flows_sessions.py
+++ b/docs/scripts/flows_sessions.py
@@ -75,7 +75,7 @@ except Exception:
 
 
 # --8<-- [start: connection_concurrent]
-import asyncio  # noqa: E402
+import asyncio
 
 questions = ["Capital of France?", "Capital of Japan?", "Capital of Peru?"]
 

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -40,6 +40,8 @@ __all__ = [
     "vector_stores",
     "rag",
     "Flow",
+    "FlowConnection",
+    "NodeMessageHistory",
     "enable_logging",
     "wrap_node",
     "after_node",
@@ -75,6 +77,7 @@ from .guardrails import input_guard, output_guard
 from .interaction import astream, broadcast, call, call_batch, couple
 from .middleware import after_node, wrap_node
 from .nodes.manifest import ToolManifest
+from .orchestration.connection import FlowConnection, NodeMessageHistory
 from .orchestration.flow import Flow
 from .rt_mcp import MCPHttpParams, MCPStdioParams, connect_mcp, create_mcp_server
 from .utils.config import ExecutorConfig

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -265,6 +265,11 @@ class Session:
         # by deleting all of the state variables we are ensuring that the next time we create a runner it is fresh
 
     @property
+    def identifier(self) -> str:
+        """The unique identifier assigned to this session."""
+        return self._identifier
+
+    @property
     def info(self) -> ExecutionInfo:
         """
         Returns the current state of the runner.

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -119,7 +119,8 @@ class Session:
 
         self.coordinator.start(self.publisher)
         self._setup_subscriber()
-        register_globals(
+        # held so the context survives `delete_globals()` on close
+        self.context = register_globals(
             session_id=self._identifier,
             rt_publisher=self.publisher,
             parent_id=None,

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -196,9 +196,8 @@ def register_globals(
     Register the global variables for the current thread.
 
     Returns:
-        MutableExternalContext: the live context object backing this run. The caller
-            should hold onto it if the context needs to outlive `delete_globals()`,
-            which drops the ContextVar's only reference to it.
+        MutableExternalContext: the live context object backing this run, used if context needs to outlive 
+        session context (`delete_globals()`).
     """
     i_c = InternalContext(
         publisher=rt_publisher,

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -196,7 +196,7 @@ def register_globals(
     Register the global variables for the current thread.
 
     Returns:
-        MutableExternalContext: the live context object backing this run, used if context needs to outlive 
+        MutableExternalContext: the live context object backing this run, used if context needs to outlive
         session context (`delete_globals()`).
     """
     i_c = InternalContext(

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -191,9 +191,14 @@ def register_globals(
     parent_id: str | None,
     executor_config: ExecutorConfig,
     global_context_vars: dict[str, Any],
-):
+) -> MutableExternalContext:
     """
     Register the global variables for the current thread.
+
+    Returns:
+        MutableExternalContext: the live context object backing this run. The caller
+            should hold onto it if the context needs to outlive `delete_globals()`,
+            which drops the ContextVar's only reference to it.
     """
     i_c = InternalContext(
         publisher=rt_publisher,
@@ -209,6 +214,8 @@ def register_globals(
     )
 
     runner_context.set(runner_context_vars)
+
+    return e_c
 
 
 async def activate_publisher():

--- a/packages/railtracks/src/railtracks/orchestration/connection.py
+++ b/packages/railtracks/src/railtracks/orchestration/connection.py
@@ -1,0 +1,207 @@
+"""Two-stage flow invocation: `Flow.connect()` returns a `FlowConnection`."""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Generic, List, ParamSpec, TypeVar
+
+from railtracks._session import Session
+from railtracks.interaction._call import call
+
+if TYPE_CHECKING:
+    from railtracks.context.external import MutableExternalContext
+    from railtracks.llm.history import MessageHistory
+
+    from .flow import Flow
+
+_TOutput = TypeVar("_TOutput")
+_P = ParamSpec("_P")
+
+
+@dataclass(frozen=True)
+class NodeMessageHistory:
+    """
+    One node's conversation with its model.
+
+    Args:
+        node_name: Display name of the node that held the conversation, or
+            `"<unknown>"` if its type could not be resolved.
+        node_id: Identifier of that node within the run.
+        request_id: Identifier of the request that produced it.
+        message_history: The messages exchanged, system prompt first.
+    """
+
+    node_name: str
+    node_id: str
+    request_id: str
+    message_history: MessageHistory
+
+
+class FlowConnection(Generic[_P, _TOutput]):
+    """
+    A connection to a flow, through which it can be invoked and inspected.
+
+    Each invocation runs in its own session. The
+    accessors describe the most recent invocation and stay readable.
+
+    A connection runs one invocation at a time; use one per concurrent run.
+
+        conn = flow.connect()
+        result = await conn.ainvoke("text")
+        conn.context.get("progress")
+    """
+
+    def __init__(self, flow: Flow[_P, _TOutput]) -> None:
+        self._flow = flow
+        self._session: Session | None = None
+        self._in_flight = False
+
+    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        """
+        Runs the flow, leaving its context reachable on this connection.
+
+        Raises:
+            RuntimeError: If this connection is already running an invocation.
+        """
+        if self._in_flight:
+            raise RuntimeError(
+                "This connection is already running an invocation. A connection "
+                "handles one at a time -- use a separate `flow.connect()` per "
+                "concurrent run."
+            )
+
+        flow = self._flow
+        self._in_flight = True
+        try:
+            with Session(
+                context=deepcopy(flow._context),
+                flow_name=flow.name,
+                flow_id=flow.equality_hash(),
+                name=None,
+                timeout=flow._timeout,
+                end_on_error=flow._end_on_error,
+                broadcast_callback=flow._broadcast_callback,
+                prompt_injection=flow._prompt_injection,
+                save_state=flow._save_state,
+                payload_callback=flow._payload_callback,
+            ) as session:
+                # bound before the entry point runs, so the context of a failed
+                # invocation is still reachable afterwards
+                self._session = session
+                return await call(flow.entry_point, *args, **kwargs)
+        finally:
+            self._in_flight = False
+
+    def invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        """
+        Synchronous `ainvoke`.
+
+        Raises:
+            RuntimeError: If an event loop is already running in this thread, as
+                in a notebook or inside async code. Use `ainvoke` there.
+        """
+        coro = self.ainvoke(*args, **kwargs)
+        try:
+            return asyncio.run(coro)
+        except RuntimeError:
+            coro.close()
+            raise RuntimeError(
+                "Cannot invoke flow synchronously within an active event loop. Use 'ainvoke' instead."
+            )
+
+    @property
+    def connected(self) -> bool:
+        """Whether this connection has begun an invocation yet."""
+        return self._session is not None
+
+    def _require_session(self) -> Session:
+        if self._session is None:
+            raise RuntimeError(
+                "Nothing has run on this connection yet, so it has no context to read.\n"
+                "\n"
+                "A common cause is invoking the flow rather than the connection. The "
+                "flow opens its own connection each time, so its context lands there "
+                "instead of here:\n"
+                "\n"
+                "    conn = flow.connect()\n"
+                '    result = await flow.ainvoke("text")   # runs on a different connection\n'
+                "    conn.context                          # nothing ran here\n"
+                "\n"
+                "Invoke the connection itself:\n"
+                "\n"
+                "    conn = flow.connect()\n"
+                '    result = await conn.ainvoke("text")\n'
+                '    conn.context.get("progress")\n'
+            )
+        return self._session
+
+    @property
+    def context(self) -> MutableExternalContext:
+        """
+        The context of the most recent invocation.
+
+        A live reference, not a copy: while an invocation is in flight, this
+        reflects writes as nodes make them.
+
+        Context is not intended to be modified.
+        """
+        return self._require_session().context
+
+    @property
+    def session_id(self) -> str:
+        """Identifier of the session backing the most recent invocation."""
+        return self._require_session()._identifier
+
+    @property
+    def session(self) -> Session:
+        """
+        The session backing the most recent invocation, for inspection.
+
+        Already closed; the connection owns its lifecycle. `Session.payload()`
+        and `Session.info` expose the run's state representation.
+        """
+        return self._require_session()
+
+    @property
+    def message_histories(self) -> List[NodeMessageHistory]:
+        """
+        Every model conversation from the most recent invocation, oldest first.
+
+        Covers nested agents, unlike an `LLMResponse`, which carries only its
+        own. Nodes that made no model calls are omitted.
+
+            for h in conn.message_histories:
+                print(h.node_name, len(h.message_history))
+        """
+        info = self._require_session().info
+        node_forest = info.node_forest
+
+        histories: List[NodeMessageHistory] = []
+        for request in info.request_forest.heap().values():
+            history = getattr(request.output, "message_history", None)
+            if history is None:
+                continue
+            node_type = node_forest.get_node_type(request.sink_id)
+            histories.append(
+                NodeMessageHistory(
+                    node_name=node_type.name()
+                    if node_type is not None
+                    else "<unknown>",
+                    node_id=request.sink_id,
+                    request_id=request.identifier,
+                    message_history=history,
+                )
+            )
+
+        # heap ordering is insertion-based; step ordering is the run's own
+        histories.sort(key=lambda h: info.request_forest[h.request_id].stamp.step)
+        return histories
+
+    def __repr__(self) -> str:
+        if self._session is None:
+            return f"FlowConnection(flow={self._flow.name!r}, not yet invoked)"
+        return (
+            f"FlowConnection(flow={self._flow.name!r}, session_id={self.session_id!r})"
+        )

--- a/packages/railtracks/src/railtracks/orchestration/connection.py
+++ b/packages/railtracks/src/railtracks/orchestration/connection.py
@@ -127,7 +127,7 @@ class FlowConnection(Generic[_P, _TOutput]):
         The context of the most recent invocation.
 
         A live reference, not a copy. Context is not intended to be modified.
-        
+
         """
         return self._require_session().context
 
@@ -149,7 +149,8 @@ class FlowConnection(Generic[_P, _TOutput]):
     @property
     def message_histories(self) -> List[NodeMessageHistory]:
         """
-        Every model conversation from the most recent invocation, oldest first.
+        Every model conversation from the most recent invocation, in the order the
+        runs were recorded. Concurrently called nodes have no guaranteed order.
 
         Covers nested agents, unlike an `LLMResponse`, which carries only its
         own. Nodes that made no model calls are omitted.
@@ -161,6 +162,7 @@ class FlowConnection(Generic[_P, _TOutput]):
         node_forest = info.node_forest
 
         histories: List[NodeMessageHistory] = []
+        # a request is inserted into the heap when it is opened
         for request in info.request_forest.heap().values():
             history = getattr(request.output, "message_history", None)
             if history is None:
@@ -177,8 +179,6 @@ class FlowConnection(Generic[_P, _TOutput]):
                 )
             )
 
-        # heap ordering is insertion-based; step ordering is the run's own
-        histories.sort(key=lambda h: info.request_forest[h.request_id].stamp.step)
         return histories
 
     def __repr__(self) -> str:

--- a/packages/railtracks/src/railtracks/orchestration/connection.py
+++ b/packages/railtracks/src/railtracks/orchestration/connection.py
@@ -26,8 +26,8 @@ class NodeMessageHistory:
     One node's conversation with its model.
 
     Args:
-        node_name: Display name of the node that held the conversation, or
-            `"<unknown>"` if its type could not be resolved.
+        node_name: Node that held the conversation, or
+            `"<unknown>"` if cannot resolve type.
         node_id: Identifier of that node within the run.
         request_id: Identifier of the request that produced it.
         message_history: The messages exchanged, system prompt first.
@@ -41,16 +41,9 @@ class NodeMessageHistory:
 
 class FlowConnection(Generic[_P, _TOutput]):
     """
-    A connection to a flow, through which it can be invoked and inspected.
+    A connection to a flow, through which it can be invoked.
 
-    Each invocation runs in its own session. The
-    accessors describe the most recent invocation and stay readable.
-
-    A connection runs one invocation at a time; use one per concurrent run.
-
-        conn = flow.connect()
-        result = await conn.ainvoke("text")
-        conn.context.get("progress")
+    Same invoke and behaviour as `Flow` object.
     """
 
     def __init__(self, flow: Flow[_P, _TOutput]) -> None:
@@ -68,8 +61,7 @@ class FlowConnection(Generic[_P, _TOutput]):
         if self._in_flight:
             raise RuntimeError(
                 "This connection is already running an invocation. A connection "
-                "handles one at a time -- use a separate `flow.connect()` per "
-                "concurrent run."
+                "handles one at a time\n use a separate `flow.connect()`"
             )
 
         flow = self._flow
@@ -121,18 +113,10 @@ class FlowConnection(Generic[_P, _TOutput]):
             raise RuntimeError(
                 "Nothing has run on this connection yet, so it has no context to read.\n"
                 "\n"
-                "A common cause is invoking the flow rather than the connection. The "
-                "flow opens its own connection each time, so its context lands there "
-                "instead of here:\n"
+                "Ensure FlowConnection is invoked instead of base Flow instance:\n"
                 "\n"
                 "    conn = flow.connect()\n"
-                '    result = await flow.ainvoke("text")   # runs on a different connection\n'
-                "    conn.context                          # nothing ran here\n"
-                "\n"
-                "Invoke the connection itself:\n"
-                "\n"
-                "    conn = flow.connect()\n"
-                '    result = await conn.ainvoke("text")\n'
+                '    result = await conn.ainvoke("text") # NOT flow.ainvoke if context is desired\n'
                 '    conn.context.get("progress")\n'
             )
         return self._session
@@ -142,10 +126,8 @@ class FlowConnection(Generic[_P, _TOutput]):
         """
         The context of the most recent invocation.
 
-        A live reference, not a copy: while an invocation is in flight, this
-        reflects writes as nodes make them.
-
-        Context is not intended to be modified.
+        A live reference, not a copy. Context is not intended to be modified.
+        
         """
         return self._require_session().context
 

--- a/packages/railtracks/src/railtracks/orchestration/connection.py
+++ b/packages/railtracks/src/railtracks/orchestration/connection.py
@@ -134,7 +134,7 @@ class FlowConnection(Generic[_P, _TOutput]):
     @property
     def session_id(self) -> str:
         """Identifier of the session backing the most recent invocation."""
-        return self._require_session()._identifier
+        return self._require_session().identifier
 
     @property
     def session(self) -> Session:
@@ -146,7 +146,6 @@ class FlowConnection(Generic[_P, _TOutput]):
         """
         return self._require_session()
 
-    @property
     def message_histories(self) -> List[NodeMessageHistory]:
         """
         Every model conversation from the most recent invocation, in the order the
@@ -155,8 +154,14 @@ class FlowConnection(Generic[_P, _TOutput]):
         Covers nested agents, unlike an `LLMResponse`, which carries only its
         own. Nodes that made no model calls are omitted.
 
-            for h in conn.message_histories:
+        Walks the run's requests on every call rather than caching, so hold the
+        result if you need it more than once.
+
+            for h in conn.message_histories():
                 print(h.node_name, len(h.message_history))
+
+        Returns:
+            List[NodeMessageHistory]: One entry per node that called a model.
         """
         info = self._require_session().info
         node_forest = info.node_forest

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -80,7 +80,7 @@ class Flow(Generic[_P, _TOutput]):
 
             conn = flow.connect()
             result = await conn.ainvoke("text") # not flow.ainvoke if context is desired
-           
+
         Returns:
             FlowConnection: A connection to current flow.
         """

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -76,12 +76,13 @@ class Flow(Generic[_P, _TOutput]):
         Opens a connection to this flow.
 
         A `FlowConnection` invokes the flow exactly as `invoke`/`ainvoke` do, and
-        additionally keeps the run's context and message histories reachable once
-        it finishes.
+        additionally keeps the run's context reachable.
 
             conn = flow.connect()
-            result = await conn.ainvoke("text")
-            conn.context.get("progress")
+            result = await conn.ainvoke("text") # not flow.ainvoke if context is desired
+           
+        Returns:
+            FlowConnection: A connection to current flow.
         """
         return FlowConnection(self)
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 from copy import deepcopy
 from typing import Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
 
-from railtracks._session import Session
 from railtracks.built_nodes.function.base import RTFunction
-from railtracks.interaction._call import call
 
 from ..nodes.nodes import Node
+from .connection import FlowConnection
 
 _TOutput = TypeVar("_TOutput")
 _P = ParamSpec("_P")
@@ -73,31 +71,25 @@ class Flow(Generic[_P, _TOutput]):
         new_obj._context.update(context)
         return new_obj
 
-    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
-        with Session(
-            context=deepcopy(self._context),
-            flow_name=self.name,
-            flow_id=self.equality_hash(),
-            name=None,
-            timeout=self._timeout,
-            end_on_error=self._end_on_error,
-            broadcast_callback=self._broadcast_callback,
-            prompt_injection=self._prompt_injection,
-            save_state=self._save_state,
-            payload_callback=self._payload_callback,
-        ):
-            result = await call(self.entry_point, *args, **kwargs)
+    def connect(self) -> FlowConnection[_P, _TOutput]:
+        """
+        Opens a connection to this flow.
 
-        return result
+        A `FlowConnection` invokes the flow exactly as `invoke`/`ainvoke` do, and
+        additionally keeps the run's context and message histories reachable once
+        it finishes.
+
+            conn = flow.connect()
+            result = await conn.ainvoke("text")
+            conn.context.get("progress")
+        """
+        return FlowConnection(self)
+
+    async def ainvoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
+        return await self.connect().ainvoke(*args, **kwargs)
 
     def invoke(self, *args: _P.args, **kwargs: _P.kwargs) -> _TOutput:
-        try:
-            return asyncio.run(self.ainvoke(*args, **kwargs))
-
-        except RuntimeError:
-            raise RuntimeError(
-                "Cannot invoke flow synchronously within an active event loop. Use 'ainvoke' instead."
-            )
+        return self.connect().invoke(*args, **kwargs)
 
     def equality_hash(self) -> str:
         """

--- a/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
+++ b/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
@@ -1,0 +1,249 @@
+import asyncio
+
+import pytest
+import railtracks as rt
+from railtracks.orchestration.connection import FlowConnection, NodeMessageHistory
+
+
+@rt.function_node
+async def writes_context(text: str) -> str:
+    rt.context.put("stage", "running")
+    await asyncio.sleep(0)
+    rt.context.put("stage", "done")
+    rt.context.put("seen", text)
+    return f"processed:{text}"
+
+
+@rt.function_node
+async def fails_midway(text: str) -> str:
+    rt.context.put("stage", "about to fail")
+    await asyncio.sleep(0)
+    raise ValueError("node blew up")
+
+
+# Module level rather than in the flow context, which is deepcopied per run.
+_gate: asyncio.Event
+
+
+@rt.function_node
+async def waits_on_gate(text: str) -> str:
+    rt.context.put("stage", "running")
+    await _gate.wait()
+    rt.context.put("stage", "done")
+    return f"processed:{text}"
+
+
+@pytest.fixture
+def flow():
+    return rt.Flow(
+        name="conn_test",
+        entry_point=writes_context,
+        context={"stage": "not started"},
+        save_state=False,
+    )
+
+
+@pytest.fixture
+def failing_flow():
+    return rt.Flow(
+        name="conn_fail",
+        entry_point=fails_midway,
+        context={"stage": "not started"},
+        save_state=False,
+    )
+
+
+def nested_flow(mock_llm):
+    """A function node delegating to two agents, so histories nest."""
+    researcher = rt.agent_node(
+        name="Researcher",
+        system_message="You research.",
+        llm=mock_llm(custom_response="facts"),
+    )
+    writer = rt.agent_node(
+        name="Writer",
+        system_message="You write.",
+        llm=mock_llm(custom_response="summary"),
+    )
+
+    @rt.function_node
+    async def pipeline(topic: str) -> str:
+        facts = await rt.call(researcher, topic)
+        summary = await rt.call(writer, facts.text)
+        return summary.text
+
+    return rt.Flow(name="nested", entry_point=pipeline, save_state=False)
+
+
+class TestConnect:
+    def test_returns_a_connection(self, flow):
+        assert isinstance(flow.connect(), FlowConnection)
+
+    def test_each_call_is_a_new_connection(self, flow):
+        assert flow.connect() is not flow.connect()
+
+    async def test_result_matches_plain_ainvoke(self, flow):
+        assert await flow.connect().ainvoke("x") == await flow.ainvoke("x")
+
+    def test_result_matches_plain_invoke(self, flow):
+        assert flow.connect().invoke("x") == flow.invoke("x")
+
+    async def test_plain_ainvoke_return_value_is_untouched(self, flow):
+        result = await flow.ainvoke("x")
+        assert result == "processed:x"
+        assert not hasattr(result, "run_info")
+
+
+class TestContext:
+    async def test_readable_after_the_run(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("hello")
+        assert conn.context.get("stage") == "done"
+        assert conn.context.get("seen") == "hello"
+
+    async def test_is_live_while_in_flight(self):
+        global _gate
+        _gate = asyncio.Event()
+
+        flow = rt.Flow(
+            name="conn_gated",
+            entry_point=waits_on_gate,
+            context={"stage": "not started"},
+            save_state=False,
+        )
+        conn = flow.connect()
+        task = asyncio.create_task(conn.ainvoke("hello"))
+
+        async def reached_running():
+            while not (conn.connected and conn.context.get("stage") == "running"):
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(reached_running(), timeout=5)
+        assert conn.context.get("stage") == "running"
+
+        _gate.set()
+        await task
+        assert conn.context.get("stage") == "done"
+
+    async def test_readable_after_a_failure(self, failing_flow):
+        conn = failing_flow.connect()
+        with pytest.raises(ValueError):
+            await conn.ainvoke("boom")
+        assert conn.context.get("stage") == "about to fail"
+
+    async def test_reflects_the_most_recent_invocation(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("first")
+        first_session = conn.session_id
+        await conn.ainvoke("second")
+
+        assert conn.context.get("seen") == "second"
+        assert conn.session_id != first_session
+
+    async def test_connections_are_isolated(self, flow):
+        conns = [flow.connect() for _ in range(3)]
+        await asyncio.gather(*(c.ainvoke(f"job-{i}") for i, c in enumerate(conns)))
+
+        assert [c.context.get("seen") for c in conns] == ["job-0", "job-1", "job-2"]
+        assert len({c.session_id for c in conns}) == 3
+
+
+class TestBeforeAnythingRuns:
+    def test_connected_is_false(self, flow):
+        assert flow.connect().connected is False
+
+    @pytest.mark.parametrize(
+        "accessor",
+        ["context", "session", "session_id", "message_histories"],
+    )
+    def test_accessors_raise(self, flow, accessor):
+        with pytest.raises(RuntimeError, match="Nothing has run on this connection"):
+            getattr(flow.connect(), accessor)
+
+    async def test_connected_is_true_afterwards(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("x")
+        assert conn.connected is True
+
+
+class TestOneInvocationAtATime:
+    async def test_concurrent_reuse_raises(self, flow):
+        conn = flow.connect()
+        task = asyncio.create_task(conn.ainvoke("a"))
+        await asyncio.sleep(0)
+
+        with pytest.raises(RuntimeError, match="already running an invocation"):
+            await conn.ainvoke("b")
+
+        await task
+
+    async def test_sequential_reuse_is_allowed(self, flow):
+        conn = flow.connect()
+        assert await conn.ainvoke("a") == "processed:a"
+        assert await conn.ainvoke("b") == "processed:b"
+
+    async def test_released_after_a_failure(self, failing_flow):
+        conn = failing_flow.connect()
+        with pytest.raises(ValueError):
+            await conn.ainvoke("boom")
+
+        # the guard must not latch on the way out
+        with pytest.raises(ValueError):
+            await conn.ainvoke("boom")
+
+
+class TestMessageHistories:
+    async def test_empty_when_no_model_was_called(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("x")
+        assert conn.message_histories == []
+
+    async def test_includes_nested_agents_in_order(self, mock_llm):
+        conn = nested_flow(mock_llm).connect()
+        await conn.ainvoke("topic")
+
+        histories = conn.message_histories
+        assert [h.node_name for h in histories] == ["Researcher", "Writer"]
+        assert all(isinstance(h, NodeMessageHistory) for h in histories)
+
+    async def test_carries_the_conversation(self, mock_llm):
+        conn = nested_flow(mock_llm).connect()
+        await conn.ainvoke("topic")
+
+        researcher = conn.message_histories[0]
+        roles = [str(m.role) for m in researcher.message_history]
+        contents = [str(m.content) for m in researcher.message_history]
+
+        assert roles == ["Role.system", "Role.user", "Role.assistant"]
+        assert contents == ["You research.", "topic", "facts"]
+
+    async def test_identifies_the_node(self, mock_llm):
+        conn = nested_flow(mock_llm).connect()
+        await conn.ainvoke("topic")
+
+        for history in conn.message_histories:
+            assert history.node_id
+            assert history.request_id
+            assert history.node_id != history.request_id
+
+
+class TestSession:
+    async def test_exposes_the_backing_session(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("x")
+        assert conn.session.payload()["session_id"] == conn.session_id
+
+    async def test_reachable_after_the_run_closes(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("x")
+        assert conn.session.info.answer is not None
+
+
+class TestRepr:
+    def test_before_invocation(self, flow):
+        assert "not yet invoked" in repr(flow.connect())
+
+    async def test_after_invocation(self, flow):
+        conn = flow.connect()
+        await conn.ainvoke("x")
+        assert conn.session_id in repr(conn)

--- a/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
+++ b/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
@@ -155,11 +155,15 @@ class TestBeforeAnythingRuns:
 
     @pytest.mark.parametrize(
         "accessor",
-        ["context", "session", "session_id", "message_histories"],
+        ["context", "session", "session_id"],
     )
     def test_accessors_raise(self, flow, accessor):
         with pytest.raises(RuntimeError, match="Nothing has run on this connection"):
             getattr(flow.connect(), accessor)
+
+    def test_message_histories_raises(self, flow):
+        with pytest.raises(RuntimeError, match="Nothing has run on this connection"):
+            flow.connect().message_histories()
 
     async def test_connected_is_true_afterwards(self, flow):
         conn = flow.connect()
@@ -197,13 +201,13 @@ class TestMessageHistories:
     async def test_empty_when_no_model_was_called(self, flow):
         conn = flow.connect()
         await conn.ainvoke("x")
-        assert conn.message_histories == []
+        assert conn.message_histories() == []
 
     async def test_includes_nested_agents_in_order(self, mock_llm):
         conn = nested_flow(mock_llm).connect()
         await conn.ainvoke("topic")
 
-        histories = conn.message_histories
+        histories = conn.message_histories()
         assert [h.node_name for h in histories] == ["Researcher", "Writer"]
         assert all(isinstance(h, NodeMessageHistory) for h in histories)
 
@@ -211,7 +215,7 @@ class TestMessageHistories:
         conn = nested_flow(mock_llm).connect()
         await conn.ainvoke("topic")
 
-        researcher = conn.message_histories[0]
+        researcher = conn.message_histories()[0]
         roles = [str(m.role) for m in researcher.message_history]
         contents = [str(m.content) for m in researcher.message_history]
 
@@ -222,7 +226,7 @@ class TestMessageHistories:
         conn = nested_flow(mock_llm).connect()
         await conn.ainvoke("topic")
 
-        for history in conn.message_histories:
+        for history in conn.message_histories():
             assert history.node_id
             assert history.request_id
             assert history.node_id != history.request_id
@@ -265,7 +269,7 @@ class TestMessageHistories:
         ).connect()
         await conn.ainvoke("topic")
 
-        names = [h.node_name for h in conn.message_histories]
+        names = [h.node_name for h in conn.message_histories()]
         assert sorted(names) == ["A", "B", "C"]
         assert names != ["C", "B", "A"]
 

--- a/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
+++ b/packages/railtracks/tests/integration_tests/orchestration/test_flow_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 import railtracks as rt
@@ -225,6 +226,48 @@ class TestMessageHistories:
             assert history.node_id
             assert history.request_id
             assert history.node_id != history.request_id
+
+    async def test_not_ordered_by_completion(self, mock_llm):
+        """
+        Agents called A, B, C whose models finish C, B, A must not come back C, B, A.
+
+        `asyncio.gather` does not promise scheduling order, so the exact sequence
+        is not contractual -- but it must not be completion order, which would
+        reverse the common fan-out.
+        """
+
+        class SlowLLM(mock_llm):
+            def __init__(self, delay: float, **kwargs):
+                super().__init__(**kwargs)
+                self.delay = delay
+
+            def _chat(self, messages, **kwargs):
+                # model.chat runs via asyncio.to_thread, so this really overlaps
+                time.sleep(self.delay)
+                return self._base_chat()
+
+        agents = [
+            rt.agent_node(
+                name=name,
+                system_message="s",
+                llm=SlowLLM(delay, custom_response=name),
+            )
+            for name, delay in [("A", 0.30), ("B", 0.15), ("C", 0.01)]
+        ]
+
+        @rt.function_node
+        async def fan_out(topic: str) -> str:
+            await asyncio.gather(*(rt.call(a, topic) for a in agents))
+            return "done"
+
+        conn = rt.Flow(
+            name="conn_fan_out", entry_point=fan_out, save_state=False
+        ).connect()
+        await conn.ainvoke("topic")
+
+        names = [h.node_name for h in conn.message_histories]
+        assert sorted(names) == ["A", "B", "C"]
+        assert names != ["C", "B", "A"]
 
 
 class TestSession:


### PR DESCRIPTION
Closes #1192.

`invoke`/`ainvoke` return only the flow's result, so a run's context — and the conversations its agents held — are unreachable once it finishes.

`flow.connect()` returns a `FlowConnection`, which you invoke in place of the Flow:

```python
conn = flow.connect()
result = await conn.ainvoke("text")

conn.context.get("progress")
```

## Surface

| accessor | |
|---|---|
| `.context` | the run's context; a live reference, readable mid-flight |
| `.message_histories()` | every model conversation, oldest first |
| `.session` | the backing `Session`, for anything without a dedicated accessor |
| `.session_id` | |
| `.connected` | whether anything has run yet |

`.message_histories()` covers **nested agents**, which the return value cannot: an `LLMResponse` carries only its own history, so a flow delegating to sub-agents has no way to surface theirs. Each entry is a `NodeMessageHistory` with `node_name`, `node_id`, `request_id` and `message_history`; nodes that made no model calls are omitted.

Accessors stay readable after an invocation raises, which is often when you most want them.

## Notes

- **Nothing else changes.** The plain `invoke`/`ainvoke` path behaves exactly as before and return values are untouched — no attribute is attached to `LLMResponse`, and custom return types work without modification. Both now delegate to a connection, so session setup lives in one place and `flow.py` gets shorter.
- **One invocation at a time.** A connection raises if you start a second while the first is in flight; open one per concurrent run. Sequential reuse is fine — accessors then describe the most recent invocation.
- **State is out of scope.** `session.payload()` and `session.info` are reachable through `.session`, but are deliberately not `FlowConnection` accessors, since that schema is expected to change.

## Testing

27 new tests in `test_flow_connection.py`. Everything else in the suite is unaffected — the failures on this branch (guardrails, middleware, `test_state.py`, MCP, live-LLM) are all present at baseline.

## Docs

New *Inspecting a Run* section in `documentation/invocation/flows.md`, with snippets in `docs/scripts/flows_sessions.py`.
