### PR TITLE
docs: define and cross-link key keywords (Node, Agent Node, Sequential Flow, Direct Invocation)

### DIFF
--- a/docs/documentation/agent_design/overview.md
+++ b/docs/documentation/agent_design/overview.md
@@ -7,16 +7,19 @@ At its core, the design is two pronged:
 1. Agent Level Design
 2. Agent Interaction Design
 
-## Core Concepts & Terminology
-
-- **Node**: The fundamental execution block in Railtracks encapsulating logic (such as LLM prompts or Python functions).
-- **Agent Node**: An LLM-powered node created via `rt.agent_node()` that manages prompt messages, model calls, and tools.
-- **[Direct Invocation](../invocation/call.md)**: Executing a node directly using `await rt.call(node, ...)` without wrapped session management.
-- **[Sequential Flow](../../tutorials/concepts/architectures/sequential.md)**: An architecture where tasks or nodes execute in sequence within a [`Flow`](../invocation/flows.md).
-
 ## Agent Level Design
 
-This is where what we'd like to call "intra-agent" decisions come into play. Things such as choice of _LLM_, _System Message_, and _Tools_. Snippet below provides the most fundamental LLM-powered agent in Railtracks with no tool calling capabilities.
+Agent-level design covers the behavior of one executable unit, including its model, system message, tools, and middleware.
+
+### Node
+
+A **Node** is Railtracks' executable building block. It defines an invocation contract: it accepts inputs, runs its `invoke` method through Railtracks' execution and middleware machinery, and produces an output. Agent logic and ordinary Python functions can both be represented as nodes, which lets Railtracks compose and track them in the same way.
+
+You will usually create a Node with a builder such as `rt.agent_node()` or `@rt.function_node` instead of subclassing `Node` directly. Use a function node for deterministic Python work and an Agent Node when the work requires an LLM.
+
+### Agent Node
+
+An **Agent Node** is a Node class created by `rt.agent_node()`. It sends messages to a configured LLM and can include a system message, tools, structured output, and middleware. The example below creates a minimal Agent Node with no tools:
 
 ```python
 --8<-- "docs/scripts/documentation/agent_design.py"
@@ -25,4 +28,4 @@ This is where what we'd like to call "intra-agent" decisions come into play. Thi
     - `name`: Optional name to give your agent. Will default to the node type if not provided
 
 ## Agent Interaction Design
-This is where the connections between different agents and the rest of your code come into play. In Railtracks, for this connection we use the concept of [`Flows`](../invocation/flows.md) where you define these relationships. Read more at [Flow Invocation](../invocation/flows.md).
+Agent-interaction design covers how nodes call one another and how your application starts the resulting graph. Use [Direct Invocation](../invocation/call.md) for a single call or for explicit async composition. Use a [Flow](../invocation/flows.md) when you want a reusable, configured entry point. A [Sequential Flow](../../tutorials/concepts/architectures/sequential.md) is one Flow architecture that invokes nodes in a fixed order.

--- a/docs/documentation/agent_design/overview.md
+++ b/docs/documentation/agent_design/overview.md
@@ -7,10 +7,16 @@ At its core, the design is two pronged:
 1. Agent Level Design
 2. Agent Interaction Design
 
+## Core Concepts & Terminology
+
+- **Node**: The fundamental execution block in Railtracks encapsulating logic (such as LLM prompts or Python functions).
+- **Agent Node**: An LLM-powered node created via `rt.agent_node()` that manages prompt messages, model calls, and tools.
+- **[Direct Invocation](../invocation/call.md)**: Executing a node directly using `await rt.call(node, ...)` without wrapped session management.
+- **[Sequential Flow](../../tutorials/concepts/architectures/sequential.md)**: An architecture where tasks or nodes execute in sequence within a [`Flow`](../invocation/flows.md).
 
 ## Agent Level Design
 
-This is where what we'd like to "intra-agent" decisions come into play. Things such as choice of _LLM_, _System Message_, and _Tools_. Snippet below provides the most fundamental LLM-powered agent in Railtracks with no tool calling capabilities.
+This is where what we'd like to call "intra-agent" decisions come into play. Things such as choice of _LLM_, _System Message_, and _Tools_. Snippet below provides the most fundamental LLM-powered agent in Railtracks with no tool calling capabilities.
 
 ```python
 --8<-- "docs/scripts/documentation/agent_design.py"
@@ -19,4 +25,4 @@ This is where what we'd like to "intra-agent" decisions come into play. Things s
     - `name`: Optional name to give your agent. Will default to the node type if not provided
 
 ## Agent Interaction Design
-This is where the connections between different agents and the rest of your code come into play. In Railtracks, for this connection we use the concept of `Flows` where you define these relationships. Read more at [Flow Invocation](../invocation/flows.md).
+This is where the connections between different agents and the rest of your code come into play. In Railtracks, for this connection we use the concept of [`Flows`](../invocation/flows.md) where you define these relationships. Read more at [Flow Invocation](../invocation/flows.md).

--- a/docs/documentation/invocation/call.md
+++ b/docs/documentation/invocation/call.md
@@ -1,3 +1,7 @@
+# Direct Invocation (`rt.call`)
+
+**Direct invocation** refers to calling an [Agent Node](../agent_design/overview.md) or [Node](../agent_design/overview.md) directly using `rt.call` without creating a full [Flow](flows.md).
+
 If you are familiar and comfortable with the `async/await` syntax and you do not require any configurations, you can simply use the `railtracks.call` API to invoke your agent:
 ```python
 import railtracks as rt
@@ -18,4 +22,4 @@ resp = await rt.call(AgentName, "user message to the agent")
 
 The `call` API is also useful when you want to use agents as tools by having them wrapped within another a function (see [Agents as Tools](../agent_design/tools/agents_as_tools.md)). 
 
-For configuration management such as context, observability through invocations, and other settings we recommend using [Flows](../invocation/flows.md).
+For configuration management such as context, observability through invocations, and other settings we recommend using [Flows](flows.md).

--- a/docs/documentation/invocation/call.md
+++ b/docs/documentation/invocation/call.md
@@ -1,8 +1,16 @@
 # Direct Invocation (`rt.call`)
 
-**Direct invocation** refers to calling an [Agent Node](../agent_design/overview.md) or [Node](../agent_design/overview.md) directly using `rt.call` without creating a full [Flow](flows.md).
+**Direct invocation** means passing a [Node](../agent_design/overview.md#node), including an [Agent Node](../agent_design/overview.md#agent-node), directly to `await rt.call(...)` and awaiting its output. Python code decides when and how the call runs, whether it is a top-level call or is nested inside another Node or a [Flow](flows.md) entry point.
 
-If you are familiar and comfortable with the `async/await` syntax and you do not require any configurations, you can simply use the `railtracks.call` API to invoke your agent:
+Railtracks still runs the Node through its normal execution and middleware machinery. For a top-level call, it creates the required execution context internally; application code does not need to construct or manage that internal state.
+
+Use direct invocation when you:
+
+- need a one-off asynchronous result;
+- want to control sequential or parallel calls with normal Python `async`/`await`; or
+- only need the returned value, rather than reusable Flow configuration or post-run inspection.
+
+For example, invoke an Agent Node and use its response immediately:
 ```python
 import railtracks as rt
 
@@ -20,6 +28,6 @@ resp = await rt.call(AgentName, "user message to the agent")
     run(outer_func(...))
     ```
 
-The `call` API is also useful when you want to use agents as tools by having them wrapped within another a function (see [Agents as Tools](../agent_design/tools/agents_as_tools.md)). 
+The `call` API is also useful when you want to use agents as tools by wrapping them in another function (see [Agents as Tools](../agent_design/tools/agents_as_tools.md)).
 
-For configuration management such as context, observability through invocations, and other settings we recommend using [Flows](flows.md).
+Wrap the entry point in a [Flow](flows.md) when you need a named, reusable entry point with Flow-scoped configuration or context, synchronous invocation, or inspection through a `FlowConnection`.

--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -1,8 +1,8 @@
 # Flows (Session Management)
-In Railtracks, flows are the primary way to organize your agent runs. Think of a Flow as a blueprint that you invoke to start a run. A single Flow can be invoked multiple times to execute the same agentic process. This guide provides concrete examples to help you get started with Flows.
+In Railtracks, flows are the primary way to organize your agent runs. Think of a Flow as a blueprint that you invoke to start a run. A single Flow can be invoked multiple times to execute the same agentic process (such as a [Sequential Flow](../../tutorials/concepts/architectures/sequential.md)). Unlike [Direct Invocation](call.md) with `rt.call`, Flows provide session management, context scoping, and connection inspection. This guide provides concrete examples to help you get started with Flows.
 
 ## Quickstart
-To get started with Flows, you simply need to provide an entry point and a name.
+To get started with Flows, you simply need to provide an entry point (such as an [Agent Node](../agent_design/overview.md)) and a name.
 
 ```python
 --8<-- "docs/scripts/flows_sessions.py:quickstart"

--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -1,8 +1,10 @@
-# Flows (Session Management)
-In Railtracks, flows are the primary way to organize your agent runs. Think of a Flow as a blueprint that you invoke to start a run. A single Flow can be invoked multiple times to execute the same agentic process (such as a [Sequential Flow](../../tutorials/concepts/architectures/sequential.md)). Unlike [Direct Invocation](call.md) with `rt.call`, Flows provide session management, context scoping, and connection inspection. This guide provides concrete examples to help you get started with Flows.
+# Flows
+In Railtracks, a Flow is a named, reusable entry point for an agent graph. It binds an entry-point Node to configuration that can be invoked repeatedly, with each run isolated from the others. Choose a Flow when you need Flow-scoped configuration or context, synchronous invocation, or post-run inspection through a `FlowConnection`. For a one-off asynchronous call where you only need the result, use [Direct Invocation](call.md).
+
+A [Sequential Flow](../../tutorials/concepts/architectures/sequential.md) is one architecture a Flow can run; the nodes' order is defined in the entry point's Python logic.
 
 ## Quickstart
-To get started with Flows, you simply need to provide an entry point (such as an [Agent Node](../agent_design/overview.md)) and a name.
+To get started with Flows, you simply need to provide an entry point (such as an [Agent Node](../agent_design/overview.md#agent-node)) and a name.
 
 ```python
 --8<-- "docs/scripts/flows_sessions.py:quickstart"

--- a/docs/tutorials/concepts/agents.md
+++ b/docs/tutorials/concepts/agents.md
@@ -46,6 +46,15 @@ graph TB
     class Env envClass;
 ```
 
+# Core Concepts & Terminology
+
+In Railtracks, the core agent abstractions include:
+
+* **[Node](../../documentation/agent_design/overview.md)**: The foundational building block in Railtracks representing an executable unit of work.
+* **[Agent Node](../../documentation/agent_design/overview.md)**: An LLM-powered node created using `rt.agent_node` that manages prompts, model calls, and tools.
+* **[Direct Invocation](../../documentation/invocation/call.md)**: Executing a node directly using `rt.call` without full session configuration.
+* **[Sequential Flow](architectures/sequential.md)**: Executing nodes in sequence step-by-step using [`Flows`](../../documentation/invocation/flows.md).
+
 # Real World Applications
 
 Agents are already being used in real world applications such as:
@@ -63,7 +72,3 @@ Agents are already being used in real world applications such as:
 
 We have build **Railtracks** with developers in mind; with just a simple prompt and a bit of Python, you’re
 already well on your way to building your first agent. Get started [Building with Railtracks](../walkthroughs/byfa.md)
-
-
-
-

--- a/docs/tutorials/concepts/agents.md
+++ b/docs/tutorials/concepts/agents.md
@@ -21,6 +21,8 @@ for a while now, but LLMs have changed the game and made it much easier to use t
 accomplish complex tasks and goals. This ability makes them uniquely suited to operate as the **brain** for your agentic
 system.
 
+In Railtracks, an [Agent Node](../../documentation/agent_design/overview.md#agent-node) packages that LLM behavior as an executable [Node](../../documentation/agent_design/overview.md#node).
+
 ```mermaid
 graph TB
     User[User]
@@ -45,15 +47,6 @@ graph TB
     class Tools toolClass;
     class Env envClass;
 ```
-
-# Core Concepts & Terminology
-
-In Railtracks, the core agent abstractions include:
-
-* **[Node](../../documentation/agent_design/overview.md)**: The foundational building block in Railtracks representing an executable unit of work.
-* **[Agent Node](../../documentation/agent_design/overview.md)**: An LLM-powered node created using `rt.agent_node` that manages prompts, model calls, and tools.
-* **[Direct Invocation](../../documentation/invocation/call.md)**: Executing a node directly using `rt.call` without full session configuration.
-* **[Sequential Flow](architectures/sequential.md)**: Executing nodes in sequence step-by-step using [`Flows`](../../documentation/invocation/flows.md).
 
 # Real World Applications
 

--- a/docs/tutorials/concepts/architectures/overview.md
+++ b/docs/tutorials/concepts/architectures/overview.md
@@ -21,9 +21,9 @@ The same flow model supports multiple agent architectures without introducing ne
   </a>
 
   <a class="card" href="../sequential/">
-    <h3>Sequential Agent</h3>
+    <h3>Sequential Flow</h3>
     <p>
-      Linear flows and branching logic between agents, tools, and functions defined programmatically in Python.
+      A fixed order of agents, tools, and functions defined programmatically in Python.
     </p>
   </a>
 </div>

--- a/docs/tutorials/concepts/architectures/sequential.md
+++ b/docs/tutorials/concepts/architectures/sequential.md
@@ -1,7 +1,33 @@
 # Sequential Flows
-In many cases you just want things to happen in a specific order. Instead of letting the LLM decide the order you chain tasks programmatically. 
+A **Sequential Flow** is a [Flow](../../../documentation/invocation/flows.md) architecture in which Python code invokes nodes in a fixed order, usually passing one node's output to the next. "Sequential" describes the execution order; it is not a separate Railtracks class or API.
 
-In the below colab notebook, we will explore how to built a simple sequential flow. Connecting an agent in a sequence
+Use a Sequential Flow when later tasks depend on earlier results or when the order must remain deterministic instead of being chosen by an LLM. Because the order lives in ordinary Python, you can also add validation, branching, or parallel sections where the application requires them.
+
+## Example
+
+Given two [Agent Nodes](../../../documentation/agent_design/overview.md#agent-node), an async function node can compose them with [Direct Invocation](../../../documentation/invocation/call.md):
+
+```python
+import railtracks as rt
+
+from my_agents import ResearchAgent, WriterAgent
+
+
+@rt.function_node
+async def research_then_write(topic: str):
+    notes = await rt.call(ResearchAgent, topic)
+    return await rt.call(WriterAgent, notes.content)
+
+
+flow = rt.Flow(name="ResearchThenWrite", entry_point=research_then_write)
+report = flow.invoke("How do heat pumps work?")
+```
+
+The second call cannot begin until the first `await` returns, so the dependency and execution order are explicit. The Flow makes this composed entry point reusable.
+
+## Try it in Colab
+
+The notebook below walks through a complete Sequential Flow interactively.
 
 
 <div class="colab-card">

--- a/docs/tutorials/notebooks/architectures.md
+++ b/docs/tutorials/notebooks/architectures.md
@@ -1,7 +1,5 @@
 ## Sequential Flows
-In many cases you just want things to happen in a specific order. Instead of letting the LLM decide the order you chain tasks programmatically. 
-
-In the below colab notebook, we will explore how to built a simple sequential flow. Connecting an agent in a sequence
+A [Sequential Flow](../concepts/architectures/sequential.md) runs nodes in a fixed order defined by Python code. Read the concept guide for the definition, tradeoffs, and a short example, or use the notebook below for an interactive walkthrough.
 
 
 <div class="colab-card">


### PR DESCRIPTION
Resolves #1179.

This PR defines key Railtracks terms ('Node', 'Agent Node', 'Sequential Flow', 'Direct Invocation') in core documentation pages and adds cross-page hyperlinks so readers can easily navigate to full explanations of each concept.

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
