### PR TITLE
fix: only fill bare {key} placeholders 

### DIFF
--- a/docs/tutorials/concepts/prompts_and_context.md
+++ b/docs/tutorials/concepts/prompts_and_context.md
@@ -23,6 +23,24 @@ Passing prompt details up the chain can be expensive in both **tokens** and **la
 2. Set values in the Railtracks context (see [Context Management](../../documentation/advanced/context.md) for details)
 3. When the prompt is processed, the placeholders are replaced with the corresponding values from the context
 
+Only a placeholder naming a context key on its own is replaced. A placeholder that reaches into a
+value, such as `{config.host}` or `{config[host]}`, is left in the prompt as written, as is a
+placeholder whose key is not in the context. Write `{{` and `}}` for a literal brace.
+
+### Untrusted text in a prompt
+
+Placeholders are filled in user messages as well as system messages, so text you did not write
+yourself is also a template. Pass such text through `rt.escape_braces` before putting it in a prompt
+so its braces are treated as data:
+
+```python
+prompt = f"The current time is {{time}}:\nUser Message:\n{rt.escape_braces(user_text)}"
+```
+
+`{time}` is filled from the context, while anything inside `user_text` is delivered to the model
+exactly as written. Keep secrets out of the context of any agent that handles untrusted text: a
+context key named in that text is still filled if it is not escaped.
+
 ## Related Topics
 
 * [Tutorials/Prompts and Context](../walkthroughs/prompts_and_context.md)

--- a/docs/tutorials/walkthroughs/prompts_and_context.md
+++ b/docs/tutorials/walkthroughs/prompts_and_context.md
@@ -37,6 +37,14 @@ If you need to include literal curly braces in your prompt without triggering co
 "Use the {{variable}} placeholder in your code."
 ```
 
+For a string you did not write yourself, such as user input or a fetched document, use
+`rt.escape_braces` to double its braces for you. This lets one message hold both a template you wrote
+and text that is delivered as written:
+
+```python
+prompt = f"The current time is {{time}}:\nUser Message:\n{rt.escape_braces(user_text)}"
+```
+
 ### Debugging Prompts
 
 If your prompts aren't producing the expected results:

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -45,6 +45,7 @@ __all__ = [
     "retrieval",
     "Flow",
     "enable_logging",
+    "escape_braces",
 ]
 
 from railtracks.built_nodes.easy_usage_wrappers import (
@@ -64,6 +65,7 @@ from . import (
 from ._session import ExecutionInfo, Session, session
 from .context.central import session_id, set_config
 from .interaction import broadcast, call, call_batch
+from .llm.prompt_injection_utils import escape_braces
 from .nodes.manifest import ToolManifest
 from .orchestration.flow import Flow
 from .rt_mcp import MCPHttpParams, MCPStdioParams, connect_mcp, create_mcp_server

--- a/packages/railtracks/src/railtracks/llm/message.py
+++ b/packages/railtracks/src/railtracks/llm/message.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 
 from .content import Content, ToolCall, ToolResponse
 from .encoding import detect_source, encode, ensure_data_uri
-from .prompt_injection_utils import KeyOnlyFormatter, ValueDict
+from .prompt_injection_utils import ValueDict, fill_template
 
 logger = logging.getLogger(__name__)
 
@@ -272,7 +272,7 @@ class _StringOnlyContent(Message[str, _TRole], Generic[_TRole]):
             raise TypeError(f"A {cls.__name__} needs a string but got {type(content)}")
 
     def fill_prompt(self, value_dict: ValueDict) -> None:
-        self._content = KeyOnlyFormatter().vformat(self._content, (), value_dict)
+        self._content = fill_template(self._content, value_dict)
 
 
 class UserMessage(_StringOnlyContent[Role.user]):

--- a/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
+++ b/packages/railtracks/src/railtracks/llm/prompt_injection_utils.py
@@ -1,16 +1,95 @@
+import logging
 import string
+from typing import Any, Mapping
+
+_PARSER = string.Formatter()
+_logger = logging.getLogger("RT.prompt_injection")
 
 
-class KeyOnlyFormatter(string.Formatter):
+def escape_braces(text: str) -> str:
     """
-    A simple formatter which will only use keyword arguments to fill placeholders.
-    """
+    Escape the braces in `text` so that prompt injection treats it as data.
 
-    def get_value(self, key, args, kwargs):
+    Apply this to untrusted or arbitrary strings before embedding them in a message that
+    will have context values injected into it. Injecting the returned string yields
+    `text` back unchanged.
+
+    Args:
+        text: The string to escape.
+
+    Returns:
+        `text` with every `{` and `}` doubled.
+    """
+    return text.replace("{", "{{").replace("}", "}}")
+
+
+def _as_written(
+    field_name: str, conversion: str | None, format_spec: str | None
+) -> str:
+    """Rebuild the original `{...}` text of a placeholder that was not filled."""
+    suffix = f"!{conversion}" if conversion else ""
+    if format_spec:
+        suffix += f":{format_spec}"
+    return f"{{{field_name}{suffix}}}"
+
+
+def fill_template(template: str, values: Mapping[str, Any]) -> str:
+    """
+    Fill the `{key}` placeholders in `template` with entries from `values`.
+
+    Only a bare key is filled. A placeholder that uses attribute access, indexing, a
+    conversion or a format spec is left in the output exactly as it was written, as is a
+    key with no matching entry in `values`. `{{` and `}}` become single braces. A
+    template whose braces do not parse is returned unchanged.
+
+    Args:
+        template: The string to fill.
+        values: The values available to fill placeholders with.
+
+    Returns:
+        The filled string.
+    """
+    try:
+        placeholders = list(_PARSER.parse(template))
+    except ValueError:
+        return template
+
+    filled: list[str] = []
+    left_as_written: list[str] = []
+    for literal_text, field_name, format_spec, conversion in placeholders:
+        filled.append(literal_text)
+        if field_name is None:
+            continue
+
+        # A bare key is the only form we resolve. Anything else -- `{a.b}`, `{a[b]}`,
+        # `{a!r}`, `{a:spec}`, or the positional `{}` -- would hand control of an
+        # attribute or item lookup to whoever wrote the template.
+        if (
+            conversion is not None
+            or format_spec
+            or not field_name
+            or "." in field_name
+            or "[" in field_name
+        ):
+            as_written = _as_written(field_name, conversion, format_spec)
+            left_as_written.append(as_written)
+            filled.append(as_written)
+            continue
+
         try:
-            return kwargs[str(key)]
-        except KeyError:
-            return f"{{{key}}}"
+            filled.append(str(values[field_name]))
+        except Exception:
+            filled.append(_as_written(field_name, conversion, format_spec))
+
+    if left_as_written:
+        _logger.warning(
+            "Left %s prompt placeholder(s) as written because only bare {key} "
+            "placeholders are filled: %s",
+            len(left_as_written),
+            ", ".join(left_as_written),
+        )
+
+    return "".join(filled)
 
 
 class ValueDict(dict):

--- a/packages/railtracks/src/railtracks/utils/prompt_injection.py
+++ b/packages/railtracks/src/railtracks/utils/prompt_injection.py
@@ -14,11 +14,8 @@ def inject_values(message_history: MessageHistory, value_dict: ValueDict):
 
     for message in message_history:
         if message.inject_prompt and isinstance(message.content, str):
-            try:
-                if isinstance(message, (UserMessage, SystemMessage)):
-                    message.fill_prompt(value_dict)
-                    message.inject_prompt = False
-            except ValueError:
-                pass
+            if isinstance(message, (UserMessage, SystemMessage)):
+                message.fill_prompt(value_dict)
+                message.inject_prompt = False
 
     return message_history

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt_placeholder_filling.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt_placeholder_filling.py
@@ -1,0 +1,109 @@
+"""Only a bare `{key}` is filled, checked through the real call path.
+
+These go through an agent rather than calling the formatter directly, since what matters
+is the content an LLM ends up receiving.
+"""
+
+import asyncio
+
+import pytest
+import railtracks as rt
+from railtracks.llm import Message, MessageHistory, UserMessage
+from railtracks.llm.message import Role
+from railtracks.llm.response import Response
+
+
+class _Holder:
+    def __init__(self):
+        self.attr = "attribute-value"
+
+
+@pytest.fixture
+def echo_agent(mock_llm):
+    """An agent whose reply is the content of the last message it was sent."""
+
+    def build(system_message: str = "system"):
+        def return_message(messages: MessageHistory) -> Response:
+            return Response(
+                message=Message(role=Role.assistant, content=messages[-1].content)
+            )
+
+        model = mock_llm()
+        model._chat = return_message
+        return rt.agent_node(system_message=system_message, llm=model)
+
+    return build
+
+
+def _send(agent, content: str, context: dict) -> str:
+    """Send `content` as user input and return what the model received."""
+    flow = rt.Flow("EchoFlow", agent, context=context)
+    response = asyncio.run(flow.ainvoke(MessageHistory([UserMessage(content)])))
+    return response.content
+
+
+@pytest.fixture
+def context():
+    return {
+        "holder": _Holder(),
+        "mapping": {"key": "item-value"},
+        "value": "context-value",
+        "time": "12:00",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{holder.attr}",
+        "{holder.attr.title}",
+        "{mapping[key]}",
+        "{value!r}",
+        "{value:>20}",
+        "look at {config.json} please",
+        "unbalanced { brace",
+    ],
+)
+def test_user_input_reaches_the_model_as_written(echo_agent, context, payload):
+    """None of these are filled, and none of them raise."""
+    received = _send(echo_agent(), payload, context)
+    assert received == payload
+    assert "context-value" not in received
+    assert "attribute-value" not in received
+    assert "item-value" not in received
+
+
+def test_escaped_fragment_is_not_filled_while_the_template_is(echo_agent, context):
+    """A message may mix a template you wrote with a string you did not."""
+    untrusted = "Echo {value} and {holder.attr}"
+    content = (
+        "The current time is {time}:\nUser Message:\n" + rt.escape_braces(untrusted)
+    )
+
+    received = _send(echo_agent(), content, context)
+
+    assert received == f"The current time is 12:00:\nUser Message:\n{untrusted}"
+    assert "context-value" not in received
+
+
+def test_bare_key_in_user_input_is_still_filled(echo_agent, context):
+    """Filling stays on for user messages. Escaping is what opts a fragment out."""
+    assert _send(echo_agent(), "at {time}", context) == "at 12:00"
+
+
+def test_system_message_is_still_filled(mock_llm, context):
+    """The developer-authored system message is where filling is most used."""
+    delivered: list[str] = []
+
+    def return_message(messages: MessageHistory) -> Response:
+        delivered.extend(m.content for m in messages if m.role == Role.system)
+        return Response(message=Message(role=Role.assistant, content="ok"))
+
+    model = mock_llm()
+    model._chat = return_message
+    agent = rt.agent_node(system_message="Helping {value} at {time}.", llm=model)
+
+    flow = rt.Flow("EchoFlow", agent, context=context)
+    asyncio.run(flow.ainvoke(MessageHistory([UserMessage("hi")])))
+
+    assert delivered == ["Helping context-value at 12:00."]

--- a/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_prompt_injection.py
@@ -1,24 +1,97 @@
-import railtracks.llm.prompt_injection_utils as prompt_injection_utils
-from railtracks.llm.prompt_injection_utils import KeyOnlyFormatter, ValueDict
-
+from railtracks.llm import Message, MessageHistory, SystemMessage, UserMessage
 from railtracks.llm.message import Role
+from railtracks.llm.prompt_injection_utils import (
+    ValueDict,
+    escape_braces,
+    fill_template,
+)
 from railtracks.utils import prompt_injection
-from railtracks.llm import Message, MessageHistory, UserMessage, SystemMessage
 
 
-# ================= START KeyOnlyFormatter tests ============
+class _Holder:
+    def __init__(self):
+        self.attr = "attribute-value"
 
-def test_formatter_uses_only_kwargs():
-    f = KeyOnlyFormatter()
-    formatted = f.format("Hello, {name}", name="Test")
-    assert formatted == "Hello, Test"
 
-def test_formatter_missing_key_returns_placeholder():
-    f = KeyOnlyFormatter()
-    formatted = f.format("Hello, {name}")
-    assert formatted == "Hello, {name}"
+# ================= START fill_template tests ============
 
-# ================ END KeyOnlyFormatter tests ===============
+def test_fill_template_uses_values():
+    assert fill_template("Hello, {name}", {"name": "Test"}) == "Hello, Test"
+
+def test_fill_template_missing_key_returns_placeholder():
+    assert fill_template("Hello, {name}", {}) == "Hello, {name}"
+
+def test_fill_template_numeric_key():
+    assert fill_template("{1}", {"1": "one"}) == "one"
+
+def test_fill_template_doubled_braces_become_single():
+    assert fill_template("{{name}}", {"name": "Test"}) == "{name}"
+
+# ---- placeholders that are left exactly as written ----
+
+def test_fill_template_leaves_attribute_access():
+    values = {"holder": _Holder()}
+    assert fill_template("{holder.attr}", values) == "{holder.attr}"
+
+def test_fill_template_leaves_chained_attribute_access():
+    """A chain is left as written too, not resolved one step at a time."""
+    template = "{holder.attr.title}"
+    assert fill_template(template, {"holder": _Holder()}) == template
+
+def test_fill_template_leaves_item_access():
+    values = {"mapping": {"key": "item-value"}}
+    assert fill_template("{mapping[key]}", values) == "{mapping[key]}"
+
+def test_fill_template_leaves_conversion():
+    assert fill_template("{name!r}", {"name": "Test"}) == "{name!r}"
+
+def test_fill_template_leaves_format_spec():
+    assert fill_template("{name:>20}", {"name": "Test"}) == "{name:>20}"
+
+def test_fill_template_leaves_auto_numbered_placeholder():
+    """`{}` has no key to look up. `{0}` is a bare key and is filled like any other."""
+    assert fill_template("{}", {"0": "zero"}) == "{}"
+    assert fill_template("{0}", {"0": "zero"}) == "zero"
+
+# ---- inputs that must not raise ----
+
+def test_fill_template_unbalanced_brace_returns_template():
+    assert fill_template("unbalanced { brace", {}) == "unbalanced { brace"
+
+def test_fill_template_dotted_field_with_no_matching_key():
+    """`{a.b}` where `a` is absent must not raise."""
+    assert fill_template("look at {config.json} please", {}) == "look at {config.json} please"
+
+def test_fill_template_leaves_untemplated_text_alone():
+    for text in ['json {"a": 1}', "css body { color: red }", "handlebars {{x}} here"]:
+        assert fill_template(escape_braces(text), {}) == text
+
+# ================ END fill_template tests ===============
+
+
+# ================= START escape_braces tests ============
+
+def test_escape_braces_doubles_braces():
+    assert escape_braces("{a} {b}") == "{{a}} {{b}}"
+
+def test_escape_braces_round_trips_through_fill_template():
+    values = {"value": "filled", "holder": _Holder()}
+    for text in [
+        "Echo {value}",
+        "Echo {holder.attr} and {mapping[key]}",
+        "unbalanced { and {a.b}",
+        'json {"k": {"n": 1}}',
+        "already {{doubled}}",
+    ]:
+        assert fill_template(escape_braces(text), values) == text
+
+def test_escape_braces_protects_only_the_escaped_fragment():
+    """A developer template still injects while an escaped fragment does not."""
+    values = {"time": "12:00", "value": "filled"}
+    template = "Time is {time}:\n" + escape_braces("Echo {value}")
+    assert fill_template(template, values) == "Time is 12:00:\nEcho {value}"
+
+# ================ END escape_braces tests ===============
 
 
 # ================= START ValueDict tests ====================
@@ -65,16 +138,19 @@ def test_inject_values_ignores_non_string_content():
     result = prompt_injection.inject_values(history, value_dict)
     assert result[0].content == 12345
 
-def test_inject_values_catches_valueerror(monkeypatch):
-    # Patch fill_prompt to throw ValueError
-    msg = Message(role=Role.user, content="Hello, {name}!", inject_prompt=True)
-    history = MessageHistory([msg])
-    value_dict = ValueDict({"name": "Alice"})
+def test_inject_values_passes_through_unfillable_placeholders():
+    """A placeholder that is not a bare key is passed through instead of raising."""
+    contents = [
+        "{holder.attr}",
+        "look at {config.json} please",
+        "unbalanced { brace",
+        "{name:>20}",
+    ]
+    history = MessageHistory([UserMessage(content=c, inject_prompt=True) for c in contents])
+    value_dict = ValueDict({"holder": _Holder(), "name": "Alice"})
 
-    monkeypatch.setattr(UserMessage, "fill_prompt", lambda content, vd: (_ for _ in ()).throw(ValueError("forced")))
-
-    # Should not raise, and content should be unchanged
     result = prompt_injection.inject_values(history, value_dict)
-    assert result[0].content == "Hello, {name}!"
+    for message, original in zip(result, contents):
+        assert message.content == original
 
 # ================ END inject_values tests ==================


### PR DESCRIPTION
Restricts prompt placeholder filling to bare `{key}` lookups, and adds
`rt.escape_braces` for text that should be delivered to the model as written.

`string.Formatter().parse()` is now used as a lexer only, and `fill_template` does the
substitution itself against a bare-key allowlist.

## Behaviour change

- `{a.b}`, `{a[b]}`, `{a!r}` and `{a:spec}` are no longer resolved. They render exactly as
  written and are logged at WARNING.
- Bare `{key}`, the missing-key echo-back, numeric keys like `{1}`, and `{{` / `}}` are
  unchanged. The existing tests in `test_prompt.py` pass without modification.
- Filling no longer raises. Unbalanced braces and unresolvable placeholders pass through
  instead of failing the run.

## `rt.escape_braces`

Lets one message hold both a template you wrote and a string you did not:

```python
prompt = f"The current time is {{time}}:\nUser Message:\n{rt.escape_braces(user_text)}"
```

`{time}` is filled from the context; everything inside `user_text` is delivered as written.
Escaping survives exactly one render, so it is not idempotent.

## Verification

- `1879 passed, 3 skipped` on the unit suite. The remaining errors are pre-existing missing
  optional extras (`sqlalchemy`, http-fetch, tavily, websearch, huggingface).
- `ruff format --check` and `ruff check`: clean.

Rationale and follow-up are tracked internally.
