### PR TITLE
fix: reject invalid param_type with a descriptive error (#1393)

### DIFF
--- a/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
+++ b/packages/railtracks/src/railtracks/llm/tools/parameters/_base.py
@@ -29,14 +29,31 @@ class ParameterType(str, Enum):
         return mapping.get(py_type, cls.OBJECT)
 
 
+# The JSON-schema type strings a Parameter may declare. Anything else that
+# reaches to_json_schema() is silently emitted into the manifest, and the LLM
+# backend eventually rejects it with a deep, unrelated traceback (#1393).
+_VALID_SCHEMA_TYPES = frozenset(t.value for t in ParameterType)
+
+
 def _normalize_param_type_scalar(
     param_type: Union[str, ParameterType, type],
 ) -> str:
-    """Map ParameterType enum, JSON schema type string, or Python type to a schema type string."""
+    """Map ParameterType enum, JSON schema type string, or Python type to a schema type string.
+
+    Raises:
+        ValueError: if a string is not a valid JSON-schema type. The caller
+            (Parameter.__init__) adds the parameter name to the message.
+    """
     if isinstance(param_type, ParameterType):
         return param_type.value
     if isinstance(param_type, type):
         return ParameterType.from_python_type(param_type).value
+    if param_type not in _VALID_SCHEMA_TYPES:
+        raise ValueError(
+            f"param_type {param_type!r} is not a valid JSON-schema type; "
+            f"expected one of {sorted(_VALID_SCHEMA_TYPES)} or a "
+            f"ParameterType / Python type"
+        )
     return param_type
 
 
@@ -86,12 +103,17 @@ class Parameter(ABC):
         self.enum = enum
         self.default_present = default_present
         if param_type is not None:
-            if isinstance(param_type, list):
-                self.param_type = [
-                    _normalize_param_type_scalar(pt) for pt in param_type
-                ]
-            else:
-                self.param_type = _normalize_param_type_scalar(param_type)
+            try:
+                if isinstance(param_type, list):
+                    self.param_type = [
+                        _normalize_param_type_scalar(pt) for pt in param_type
+                    ]
+                else:
+                    self.param_type = _normalize_param_type_scalar(param_type)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Invalid param_type for parameter '{name}': {exc}"
+                ) from exc
         elif hasattr(self, "param_type") and self.param_type is None:
             self.param_type = None
 

--- a/packages/railtracks/tests/unit_tests/llm/tools/parameters/test__base.py
+++ b/packages/railtracks/tests/unit_tests/llm/tools/parameters/test__base.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from railtracks.llm.tools.parameters._base import Parameter, ParameterType
 
 
@@ -46,3 +47,26 @@ def test_parameter_accepts_python_type_int():
 def test_parameter_list_accepts_mixed_python_and_schema_types():
     p = Parameter("x", param_type=[str, "null"])
     assert p.param_type == ["string", "null"]
+
+
+def test_invalid_param_type_string_raises_descriptive_error():
+    # #1393: a bad param_type like "bool" used to flow through into the
+    # manifest and surface only as a deep LLM-backend BadRequestError.
+    with pytest.raises(ValueError) as excinfo:
+        Parameter("param_name", param_type="bool")
+    message = str(excinfo.value)
+    assert "param_name" in message
+    assert "'bool'" in message
+    assert "string" in message
+
+
+def test_invalid_param_type_in_list_raises_with_parameter_name():
+    with pytest.raises(ValueError) as excinfo:
+        Parameter("items", param_type=["string", "bool"])
+    assert "items" in str(excinfo.value)
+
+
+def test_all_parameter_type_values_are_accepted():
+    for value in (t.value for t in ParameterType):
+        p = Parameter("x", param_type=value)
+        assert p.to_json_schema()["type"] == value


### PR DESCRIPTION
## What

Fixes #1393. A bad schema type (e.g. `param_type="bool"`) used to pass through `_normalize_param_type_scalar()` unchanged, get emitted into the tool manifest as an invalid `"type": "bool"`, and only fail later with a deep litellm `BadRequestError` traceback that says nothing about the parameter.

`Parameter.__init__` now validates every `param_type` string against the JSON-schema types (`string`, `integer`, `number`, `boolean`, `array`, `object`, `null`) at the single normalization choke point, and raises immediately, naming the parameter:

```
ValueError: Invalid param_type for parameter 'param_name': param_type 'bool' is not a valid JSON-schema type; expected one of ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'] or a ParameterType / Python type
```

That's the issue's exact repro (`Parameter(name="param_name", param_type="bool")`) — it now fails at construction with a message pointing at the fix, instead of hours later at the LLM call.

## Unaffected

- `ParameterType` enums, Python types (`str` → `"string"`, …), and union lists (`["string", "null"]`) still normalize as before — verified against every existing `param_type=` usage in `src/` and the tests (schema_parser, docstring_parser, parameter_handlers, built_nodes).
- No tool/agent context is threaded into the message: `Parameter` doesn't know its tool. Naming the parameter + the invalid value + the accepted set is the earliest, most precise boundary; happy to enrich with tool/agent names if you'd like that context added at the manifest layer.

## Verification

- 3 new regression tests in `test__base.py` (invalid scalar, invalid union element, all valid enum values accepted).
- `llm/tools` unit tests: **52 passed**. Full `unit_tests` suite: 2094 passed, with the same 20 pre-existing cloud/API-key failures (portkey/tavily/s3/sql — no creds locally) as the pristine checkout.
- `ruff check` clean on changed files.

Closes #1393
