### PR TITLE
some safety checks for scope_id since it needs to support file names

### DIFF
--- a/packages/railtracks/src/railtracks/observability/writers/jsonl.py
+++ b/packages/railtracks/src/railtracks/observability/writers/jsonl.py
@@ -17,12 +17,13 @@ class JsonlWriter:
         self._directory.mkdir(parents=True, exist_ok=True)
 
     async def write(self, event: Event) -> None:
-        handle = self._files.get(event.scope_type)
+        handle = self._files.get(event.scope_id)
         if handle is None:
-            handle = (self._directory / f"{event.scope_type}.jsonl").open(
+            _check_safe_scope_id(event.scope_id)
+            handle = (self._directory / f"{event.scope_id}.jsonl").open(
                 "a", encoding="utf-8"
             )
-            self._files[event.scope_type] = handle
+            self._files[event.scope_id] = handle
         handle.write(_serialize(event) + "\n")
         handle.flush()
 
@@ -37,3 +38,20 @@ def _serialize(event: Event) -> str:
     data = dataclasses.asdict(event)
     data["stamp"] = event.stamp.isoformat()
     return json.dumps(data)
+
+
+_UNSAFE_SCOPE_ID_CHARS = frozenset("/\\\0")
+
+
+def _check_safe_scope_id(scope_id: str) -> None:
+    if (
+        not scope_id
+        or scope_id in (".", "..")
+        or scope_id.startswith(".")
+        or any(c in _UNSAFE_SCOPE_ID_CHARS for c in scope_id)
+    ):
+        raise ValueError(
+            f"unsafe scope_id for filesystem writer: {scope_id!r}; "
+            "must be non-empty, must not start with '.', "
+            "and must not contain path separators or null bytes"
+        )

--- a/packages/railtracks/tests/unit_tests/observability/test_jsonl_writer.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_jsonl_writer.py
@@ -2,6 +2,8 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import pytest
+
 from railtracks.observability import (
     SCOPE_RETRIEVAL,
     SCOPE_SESSION,
@@ -37,29 +39,29 @@ async def test_start_creates_directory(tmp_path: Path):
         await writer.shutdown()
 
 
-async def test_write_creates_per_scope_files(tmp_path: Path):
+async def test_write_creates_per_scope_id_files(tmp_path: Path):
     writer = JsonlWriter(tmp_path)
     await writer.start()
     try:
-        await writer.write(_make_session_event(SCOPE_SESSION))
-        await writer.write(_make_session_event(SCOPE_RETRIEVAL))
+        await writer.write(_make_session_event(SCOPE_SESSION, scope_id="sess-1"))
+        await writer.write(_make_session_event(SCOPE_RETRIEVAL, scope_id="ret-1"))
     finally:
         await writer.shutdown()
 
-    assert (tmp_path / "session.jsonl").exists()
-    assert (tmp_path / "retrieval.jsonl").exists()
+    assert (tmp_path / "sess-1.jsonl").exists()
+    assert (tmp_path / "ret-1.jsonl").exists()
 
 
 async def test_one_line_per_event(tmp_path: Path):
     writer = JsonlWriter(tmp_path)
     await writer.start()
     try:
-        for i in range(5):
-            await writer.write(_make_session_event(SCOPE_SESSION, scope_id=f"s{i}"))
+        for _ in range(5):
+            await writer.write(_make_session_event(SCOPE_SESSION, scope_id="s1"))
     finally:
         await writer.shutdown()
 
-    lines = (tmp_path / "session.jsonl").read_text().splitlines()
+    lines = (tmp_path / "s1.jsonl").read_text().splitlines()
     assert len(lines) == 5
 
 
@@ -76,7 +78,7 @@ async def test_each_line_round_trips_to_original_event(tmp_path: Path):
     finally:
         await writer.shutdown()
 
-    lines = (tmp_path / "session.jsonl").read_text().splitlines()
+    lines = (tmp_path / "id-1.jsonl").read_text().splitlines()
     assert len(lines) == 1
     assert _parse_line(lines[0]) == original
 
@@ -84,23 +86,27 @@ async def test_each_line_round_trips_to_original_event(tmp_path: Path):
 async def test_append_across_writer_lifecycles(tmp_path: Path):
     first = JsonlWriter(tmp_path)
     await first.start()
-    await first.write(_make_session_event(SCOPE_SESSION, scope_id="a"))
+    await first.write(
+        _make_session_event(SCOPE_SESSION, scope_id="s1", event_type="first")
+    )
     await first.shutdown()
 
     second = JsonlWriter(tmp_path)
     await second.start()
-    await second.write(_make_session_event(SCOPE_SESSION, scope_id="b"))
+    await second.write(
+        _make_session_event(SCOPE_SESSION, scope_id="s1", event_type="second")
+    )
     await second.shutdown()
 
-    lines = (tmp_path / "session.jsonl").read_text().splitlines()
-    assert [_parse_line(line).scope_id for line in lines] == ["a", "b"]
+    lines = (tmp_path / "s1.jsonl").read_text().splitlines()
+    assert [_parse_line(line).event_type for line in lines] == ["first", "second"]
 
 
 async def test_shutdown_closes_handles(tmp_path: Path):
     writer = JsonlWriter(tmp_path)
     await writer.start()
-    await writer.write(_make_session_event(SCOPE_SESSION))
-    handle = writer._files[SCOPE_SESSION]
+    await writer.write(_make_session_event(SCOPE_SESSION, scope_id="s1"))
+    handle = writer._files["s1"]
     await writer.shutdown()
     assert handle.closed
     assert writer._files == {}
@@ -110,8 +116,32 @@ async def test_flush_makes_bytes_readable_before_shutdown(tmp_path: Path):
     writer = JsonlWriter(tmp_path)
     await writer.start()
     try:
-        await writer.write(_make_session_event(SCOPE_SESSION))
-        lines = (tmp_path / "session.jsonl").read_text().splitlines()
+        await writer.write(_make_session_event(SCOPE_SESSION, scope_id="s1"))
+        lines = (tmp_path / "s1.jsonl").read_text().splitlines()
         assert len(lines) == 1
+    finally:
+        await writer.shutdown()
+
+
+@pytest.mark.parametrize(
+    "bad_scope_id",
+    [
+        "",
+        ".",
+        "..",
+        ".hidden",
+        "../escape",
+        "a/b",
+        "a\\b",
+        "with\x00null",
+    ],
+)
+async def test_write_rejects_unsafe_scope_id(tmp_path: Path, bad_scope_id: str):
+    writer = JsonlWriter(tmp_path)
+    await writer.start()
+    try:
+        with pytest.raises(ValueError, match="unsafe scope_id"):
+            await writer.write(_make_session_event(SCOPE_SESSION, scope_id=bad_scope_id))
+        assert list(tmp_path.iterdir()) == []
     finally:
         await writer.shutdown()


### PR DESCRIPTION
## Summary

Closes #1363 with a minor change to how the jsonl writer stores events

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests