### PR TITLE
fix: drop rt.Session from public surface and error guidance

### DIFF
--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
     from railtracks.interaction import interactive as interactive
 
 __all__ = [
-    "Session",
-    "session",
     "call",
     "broadcast",
     "call_batch",
@@ -61,7 +59,9 @@ from . import (
     observability,
     prebuilt,
 )
-from ._session import ExecutionInfo, Session, session
+from ._session import ExecutionInfo
+from ._session import Session as Session
+from ._session import session as session
 from .context.central import session_id, set_config
 from .interaction import broadcast, call, call_batch
 from .llm.prompt_injection_utils import escape_braces

--- a/packages/railtracks/src/railtracks/context/central.py
+++ b/packages/railtracks/src/railtracks/context/central.py
@@ -83,7 +83,7 @@ def safe_get_runner_context() -> RunnerContextVars:
             message="Context is not available. But some function tried to access it.",
             notes=[
                 "You need to have an active runner to access context.",
-                "Eg.-\n with rt.Session():\n    _ = rt.call(node)",
+                "Eg.-\n flow = rt.Flow('my-agent', entry_point=my_node)\n result = await flow.ainvoke(query)",
             ],
         )
     return context

--- a/packages/railtracks/src/railtracks/prompts/prompt.py
+++ b/packages/railtracks/src/railtracks/prompts/prompt.py
@@ -18,9 +18,9 @@ def inject_context(message_history: MessageHistory):
         message_history (MessageHistory): The prompts to inject context into.
 
     """
-    # we need to be able to handle the case where the user is not running this within the context of a `rt.Session()`
+    # we need to be able to handle the case where the user is not running this within an active runner
     try:
-        # if the context is not set (Session is not active), the `ContextError` will be raised.
+        # if the context is not set (no active runner), the `ContextError` will be raised.
         local_config = get_local_config()
         is_prompt_inject = local_config.prompt_injection
     except ContextError:


### PR DESCRIPTION
## Problem

Closes #1376. When no runner is active, `safe_get_runner_context()` raises `ContextError` with notes that point users at `rt.Session()`. Session is largely internal, and the maintainer asked to stop actively referencing it and to remove it from the public interface.

## Change

- `context/central.py`: the `ContextError` notes now point at the public `rt.Flow` API instead of `rt.Session()`.
- `__init__.py`: `Session` and `session` are removed from `__all__`, so they no longer appear in the documented public surface (pdoc renders from `__all__`) or star-imports.
- Both names remain reachable as module attributes (`rt.Session`, `rt.session`) for backward compatibility; only the advertised interface changes.
- `prompts/prompt.py`: internal comment updated to match.

## Why this approach

Removing the names entirely would be a hard breaking change (they are used widely in tests and by existing users). Keeping them importable while dropping them from `__all__` matches the repository's own precedent for de-emphasized public names and the maintainer's explicit request.

## Testing

```text
uv run python -m pytest packages/railtracks/tests/unit_tests/context   packages/railtracks/tests/unit_tests/prompt packages/railtracks/tests/unit_tests/test_pending_changes.py   packages/railtracks/tests/unit_tests/test_session.py packages/railtracks/tests/unit_tests/test_exceptions.py   packages/railtracks/tests/unit_tests/observability -q
result: 199 passed

uv run ruff check packages/railtracks/src/railtracks/ && uv run ruff format --check
result: All checks passed / 259 files already formatted

Full unit suite: 2008 passed; the 18 failures + 16 collection errors are
pre-existing on clean main (optional-extra deps: portkey, boto3, datasets).
```

## Documentation and release impact

- [x] User-facing documentation updated (public `__all__` surface)
- [ ] Changelog/release note needed
- [ ] Migration or compatibility note needed (names remain reachable, so none)
- [ ] No documentation impact

## Review notes

- Known limitations: `Session`/`session` are still accessible as attributes for backward compatibility; a future release can remove them entirely.
- Follow-up issue, if any: none
- Security/licensing considerations: none