### PR TITLE
Logan update middleware docs

### DIFF
--- a/docs/documentation/agent_design/llms/handling_failures.md
+++ b/docs/documentation/agent_design/llms/handling_failures.md
@@ -9,7 +9,7 @@ LLM failures fall into two categories, and the right handling differs between th
 2. **Fatal Failures**: Unexpected errors that retrying won't fix — unhandled exceptions, malformed responses, or hard API errors. These should fail fast and surface to the caller.
 
 ## Railtracks Tooling for Retries
-Pass a `RetryApproach` to your LLM and it handles retry logic automatically. The internal logic will handle the difference between errors where you should retry on vs. not. Here's an example using `ExponentialBackoffRetry`:
+Pass a `RetryApproach` to your LLM and it handles retry logic automatically. The internal logic will handle the difference between errors where you should retry on vs. not. Here's an example using jittered exponential backoff:
 
 ```python
 --8<-- "docs/scripts/documentation/retries.py:exponential_backoff"

--- a/docs/documentation/agent_design/middleware/custom.md
+++ b/docs/documentation/agent_design/middleware/custom.md
@@ -1,6 +1,6 @@
 # Custom Middleware
 
-The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object. Node-level decorators can be passed to `middleware=` on either `rt.agent_node` or `rt.function_node`. Model-level decorators can only be passed to `model_middleware=` on `rt.agent_node` — a `function_node` never calls a model, so it has no `model_middleware=` slot (the parameter doesn't exist on `function_node`, so passing one is a type/argument error, not a silent no-op).
+The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object. Node-level decorators can be passed to `middleware=` on either `rt.agent_node` or `rt.function_node`. Model-level decorators can only be passed to `model_middleware=` on `rt.agent_node`. A `function_node` never calls a model, so it has no `model_middleware=` slot (the parameter doesn't exist on `function_node`, so passing one is a type/argument error, not a silent no-op).
 
 | Decorator | Scope | Runs
 |---|---|---|
@@ -13,7 +13,7 @@ The middleware system is designed to support the custom creation of middleware t
 `wrap_node` and `wrap_llm` are the general-purpose forms. Every other decorator is a thin convenience built on top of one of them (`after_node` and `after_llm` only get to run the inner call once and act on its result; `before_llm` only gets to transform the inputs before the inner call runs). 
 
 !!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
-    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def` — a plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 ## Node middleware
 

--- a/docs/documentation/agent_design/middleware/custom.md
+++ b/docs/documentation/agent_design/middleware/custom.md
@@ -1,6 +1,6 @@
 # Custom Middleware
 
-The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object that can be passed to `middleware=` (node-level) or `model_middleware=` (model-level) on `rt.agent_node` / `rt.function_node`.
+The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object. Node-level decorators can be passed to `middleware=` on either `rt.agent_node` or `rt.function_node`. Model-level decorators can only be passed to `model_middleware=` on `rt.agent_node` — a `function_node` never calls a model, so it has no `model_middleware=` slot (the parameter doesn't exist on `function_node`, so passing one is a type/argument error, not a silent no-op).
 
 | Decorator | Scope | Runs
 |---|---|---|
@@ -12,6 +12,8 @@ The middleware system is designed to support the custom creation of middleware t
 
 `wrap_node` and `wrap_llm` are the general-purpose forms. Every other decorator is a thin convenience built on top of one of them (`after_node` and `after_llm` only get to run the inner call once and act on its result; `before_llm` only gets to transform the inputs before the inner call runs). 
 
+!!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def` — a plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 ## Node middleware
 
@@ -21,6 +23,12 @@ The middleware system is designed to support the custom creation of middleware t
 
 ```python
 --8<-- "docs/scripts/middleware.py:after_node_demo"
+```
+
+The same middleware attaches to a `function_node` exactly the same way, via `middleware=`:
+
+```python
+--8<-- "docs/scripts/middleware.py:function_node_demo"
 ```
 
 ## Model middleware

--- a/docs/documentation/agent_design/middleware/guardrails/overview.md
+++ b/docs/documentation/agent_design/middleware/guardrails/overview.md
@@ -74,7 +74,7 @@ For a reusable, configurable rail, subclass `InputGuard` or `OutputGuard` and im
 ```
 
 !!! tip "Testing a guard in isolation"
-    Both bases provide `decide(value)`, which builds the event for you from a `str`, `Message`, or `MessageHistory` and returns the `GuardrailDecision` — handy for unit tests without running a model.
+    Both bases provide `decide(value)`, which builds the event for you from a `str`, `Message`, or `MessageHistory` and returns the `GuardrailDecision`, handy for unit tests without running a model.
 
 To publish a guard for others to reuse, see [Contributing a Guardrail](contributions.md).
 

--- a/docs/documentation/agent_design/middleware/overview.md
+++ b/docs/documentation/agent_design/middleware/overview.md
@@ -23,10 +23,10 @@ Most middleware will wrap an entire node or function call, including `rt.functio
 
 | Decorator | Runs |
 |---|---|
-| `rt.wrap_node` | Wraps the whole node call — you decide if/how many times the inner call runs 
+| `rt.wrap_node` | Wraps the whole node call; you decide if/how many times the inner call runs 
 | `rt.after_node` | Once, after the node completes successfully (skipped if the node raises)
 
-`rt.wrap_node` is the general-purpose form — the retry example above is built on it. `rt.after_node` is a narrower convenience for the common "do something with the result and pass it through" case:
+`rt.wrap_node` is the general-purpose form. The retry example above is built on it. `rt.after_node` is a narrower convenience for the common "do something with the result and pass it through" case:
 
 ```python
 --8<-- "docs/scripts/middleware.py:after_node_demo"
@@ -39,7 +39,7 @@ The same middleware attaches to a `function_node` exactly the same way, via `mid
 ```
 
 ### Model Middleware
-Sometimes you want your middleware to wrap around the model call itself, rather than the whole node. This lets you build retry logic specific to the LLM, message history compression, PII detection guards, or similar. Model middleware only applies to `rt.agent_node` — a `function_node` never calls a model, so it has no `model_middleware=` slot to attach to. We support several prebuilt middlewares for the LLM, plus the same kind of decorator API to build your own.
+Sometimes you want your middleware to wrap around the model call itself, rather than the whole node. This lets you build retry logic specific to the LLM, message history compression, PII detection guards, or similar. Model middleware only applies to `rt.agent_node`. A `function_node` never calls a model, so it has no `model_middleware=` slot to attach to. We support several prebuilt middlewares for the LLM, plus the same kind of decorator API to build your own.
 
 | Decorator | Runs |
 |---|---|
@@ -52,7 +52,7 @@ Sometimes you want your middleware to wrap around the model call itself, rather 
 ```
 
 !!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
-    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def` — a plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 !!! note "Guardrails are Model Middleware"
     Built-in guardrails (PII redaction, length limits, blocked text, ...) are implemented as model middleware under the hood. See [Guardrails](../middleware/guardrails/overview.md).

--- a/docs/documentation/agent_design/middleware/overview.md
+++ b/docs/documentation/agent_design/middleware/overview.md
@@ -1,13 +1,13 @@
 # Middleware
 
-Middleware is a pervasive software concept. One which, when applied to the tooling of an agent, can have immense power and clean composability. At its core, middleware in railtracks is a function which wraps your node's call. Concretely, middleware can do things like:
+Middleware in Railtracks is a function that wraps a node's call, letting you add behavior around it without touching the node itself. Concretely, middleware can do things like:
 
 - Log inputs and outputs
 - Handle automatic retries
 - PII detection and redaction
 - Unwanted Question rejection
 
-The beauty of this concept is how easy it is to compose middleware and add it to your flows. Below you can see a simple example of injecting a retry middleware into a flow.
+Middleware composes: attach several to the same node and they run as nested layers around the call. Below is a simple example of adding a retry middleware to a flow.
 
 ```python
 --8<-- "docs/scripts/middleware.py:wrappers"
@@ -18,8 +18,8 @@ We provide a suite of prebuilt middleware for common use cases. Check out the co
 
 ## Types of Middleware
 
-### Middleware (Regular)
-Most middleware will wrap an entire node or function call. Common examples include logging, retry logic, HIL verification, rate limiting, caching, and more. Outside of what we supply, you can create your own with a small decorator API.
+### Node Middleware
+Most middleware will wrap an entire node or function call, including `rt.function_node`. Common examples include logging, retry logic, HIL verification, rate limiting, caching, and more. Outside of what we supply, you can create your own with a small decorator API.
 
 | Decorator | Runs |
 |---|---|
@@ -32,8 +32,14 @@ Most middleware will wrap an entire node or function call. Common examples inclu
 --8<-- "docs/scripts/middleware.py:after_node_demo"
 ```
 
+The same middleware attaches to a `function_node` exactly the same way, via `middleware=`:
+
+```python
+--8<-- "docs/scripts/middleware.py:function_node_demo"
+```
+
 ### Model Middleware
-Sometimes you want your middleware to wrap around the model call itself, rather than the whole node. This lets you build retry logic specific to the LLM, message history compression, PII detection guards, or similar. We support several prebuilt middlewares for the LLM, plus the same kind of decorator API to build your own.
+Sometimes you want your middleware to wrap around the model call itself, rather than the whole node. This lets you build retry logic specific to the LLM, message history compression, PII detection guards, or similar. Model middleware only applies to `rt.agent_node` — a `function_node` never calls a model, so it has no `model_middleware=` slot to attach to. We support several prebuilt middlewares for the LLM, plus the same kind of decorator API to build your own.
 
 | Decorator | Runs |
 |---|---|
@@ -44,6 +50,9 @@ Sometimes you want your middleware to wrap around the model call itself, rather 
 ```python
 --8<-- "docs/scripts/middleware.py:model_middleware_demo"
 ```
+
+!!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def` — a plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 !!! note "Guardrails are Model Middleware"
     Built-in guardrails (PII redaction, length limits, blocked text, ...) are implemented as model middleware under the hood. See [Guardrails](../middleware/guardrails/overview.md).
@@ -60,7 +69,7 @@ You can attach middleware to any node at creation time, or at any time after.
 ```
 
 !!! Note
-    `extend_middleware` returns a **new**, immutable `Node` subclass rather than mutating the original. This means any previous references to the node (e.g. `BaseAgent` above) will not have the new middleware attached. Instead you must use the returned reference (`ExtendedAgent` above) going forward.
+    `couple` returns a **new**, immutable `Node` subclass rather than mutating the original. This means any previous references to the node (e.g. `BaseAgent` above) will not have the new middleware attached. Instead you must use the returned reference (`ExtendedAgent` above) going forward.
 
 ## Middleware Ordering
 A common question when working with middleware is how the ordering is determined. Our API is designed to be as simple as possible: every time you add a middleware to a node, it is added as the outermost layer.
@@ -69,7 +78,7 @@ A common question when working with middleware is how the ordering is determined
 Middleware -> Node -> Middleware
 ```
 
-When adding multiple middleware at once, they run in list order (i.e. index 0 runs first, and is outermost):
+When adding multiple middleware in one call, they run in list order (i.e. index 0 runs first, and is outermost):
 
 ```
 middleware[0] -> middleware[1] -> Node -> middleware[1] -> middleware[0]
@@ -77,4 +86,10 @@ middleware[0] -> middleware[1] -> Node -> middleware[1] -> middleware[0]
 
 ```python
 --8<-- "docs/scripts/middleware.py:ordering_demo"
+```
+
+The same "outermost" rule applies when you call `couple()` more than once on the same node: each call's middleware wraps *everything* attached so far, so the most recently coupled middleware ends up outermost:
+
+```python
+--8<-- "docs/scripts/middleware.py:ordering_couple_demo"
 ```

--- a/docs/scripts/context.py
+++ b/docs/scripts/context.py
@@ -4,6 +4,7 @@ import railtracks as rt
 # Set up some context data
 data = {"var_1": "value_1"}
 
+@rt.function_node
 def some_node():
     rt.context.get("var_1")  # Outputs: value_1
     rt.context.get("var_2", "default_value")  # Outputs: default_value

--- a/docs/scripts/custom_guardrails.py
+++ b/docs/scripts/custom_guardrails.py
@@ -1,8 +1,8 @@
 """Runnable examples for authoring custom guardrails.
 
 Two ways to build a guard:
-  1. the decorator API (``@rt.input_guard`` / ``@rt.output_guard``) — quickest,
-  2. subclassing ``InputGuard`` / ``OutputGuard`` — for reusable, configurable rails.
+  1. the decorator API (``@rt.input_guard`` / ``@rt.output_guard``), quickest,
+  2. subclassing ``InputGuard`` / ``OutputGuard``, for reusable, configurable rails.
 
 Snippet regions (--8<-- [start:name]) are pulled into the guardrails docs by
 MkDocs. Type-checked in CI via scripts/docs_validation.sh.

--- a/docs/scripts/first_agent.py
+++ b/docs/scripts/first_agent.py
@@ -72,13 +72,25 @@ StructuredWeatherAgent = rt.agent_node(
 # --8<-- [end: first_agent_model]
 
 # --8<-- [start: first_agent_all]
-StructuredToolCallWeatherAgent = rt.agent_node(
+WeatherToolCallAgent = rt.agent_node(
     name="Weather Agent",
     llm=rt.llm.OpenAILLM("gpt-4o"),
     system_message="You are a helpful assistant that answers weather-related questions.",
     tool_nodes=[weather_tool],
+)
+
+WeatherStructuredAgent = rt.agent_node(
+    name="Weather Formatter Agent",
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message="Extract the temperature and condition from the assistant's answer.",
     output_schema=WeatherResponse,
 )
+
+# Call the ToolCall agent first, then hand its answer to the structured agent, wrapped by an rt function
+@rt.function_node
+async def StructuredToolCallWeatherAgent(prompt: str):
+    tool_response = await rt.call(WeatherToolCallAgent, user_input=prompt)
+    return await rt.call(WeatherStructuredAgent, user_input=tool_response.text)
 # --8<-- [end: first_agent_all]
 
 # --8<-- [start: call]

--- a/docs/scripts/flows.py
+++ b/docs/scripts/flows.py
@@ -16,27 +16,36 @@ def weather_tool(city: str):
     # Simulate a weather API call
     return f"{city} is sunny with a temperature of 25°C."
 
-weather_manifest = rt.ToolManifest(
-description="A tool you can call to see what the weather in a specified city",
-    parameters=[rt.llm.Parameter(name="prompt", param_type="string", description="This is the prompt that you should provide that tells the CodeAgent what you would like to code.")]
-)
 
 #As before, we will create our Weather Agent with the additional tool manifest so that other agents know how to use it
-WeatherAgent = rt.agent_node(
+WeatherToolCallAgent = rt.agent_node(
     name="Weather Agent",
     llm=rt.llm.OpenAILLM("gpt-4o"),
     system_message="You are a helpful assistant that answers weather-related questions.",
     tool_nodes=[rt.function_node(weather_tool)],
-    output_schema=WeatherResponse,
-    manifest=weather_manifest
 )
+
+WeatherStructuredAgent = rt.agent_node(
+    name="Weather Formatter Agent",
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    system_message="Extract the temperature and condition from the assistant's answer.",
+    output_schema=WeatherResponse,
+)
+
+#Call the ToolCall agent first, then hand its answer to the structured agent, wrapped by an rt function so it can be used as a tool
+@rt.function_node
+async def weather_agent(prompt: str):
+    tool_response = await rt.call(WeatherToolCallAgent, user_input=prompt)
+    return await rt.call(WeatherStructuredAgent, user_input=tool_response.text)
+
+
 
 #Now lets create a hiking planner agent
 HikingAgent = rt.agent_node(
     name="Hiking Agent",
     llm=rt.llm.OpenAILLM("gpt-4o"),
     system_message="You are a helpful assistant that answers questions about which cities have the best conditions for hiking. The user should specify multiple cities near them.",
-    tool_nodes=[WeatherAgent],
+    tool_nodes=[weather_agent],
 )
 # --8<-- [end: hiking_example]
 

--- a/docs/scripts/flows.py
+++ b/docs/scripts/flows.py
@@ -135,14 +135,14 @@ ProductExpertAgent = rt.agent_node(
 BillingAgent = rt.agent_node(
     name="Billing Agent",
     output_schema=StructuredResponse,
-    llm=rt.llm.OpenAILLM("gpt-4o", stream=False),
+    llm=rt.llm.OpenAILLM("gpt-4o"),
     #adding all other arguments as needed
     )
     
 TechnicalAgent = rt.agent_node(
     name="Technical Support Agent",
     output_schema=StructuredResponse,
-    llm=rt.llm.OpenAILLM("gpt-4o", stream=False),
+    llm=rt.llm.OpenAILLM("gpt-4o"),
     #adding all other arguments as needed
     )
 

--- a/docs/scripts/guardrails_quickstart.py
+++ b/docs/scripts/guardrails_quickstart.py
@@ -24,7 +24,7 @@ def block_sensitive_requests(event: LLMGuardrailEvent) -> GuardrailDecision:
     return GuardrailDecision.allow()
 
 
-# Guards are model middleware — attach them with model_middleware=[...].
+# Guards are model middleware. Attach them with model_middleware=[...].
 Agent = rt.agent_node(
     name="guardrails-quickstart-agent",
     llm=rt.llm.GeminiLLM("gemini-2.5-flash"),

--- a/docs/scripts/middleware.py
+++ b/docs/scripts/middleware.py
@@ -82,9 +82,19 @@ CreationTimeAgent = rt.agent_node(
 # --8<-- [start: attach_after_creation]
 BaseAgent = rt.agent_node(name="Agent", llm=rt.llm.OpenAILLM("gpt-4o"))
 
-# extend_middleware returns a NEW Node subclass; BaseAgent itself is untouched.
+# couple() returns a NEW Node subclass; BaseAgent itself is untouched.
 ExtendedAgent = rt.couple(BaseAgent, middleware=[retry, log_result])
 # --8<-- [end: attach_after_creation]
+
+
+# --8<-- [start: function_node_demo]
+# The same middleware works unchanged on a function_node — only the node-level
+# `middleware=` slot applies, since a function node never calls a model.
+@rt.function_node(middleware=[retry])
+def add(a: int, b: int) -> int:
+    """Add two numbers."""
+    return a + b
+# --8<-- [end: function_node_demo]
 
 
 # --8<-- [start: ordering_demo]
@@ -113,6 +123,20 @@ OrderedAgent = rt.agent_node(
 #   inner: after
 #   outer: after
 # --8<-- [end: ordering_demo]
+
+
+# --8<-- [start: ordering_couple_demo]
+# couple() adds its middleware as the new outermost layer, so calling it twice
+# nests in reverse call order: whatever you couple() last wraps everything
+# coupled before it — regardless of what the middleware happens to be named.
+StepOne = rt.couple(BaseAgent, middleware=[outer])
+StepTwo = rt.couple(StepOne, middleware=[inner])
+# calling StepTwo prints, in order:
+#   inner: before
+#   outer: before
+#   outer: after
+#   inner: after
+# --8<-- [end: ordering_couple_demo]
 
 
 

--- a/docs/scripts/middleware.py
+++ b/docs/scripts/middleware.py
@@ -88,7 +88,7 @@ ExtendedAgent = rt.couple(BaseAgent, middleware=[retry, log_result])
 
 
 # --8<-- [start: function_node_demo]
-# The same middleware works unchanged on a function_node — only the node-level
+# The same middleware works unchanged on a function_node. Only the node-level
 # `middleware=` slot applies, since a function node never calls a model.
 @rt.function_node(middleware=[retry])
 def add(a: int, b: int) -> int:
@@ -128,7 +128,7 @@ OrderedAgent = rt.agent_node(
 # --8<-- [start: ordering_couple_demo]
 # couple() adds its middleware as the new outermost layer, so calling it twice
 # nests in reverse call order: whatever you couple() last wraps everything
-# coupled before it — regardless of what the middleware happens to be named.
+# coupled before it, regardless of what the middleware happens to be named.
 StepOne = rt.couple(BaseAgent, middleware=[outer])
 StepTwo = rt.couple(StepOne, middleware=[inner])
 # calling StepTwo prints, in order:

--- a/docs/scripts/node_builder.py
+++ b/docs/scripts/node_builder.py
@@ -7,121 +7,39 @@ Each region is embedded via pymdownx.snippets.
 """
 
 # --8<-- [start: llm_basic]
-import railtracks as rt
-from railtracks.built_nodes._node_builder import NodeBuilder
 
-MyAgent = NodeBuilder.llm(
-    name="MyAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    system_message=rt.llm.SystemMessage("You are a helpful assistant."),
-).build()
 # --8<-- [end: llm_basic]
 
 
 # --8<-- [start: llm_structured]
-from pydantic import BaseModel
 
-
-class Summary(BaseModel):
-    title: str
-    body: str
-
-
-SummaryAgent = NodeBuilder.llm(
-    name="SummaryAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    schema=Summary,  # node now returns StructuredResponse[Summary]
-).build()
 # --8<-- [end: llm_structured]
 
 
 # --8<-- [start: function_node]
-from railtracks.llm import Parameter
 
-
-async def fetch_weather(city: str) -> str:
-    return f"Sunny in {city}"
-
-
-WeatherNode = NodeBuilder.function(
-    fetch_weather,
-    name="fetch_weather",
-    tool_details="Returns the current weather for a city.",
-    tool_params=[Parameter(name="city", description="City name", param_type="string")],
-).build()
 # --8<-- [end: function_node]
 
 
 # --8<-- [start: connected_tools]
-SearchAgent = NodeBuilder.llm(
-    name="SearchAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    connected_nodes=[WeatherNode],  # tools this agent may call
-).build()
+
 # --8<-- [end: connected_tools]
 
 
 # --8<-- [start: expose_as_tool]
-TranslatorAgent = NodeBuilder.llm(
-    name="Translator",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    system_message=rt.llm.SystemMessage("Translate the given text."),
-    tool_details="Translates text from one language to another.",
-    tool_params=[
-        Parameter(name="text", description="Text to translate", param_type="string"),
-        Parameter(
-            name="target_language",
-            description="Target language",
-            param_type="string",
-        ),
-    ],
-).build()
+
 # --8<-- [end: expose_as_tool]
 
 
 # --8<-- [start: middleware]
-@rt.wrapper
-async def retry(call, *args, **kwargs):
-    for attempt in range(3):
-        try:
-            return await call(*args, **kwargs)
-        except Exception:
-            if attempt == 2:
-                raise
 
-
-ResilientAgent = NodeBuilder.llm(
-    name="ResilientAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    middleware=[retry],  # node boundary: once per agent run
-    model_middleware=[retry],  # raw model call: once per model round-trip
-).build()
 # --8<-- [end: middleware]
 
 
 # --8<-- [start: model_factory]
-def pick_model():
-    # Resolved fresh on every model call.
-    return rt.llm.OpenAILLM(rt.context.get("model_name") or "gpt-4o-mini")
-
-
-DynamicAgent = NodeBuilder.llm(name="DynamicAgent", model=pick_model).build()
 # --8<-- [end: model_factory]
 
 
 # --8<-- [start: context_injection]
-# Injection is opt-in: without rt.prebuilt.middleware.ContextInjection() in
-# model_middleware, {placeholders} are left untouched.
-LiteralAgent = NodeBuilder.llm(
-    name="LiteralAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    system_message=rt.llm.SystemMessage("Use {curly braces} freely."),
-).build()
 
-InjectingAgent = NodeBuilder.llm(
-    name="InjectingAgent",
-    model=rt.llm.OpenAILLM("gpt-4o"),
-    system_message=rt.llm.SystemMessage("You are helping {user_name}."),
-    model_middleware=[rt.prebuilt.middleware.ContextInjection()],
-).build()
 # --8<-- [end: context_injection]

--- a/docs/scripts/prebuilt_guardrails.py
+++ b/docs/scripts/prebuilt_guardrails.py
@@ -96,7 +96,7 @@ redact_input = PIIRedactInputGuard(config=config, name="RedactEmail")
 
 msg = "My name is Alice and my email is alice@example.com and my SIN is 163-180-003"
 result = redact_input.decide(msg)
-# result.messages — redacted user message(s)
+# result.messages: redacted user message(s)
 # --8<-- [end: pii_configured_demo]
 
 # --8<-- [start: pii_custom_patterns]
@@ -120,7 +120,7 @@ guard_with_custom = PIIRedactInputGuard(config=custom_config)
 result = guard_with_custom.decide(
     "My ID is EMP-123456; contact hr@company.example internally."
 )
-# result.messages — redacted user message(s), e.g. [EMPLOYEE_ID] and [EMAIL_ADDRESS]
+# result.messages: redacted user message(s), e.g. [EMPLOYEE_ID] and [EMAIL_ADDRESS]
 # --8<-- [end: pii_custom_patterns]
 
 

--- a/docs/scripts/prompts.py
+++ b/docs/scripts/prompts.py
@@ -5,7 +5,7 @@ import railtracks as rt
 system_message = "You are a {role} assistant specialized in {domain}."
 
 # Create an LLM node with this prompt. ContextInjection() enables placeholder
-# substitution from rt.context — without it the {placeholders} are left as-is.
+# substitution from rt.context; without it the {placeholders} are left as-is.
 assistant = rt.agent_node(
     name="Assistant",
     system_message=system_message,

--- a/docs/scripts/rag_examples.py
+++ b/docs/scripts/rag_examples.py
@@ -12,7 +12,6 @@ vs = rt.vector_stores.ChromaVectorStore("My Vector Store", embedding_function)
 
 Agent = rt.agent_node(
     "Simple Rag Agent",
-    rag=rt.RagConfig(vector_store=vs, top_k=3),
     system_message="You are a helpful assistant",
     llm=rt.llm.OpenAILLM("gpt-4o"),
 )

--- a/docs/scripts/session.py
+++ b/docs/scripts/session.py
@@ -15,7 +15,7 @@ print(result)  # "Hello, Alice!"
 
 # --8<-- [start: configured_session_dec]
 @rt.function_node
-async def greet_multiple(names: list[str]):
+async def greet_multiple(names: list[str]) -> list[str]:
     results = []
     for name in names:
         result = await rt.call(greet, name=name)
@@ -81,7 +81,7 @@ second_flow = rt.Flow(
     save_state=True,  # Save execution state to file
 )
 
-result = second_flow.invoke(names =["Bob", "Charlie"])
+result = second_flow.invoke(names=["Bob", "Charlie"])
 print(result)  # ['Hello, Bob!', 'Hello, Charlie!']
 # --8<-- [end: configured_session_cm]
 

--- a/docs/scripts/tools_mcp_guides.py
+++ b/docs/scripts/tools_mcp_guides.py
@@ -96,6 +96,7 @@ def kill_sandbox():
     subprocess.run(["docker", "rm", "-f", "sandbox_chatbot_session"])
 
 
+@rt.function_node
 def execute_code(code: str) -> str:
     exec_result = subprocess.run([
         "docker", "exec", "sandbox_chatbot_session",

--- a/docs/tutorials/walkthroughs/prompts_and_context.md
+++ b/docs/tutorials/walkthroughs/prompts_and_context.md
@@ -21,7 +21,7 @@ Once an agent opts in, injection can still be suppressed at several levels, from
 
 #### Precedence
 
-The agent-level middleware is the master switch: with no `ContextInjection` entry, nothing is injected regardless of the other settings. When it *is* present, the remaining levels act as independent gates — a placeholder is filled **only when injection is enabled at every applicable level**. The most restrictive setting wins, and a narrower scope cannot re-enable injection that a broader scope has turned off.
+The agent-level middleware is the master switch: with no `ContextInjection` entry, nothing is injected regardless of the other settings. When it *is* present, the remaining levels act as independent gates: a placeholder is filled **only when injection is enabled at every applicable level**. The most restrictive setting wins, and a narrower scope cannot re-enable injection that a broader scope has turned off.
 
 The one exception is the run-wide flag itself: a **Flow's `prompt_injection` overrides the global `rt.set_config` value**. If the flow does not set it, the global value applies; if neither is set, the default (`True`) is used.
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node.py
@@ -55,11 +55,11 @@ def _build_dynamic_agent(
     llm: ModelSource,
     system_message: SystemMessage | str | None,
     tool_details: str | None,
-    tool_params: list[Parameter] | None,
-    middleware: list[Middleware[_P, StringResponse]]
-    | list[Middleware[_P, StructuredResponse[_TBaseModel]]]
+    tool_params: Iterable[Parameter] | None,
+    middleware: Iterable[Middleware[_P, StringResponse]]
+    | Iterable[Middleware[_P, StructuredResponse[_TBaseModel]]]
     | None = None,
-    model_middleware: list[ModelMiddleware] | None = None,
+    model_middleware: Iterable[ModelMiddleware] | None = None,
 ) -> type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]:
     resolved_system = (
         SystemMessage(content=system_message)
@@ -80,9 +80,9 @@ def _build_dynamic_agent(
             system_message=resolved_system,
             connected_nodes=unpacked_tool_nodes,
             tool_details=tool_details,
-            tool_params=tool_params,
+            tool_params=list(tool_params) if tool_params is not None else None,
             middleware=cast(
-                "Iterable[Middleware[[UserInput], StringResponse]] | None", middleware
+                Iterable[Middleware[[UserInput], StringResponse]] | None, middleware
             ),
             model_middleware=model_middleware,
         )
@@ -93,16 +93,16 @@ def _build_dynamic_agent(
             system_message=resolved_system,
             schema=output_schema,
             tool_details=tool_details,
-            tool_params=tool_params,
+            tool_params=list(tool_params) if tool_params is not None else None,
             middleware=cast(
-                "Iterable[Middleware[[UserInput], StructuredResponse[_TBaseModel]]] | None",
+                Iterable[Middleware[[UserInput], StructuredResponse[_TBaseModel]]] | None,
                 middleware,
             ),
             model_middleware=model_middleware,
         )
 
     return cast(
-        "type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]",
+        type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]],
         nb.build(),
     )
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Type, TypeVar, overload
+from typing import Callable, Iterable, ParamSpec, Type, TypeVar, cast, overload
 
 from pydantic import BaseModel
 
@@ -19,6 +19,17 @@ from .node_builder import LLMNodeBuilder, UserInput
 
 _TBaseModel = TypeVar("_TBaseModel", bound=BaseModel)
 _R = TypeVar("_R", bound=StructuredResponse | StringResponse)
+_P = ParamSpec("_P")
+
+
+def _user_input_shape(user_input: UserInput) -> object:
+    """Never called -- exists purely so pyright infers `_P` (below) from a real,
+    named parameter instead of the positional-only literal-list form `[UserInput]`.
+    A ParamSpec solved this way (via a defaulted argument on a plain function) keeps
+    the parameter name through `*args: _P.args, **kwargs: _P.kwargs` wherever `_P` is
+    later threaded -- e.g. in `rt.call`/`rt.astream`/`Flow`, which need no changes of
+    their own as a result. Verified empirically against this project's pyright."""
+    raise NotImplementedError
 
 
 def _unpack_tool_nodes(
@@ -45,17 +56,23 @@ def _build_dynamic_agent(
     system_message: SystemMessage | str | None,
     tool_details: str | None,
     tool_params: list[Parameter] | None,
-    middleware: list[Middleware[[UserInput], StringResponse]]
-    | list[Middleware[[UserInput], StructuredResponse[_TBaseModel]]]
+    middleware: list[Middleware[_P, StringResponse]]
+    | list[Middleware[_P, StructuredResponse[_TBaseModel]]]
     | None = None,
     model_middleware: list[ModelMiddleware] | None = None,
-):
+) -> type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]:
     resolved_system = (
         SystemMessage(content=system_message)
         if isinstance(system_message, str)
         else system_message
     )
 
+    # `LLMNodeBuilder` still fixes its ParamSpec as the positional-only literal list
+    # `[UserInput]` (see node_builder.py) -- it's an internal builder never exposed to
+    # callers, so it doesn't need the name-preserving `_P` this module's public
+    # `agent_node()` overloads use. The two casts below bridge that one seam: pyright
+    # can't see through `type(...)`-based dynamic class construction either way, so it
+    # was already trusting the declared return annotation here, not verifying it.
     if output_schema is None:
         nb = LLMNodeBuilder.llm(
             name=name if name is not None else "LLM Agent",
@@ -64,7 +81,9 @@ def _build_dynamic_agent(
             connected_nodes=unpacked_tool_nodes,
             tool_details=tool_details,
             tool_params=tool_params,
-            middleware=middleware,
+            middleware=cast(
+                "Iterable[Middleware[[UserInput], StringResponse]] | None", middleware
+            ),
             model_middleware=model_middleware,
         )
     else:
@@ -75,11 +94,17 @@ def _build_dynamic_agent(
             schema=output_schema,
             tool_details=tool_details,
             tool_params=tool_params,
-            middleware=middleware,
+            middleware=cast(
+                "Iterable[Middleware[[UserInput], StructuredResponse[_TBaseModel]]] | None",
+                middleware,
+            ),
             model_middleware=model_middleware,
         )
 
-    return nb.build()
+    return cast(
+        "type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]",
+        nb.build(),
+    )
 
 
 # --- agent_node overloads (string vs structured output) ---
@@ -89,13 +114,14 @@ def _build_dynamic_agent(
 def agent_node(
     name: str | None = None,
     *,
-    tool_nodes: Iterable[Type[Node] | RTFunction],
+    tool_nodes: Iterable[Type[Node] | RTFunction] | None = None,
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[[UserInput], StringResponse]] | None = None,
+    middleware: list[Middleware[_P, StringResponse]] | None = None,
     model_middleware: list[ModelMiddleware] | None = None,
-) -> type[Node[[UserInput], StringResponse]]: ...
+    _shape: Callable[_P, object] = _user_input_shape,
+) -> type[Node[_P, StringResponse]]: ...
 
 
 @overload
@@ -106,10 +132,10 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[[UserInput], StructuredResponse[_TBaseModel]]]
-    | None = None,
+    middleware: list[Middleware[_P, StructuredResponse[_TBaseModel]]] | None = None,
     model_middleware: list[ModelMiddleware] | None = None,
-) -> type[Node[[UserInput], StructuredResponse[_TBaseModel]]]: ...
+    _shape: Callable[_P, object] = _user_input_shape,
+) -> type[Node[_P, StructuredResponse[_TBaseModel]]]: ...
 
 
 def agent_node(
@@ -120,11 +146,12 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[[UserInput], StructuredResponse[_TBaseModel]]]
-    | list[Middleware[[UserInput], StringResponse]]
+    middleware: list[Middleware[_P, StructuredResponse[_TBaseModel]]]
+    | list[Middleware[_P, StringResponse]]
     | None = None,
     model_middleware: list[ModelMiddleware] | None = None,
-):
+    _shape: Callable[_P, object] = _user_input_shape,
+) -> type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]:
     """
     Dynamically creates an agent based on the provided parameters.
 
@@ -141,6 +168,9 @@ def agent_node(
             (user_input -> Response).
         model_middleware (list[Middleware] | None): Middleware applied around each raw model call
             (messages/schema/tools -> Response), inside the tool-calling loop.
+        _shape (Callable[_P, object]): Internal use only. Used to infer the ParamSpec for the agent's input shape.
+
+    NOTE: Supplying a parameter `_shape` will break typing and you will be responsible for it. DO NOT USE THIS!!
     """
     unpacked_tool_nodes = _unpack_tool_nodes(tool_nodes)
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node.py
@@ -118,8 +118,8 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[_P, StringResponse]] | None = None,
-    model_middleware: list[ModelMiddleware] | None = None,
+    middleware: Iterable[Middleware[_P, StringResponse]] | None = None,
+    model_middleware: Iterable[ModelMiddleware] | None = None,
     _shape: Callable[_P, object] = _user_input_shape,
 ) -> type[Node[_P, StringResponse]]: ...
 
@@ -132,8 +132,8 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[_P, StructuredResponse[_TBaseModel]]] | None = None,
-    model_middleware: list[ModelMiddleware] | None = None,
+    middleware: Iterable[Middleware[_P, StructuredResponse[_TBaseModel]]] | None = None,
+    model_middleware: Iterable[ModelMiddleware] | None = None,
     _shape: Callable[_P, object] = _user_input_shape,
 ) -> type[Node[_P, StructuredResponse[_TBaseModel]]]: ...
 
@@ -146,10 +146,10 @@ def agent_node(
     llm: ModelSource,
     system_message: SystemMessage | str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: list[Middleware[_P, StructuredResponse[_TBaseModel]]]
-    | list[Middleware[_P, StringResponse]]
+    middleware: Iterable[Middleware[_P, StructuredResponse[_TBaseModel]]]
+    | Iterable[Middleware[_P, StringResponse]]
     | None = None,
-    model_middleware: list[ModelMiddleware] | None = None,
+    model_middleware: Iterable[ModelMiddleware] | None = None,
     _shape: Callable[_P, object] = _user_input_shape,
 ) -> type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]]:
     """

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node.py
@@ -95,14 +95,16 @@ def _build_dynamic_agent(
             tool_details=tool_details,
             tool_params=list(tool_params) if tool_params is not None else None,
             middleware=cast(
-                Iterable[Middleware[[UserInput], StructuredResponse[_TBaseModel]]] | None,
+                Iterable[Middleware[[UserInput], StructuredResponse[_TBaseModel]]]
+                | None,
                 middleware,
             ),
             model_middleware=model_middleware,
         )
 
     return cast(
-        type[Node[_P, StringResponse]] | type[Node[_P, StructuredResponse[_TBaseModel]]],
+        type[Node[_P, StringResponse]]
+        | type[Node[_P, StructuredResponse[_TBaseModel]]],
         nb.build(),
     )
 

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node.py
@@ -67,12 +67,6 @@ def _build_dynamic_agent(
         else system_message
     )
 
-    # `LLMNodeBuilder` still fixes its ParamSpec as the positional-only literal list
-    # `[UserInput]` (see node_builder.py) -- it's an internal builder never exposed to
-    # callers, so it doesn't need the name-preserving `_P` this module's public
-    # `agent_node()` overloads use. The two casts below bridge that one seam: pyright
-    # can't see through `type(...)`-based dynamic class construction either way, so it
-    # was already trusting the declared return annotation here, not verifying it.
     if output_schema is None:
         nb = LLMNodeBuilder.llm(
             name=name if name is not None else "LLM Agent",

--- a/packages/railtracks/src/railtracks/interaction/couple.py
+++ b/packages/railtracks/src/railtracks/interaction/couple.py
@@ -73,8 +73,9 @@ def couple(
 
     Ordering:
     - Middleware = [A, B, C] -> A wraps B, B wraps C, C wraps the node. A -> B -> C -> Node -> C -> B -> A
-    - Existing middleware on `node` is preserved and wraps around the newly added middleware
-      (the new middleware ends up innermost, closest to the node).
+    - Newly added middleware wraps around any existing middleware already on `node`
+      (the new middleware ends up outermost, farthest from the node). Call `couple()`
+      again on the result to add another, even-more-outer layer.
     """
     from railtracks.built_nodes.function.base import RTFunction
 

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -144,9 +144,9 @@ class Node(ABC, Generic[_P, _TOutput]):
         cls, *middleware: Middleware[_P, _TOutput]
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
-            *deepcopy(cls._user_middleware),
             *middleware,
-        ]  # fresh list a nice protection around things
+            *deepcopy(cls._user_middleware),
+        ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_middleware": new_middleware})
 
     @classmethod
@@ -154,9 +154,9 @@ class Node(ABC, Generic[_P, _TOutput]):
         cls, *middleware: ModelMiddleware
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
-            *deepcopy(cls._user_model_middleware),
             *middleware,
-        ]  # fresh list a nice protection around things
+            *deepcopy(cls._user_model_middleware),
+        ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_model_middleware": new_middleware})
 
     def __repr__(self):

--- a/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
@@ -144,7 +144,7 @@ def test_couple_twice_from_same_original_produces_independent_siblings():
     assert log == []
 
 
-def test_couple_chained_composes_first_outer_second_inner():
+def test_couple_chained_composes_second_outer_first_inner():
     """To compose middleware across multiple `couple()` calls, chain off the
     previous result rather than calling `couple()` repeatedly against the same
     original -- each call wraps a fresh layer around whatever it's given."""
@@ -155,8 +155,9 @@ def test_couple_chained_composes_first_outer_second_inner():
 
     asyncio.run(_run(twice, 1, 1))
 
-    # first-coupled is outer, second-coupled is inner
-    assert log == ["first-in", "second-in", "second-out", "first-out"]
+    # second-coupled is outer (it wraps the result of the first couple() call),
+    # first-coupled is inner
+    assert log == ["second-in", "first-in", "first-out", "second-out"]
 
 
 def test_couple_with_multiple_middleware_in_one_call_preserves_list_order():
@@ -330,7 +331,7 @@ def test_couple_middleware_alone_leaves_model_middleware_untouched(mock_llm):
     assert new_cls._user_model_middleware == agent_cls._user_model_middleware == []
 
 
-def test_couple_model_middleware_chained_composes_first_outer_second_inner(mock_llm):
+def test_couple_model_middleware_chained_composes_second_outer_first_inner(mock_llm):
     log = []
     agent_cls = _make_agent(mock_llm)
 
@@ -339,7 +340,9 @@ def test_couple_model_middleware_chained_composes_first_outer_second_inner(mock_
 
     asyncio.run(_run_agent(twice))
 
-    assert log == ["first-in", "second-in", "second-out", "first-out"]
+    # second-coupled is outer (it wraps the result of the first couple() call),
+    # first-coupled is inner
+    assert log == ["second-in", "first-in", "first-out", "second-out"]
 
 
 def test_couple_model_middleware_on_rt_function_is_a_documented_no_op():


### PR DESCRIPTION
## Summary

Some general typing fixes and docs changes. I don't feel it super needed to explain them all. Some critical ones include the ultimate hack to get paramspec typing to work for LLM node

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
