### PR TITLE
Fix 1405 mcp close loop race

### DIFF
--- a/packages/railtracks/src/railtracks/rt_mcp/main.py
+++ b/packages/railtracks/src/railtracks/rt_mcp/main.py
@@ -389,7 +389,11 @@ class MCPServer:
                 turns that into a logged warning instead of an indefinite hang.
         """
         if self._loop is not None and self._shutdown_event is not None:
-            self._loop.call_soon_threadsafe(self._shutdown_event.set)
+            try:
+                self._loop.call_soon_threadsafe(self._shutdown_event.set)
+            except RuntimeError:
+                # The background thread already signalled itself and closed the loop
+                pass
             self._thread.join(timeout=join_timeout)
             if self._thread.is_alive():
                 logger.warning(

--- a/packages/railtracks/tests/unit_tests/rt_mcp/test_error_handling.py
+++ b/packages/railtracks/tests/unit_tests/rt_mcp/test_error_handling.py
@@ -8,6 +8,7 @@ including invalid commands, timeouts, and exception propagation from background 
 
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 from railtracks.rt_mcp import MCPStdioParams
@@ -143,3 +144,29 @@ class TestCloseMethod:
         
         # Should not raise an error
         server.close()
+
+    def test_close_tolerates_loop_closed_by_background_thread(self):
+        """Test that a setup failure surfaces as itself, not 'Event loop is closed'.
+
+        On a setup failure the background thread signals shutdown and then closes its
+        own loop, while __init__ concurrently calls close() to signal that same loop.
+        The two are unordered, so close() must tolerate an already-closed loop. The
+        sleep pins the interleaving that otherwise only shows up intermittently.
+        """
+        original_close = MCPServer.close
+
+        def delayed_close(self, *args, **kwargs):
+            time.sleep(0.3)  # let the background thread reach self._loop.close()
+            return original_close(self, *args, **kwargs)
+
+        with patch.object(MCPServer, "close", delayed_close):
+            with pytest.raises(FileNotFoundError) as exc_info:
+                MCPServer(
+                    config=MCPStdioParams(
+                        command="missing_mcp_server",
+                        args=[]
+                    ),
+                    setup_timeout=5
+                )
+
+        assert "missing_mcp_server" in str(exc_info.value)


### PR DESCRIPTION
## Summary

Closes #1405.

`MCPServer.close()` signals shutdown via `self._loop.call_soon_threadsafe(...)`. On a
setup failure the background thread has already signalled itself and closed that loop,
so the call raises `RuntimeError: Event loop is closed` which replaces the real
`FileNotFoundError`/`TimeoutError` the caller needs. Wrapping the signal in
`except RuntimeError` lets the genuine setup error propagate.

## Why this is a one-line change (and why it is in `close()`)

The bug is not that `close()` is called at the wrong time it is that `close()` is not
safe to call once the background thread has disposed of the loop, which its own
docstring already promises ("Safe to call even if initialization failed early").

### Two alternatives were considered and rejected:

- **Reverting the `self.close()` call at line 306** (added by #1392)  the timeout branch
  at line 297 calls `close()` the same way against the same possibly-closed loop, so this
  would leave the defect reachable. Fixing `close()` covers both callers.
- **Guarding with `if not self._loop.is_closed()`**  check-then-act. The loop can close
  between the check and the call, leaving the same window open. The `except` has to wrap
  the call itself.
## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check packages/ && ruff format --check packages/`)
- [x] Tests added/updated and pass locally
- [x] Docs updated if user-facing behavior changed (n/a — `close()` now matches its
      documented contract; no signature or behaviour change on the success path)
- [x] Breaking changes include migration notes (n/a)
.
