### PR TITLE
Got rid of Duplicate names for serialization purposes

### DIFF
--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -59,7 +59,7 @@ class SpatialParent:
 
 @dataclass(frozen=True)
 class MiddlewareSpatialParent(SpatialParent):
-    spatial_type: Literal[SpatialType.MIDDLEWARE] = field(
+    type: Literal[SpatialType.MIDDLEWARE] = field(
         init=False, default=SpatialType.MIDDLEWARE
     )
     middleware_invoke_id: str
@@ -67,7 +67,7 @@ class MiddlewareSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class NodeSpatialParent(SpatialParent):
-    spatial_type: Literal[SpatialType.NODE] = field(
+    type: Literal[SpatialType.NODE] = field(
         init=False, default=SpatialType.NODE
     )
     node_id: str | None
@@ -75,7 +75,7 @@ class NodeSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class NodeAndMiddlewareSpatialParent(SpatialParent):
-    spatial_type: Literal[SpatialType.NODE_AND_MIDDLEWARE] = field(
+    type: Literal[SpatialType.NODE_AND_MIDDLEWARE] = field(
         init=False, default=SpatialType.NODE_AND_MIDDLEWARE
     )
     node_id: str
@@ -84,7 +84,7 @@ class NodeAndMiddlewareSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class LLMAndMiddlewareSpatialParent(SpatialParent):
-    spatial_type: Literal[SpatialType.LLM_AND_MIDDLEWARE] = field(
+    type: Literal[SpatialType.LLM_AND_MIDDLEWARE] = field(
         init=False, default=SpatialType.LLM_AND_MIDDLEWARE
     )
     llm_invoke_id: str
@@ -93,7 +93,7 @@ class LLMAndMiddlewareSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class NoSpatialParent(SpatialParent):
-    spatial_type: Literal[SpatialType.NONE] = field(
+    type: Literal[SpatialType.NONE] = field(
         init=False, default=SpatialType.NONE
     )
 
@@ -122,13 +122,13 @@ class Parent:
 
 @dataclass(frozen=True)
 class NodeParent(Parent):
-    parent_type: Literal[ParentType.NODE] = field(init=False, default=ParentType.NODE)
+    type: Literal[ParentType.NODE] = field(init=False, default=ParentType.NODE)
     node_id: str
 
 
 @dataclass(frozen=True)
 class MiddlewareParent(Parent):
-    parent_type: Literal[ParentType.MIDDLEWARE] = field(
+    type: Literal[ParentType.MIDDLEWARE] = field(
         init=False, default=ParentType.MIDDLEWARE
     )
     middleware_type_id: str
@@ -137,7 +137,7 @@ class MiddlewareParent(Parent):
 
 @dataclass(frozen=True)
 class LLMParent(Parent):
-    parent_type: Literal[ParentType.LLM] = field(init=False, default=ParentType.LLM)
+    type: Literal[ParentType.LLM] = field(init=False, default=ParentType.LLM)
     llm_type_id: str
     llm_invoke_id: str
 

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -48,9 +48,9 @@ class SpatialType(str, Enum):
 @dataclass(frozen=True)
 class SpatialParent:
     def __post_init__(self):
-        if not hasattr(self, "spatial_type"):
+        if not hasattr(self, "type"):
             raise ValueError(
-                f"SpatialParent subclass {self.__class__.__name__} must define a 'spatial_type' field."
+                f"SpatialParent subclass {self.__class__.__name__} must define a 'type' field."
             )
 
     def encode(self):
@@ -107,9 +107,9 @@ class ParentType(str, Enum):
 @dataclass(frozen=True)
 class Parent:
     def __post_init__(self):
-        if not hasattr(self, "parent_type"):
+        if not hasattr(self, "type"):
             raise ValueError(
-                f"Parent subclass {self.__class__.__name__} must define a 'parent_type' field."
+                f"Parent subclass {self.__class__.__name__} must define a 'type' field."
             )
 
     def encode(self):

--- a/packages/railtracks/src/railtracks/events/_base.py
+++ b/packages/railtracks/src/railtracks/events/_base.py
@@ -67,9 +67,7 @@ class MiddlewareSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class NodeSpatialParent(SpatialParent):
-    type: Literal[SpatialType.NODE] = field(
-        init=False, default=SpatialType.NODE
-    )
+    type: Literal[SpatialType.NODE] = field(init=False, default=SpatialType.NODE)
     node_id: str | None
 
 
@@ -93,9 +91,7 @@ class LLMAndMiddlewareSpatialParent(SpatialParent):
 
 @dataclass(frozen=True)
 class NoSpatialParent(SpatialParent):
-    type: Literal[SpatialType.NONE] = field(
-        init=False, default=SpatialType.NONE
-    )
+    type: Literal[SpatialType.NONE] = field(init=False, default=SpatialType.NONE)
 
 
 class ParentType(str, Enum):

--- a/packages/railtracks/src/railtracks/events/registry.py
+++ b/packages/railtracks/src/railtracks/events/registry.py
@@ -54,14 +54,14 @@ def _enum(*members: str) -> ColumnSpec:
 
 # ---- reusable blocks -------------------------------------------------------
 _SPATIAL_PARENT: dict[str, ColumnSpec] = {
-    "spatial_parent_spatial_type": _enum(*(m.value for m in SpatialType)),
+    "spatial_parent_type": _enum(*(m.value for m in SpatialType)),
     "spatial_parent_node_id": STRING,
     "spatial_parent_middleware_invoke_id": STRING,
     "spatial_parent_llm_invoke_id": STRING,
 }
 
 _PARENT: dict[str, ColumnSpec] = {
-    "parent_parent_type": _enum(*(m.value for m in ParentType)),
+    "parent_type": _enum(*(m.value for m in ParentType)),
     "parent_node_id": STRING,
     "parent_middleware_type_id": STRING,
     "parent_middleware_invoke_id": STRING,

--- a/packages/railtracks/tests/unit_tests/events/test_registry.py
+++ b/packages/railtracks/tests/unit_tests/events/test_registry.py
@@ -80,13 +80,13 @@ class TestPayloadColumnsLLM:
 class TestSpatialParentFlattening:
     def test_llm_namespace_exposes_every_spatial_parent_subfield(self):
         cols = payload_columns("llm")
-        assert _kind(cols, "spatial_parent_spatial_type") == ColumnKind.ENUM
+        assert _kind(cols, "spatial_parent_type") == ColumnKind.ENUM
         assert _kind(cols, "spatial_parent_node_id") == ColumnKind.STRING
         assert _kind(cols, "spatial_parent_middleware_invoke_id") == ColumnKind.STRING
         assert _kind(cols, "spatial_parent_llm_invoke_id") == ColumnKind.STRING
 
-    def test_spatial_type_enum_covers_every_subclass_value(self):
-        spec = payload_columns("llm")["spatial_parent_spatial_type"]
+    def test_type_enum_covers_every_subclass_value(self):
+        spec = payload_columns("llm")["spatial_parent_type"]
         assert spec.kind == ColumnKind.ENUM
         assert set(spec.enum_members or ()) == {
             "none",
@@ -105,15 +105,15 @@ class TestSpatialParentFlattening:
 class TestParentFlattening:
     def test_llm_namespace_exposes_every_parent_subfield(self):
         cols = payload_columns("llm")
-        assert _kind(cols, "parent_parent_type") == ColumnKind.ENUM
+        assert _kind(cols, "parent_type") == ColumnKind.ENUM
         assert _kind(cols, "parent_node_id") == ColumnKind.STRING
         assert _kind(cols, "parent_middleware_type_id") == ColumnKind.STRING
         assert _kind(cols, "parent_middleware_invoke_id") == ColumnKind.STRING
         assert _kind(cols, "parent_llm_type_id") == ColumnKind.STRING
         assert _kind(cols, "parent_llm_invoke_id") == ColumnKind.STRING
 
-    def test_parent_type_enum_covers_every_subclass_value(self):
-        spec = payload_columns("llm")["parent_parent_type"]
+    def test_type_enum_covers_every_subclass_value(self):
+        spec = payload_columns("llm")["parent_type"]
         assert spec.kind == ColumnKind.ENUM
         assert set(spec.enum_members or ()) == {"node", "middleware", "llm"}
 
@@ -199,8 +199,8 @@ class TestRegistryCompleteness:
             cols = payload_columns(namespace)
             for f in fields(cls):
                 if f.name == "spatial_parent":
-                    assert "spatial_parent_spatial_type" in cols, cls
+                    assert "spatial_parent_type" in cols, cls
                 elif f.name == "parent":
-                    assert "parent_parent_type" in cols, cls
+                    assert "parent_type" in cols, cls
                 else:
                     assert f.name in cols, f"{cls.__name__}.{f.name} missing"

--- a/packages/railtracks/tests/unit_tests/events/test_send.py
+++ b/packages/railtracks/tests/unit_tests/events/test_send.py
@@ -63,9 +63,9 @@ async def test_pipe_resolves_relationships_and_publishes_payload():
 
     p = ev.payload
     # the resolved relationships flatten into <field>_<subfield> keys
-    assert p["parent_parent_type"] == "node"
+    assert p["parent_type"] == "node"
     assert p["parent_node_id"] == "n1"
-    assert p["spatial_parent_spatial_type"] == "node"
+    assert p["spatial_parent_type"] == "node"
     assert p["spatial_parent_node_id"] == "caller"
     # payload values are passed through untouched: tuple stays tuple, datetime stays datetime
     assert p["args"] == (1,)
@@ -81,7 +81,7 @@ async def test_pipe_root_node_has_no_enclosing_node():
         events = await _emit(NodeInvocation(args=(), kwargs={}))
 
     p = events[0].payload
-    assert p["parent_parent_type"] == "node"
+    assert p["parent_type"] == "node"
     assert p["parent_node_id"] == "root"
-    assert p["spatial_parent_spatial_type"] == "node"
+    assert p["spatial_parent_type"] == "node"
     assert p["spatial_parent_node_id"] is None

--- a/packages/railtracks/tests/unit_tests/query/_events.py
+++ b/packages/railtracks/tests/unit_tests/query/_events.py
@@ -14,9 +14,9 @@ LLM_RESPONSE = {
     "parent_scope_id": None,
     "stamp": "2026-07-10T14:00:00.000+00:00",
     "payload": {
-        "spatial_parent_spatial_type": "node",
+        "spatial_parent_type": "node",
         "spatial_parent_node_id": "node_root",
-        "parent_parent_type": "llm",
+        "parent_type": "llm",
         "parent_llm_type_id": "llm_type_a",
         "parent_llm_invoke_id": "llm_invoke_b",
         "timestamp": "2026-07-10T14:00:00.000+00:00",
@@ -38,7 +38,7 @@ LLM_CREATION = {
     "parent_scope_id": None,
     "stamp": "2026-07-10T13:59:59.000+00:00",
     "payload": {
-        "spatial_parent_spatial_type": "none",
+        "spatial_parent_type": "none",
         "timestamp": "2026-07-10T13:59:59.000+00:00",
         "llm_id": "llm_type_a",
         "model_provider": "Anthropic",
@@ -54,7 +54,7 @@ NODE_CREATION = {
     "parent_scope_id": None,
     "stamp": "2026-07-10T14:00:00.100+00:00",
     "payload": {
-        "spatial_parent_spatial_type": "none",
+        "spatial_parent_type": "none",
         "timestamp": "2026-07-10T14:00:00.100+00:00",
         "node_id": "node_root",
         "name": "Root",
@@ -70,7 +70,7 @@ SESSION_STARTED = {
     "parent_scope_id": None,
     "stamp": "2026-07-10T13:59:58.000+00:00",
     "payload": {
-        "spatial_parent_spatial_type": "none",
+        "spatial_parent_type": "none",
         "timestamp": "2026-07-10T13:59:58.000+00:00",
         "session_id": "sess_a1",
         "flow_name": "demo_flow",

--- a/packages/railtracks/tests/unit_tests/query/test_connect.py
+++ b/packages/railtracks/tests/unit_tests/query/test_connect.py
@@ -178,7 +178,7 @@ class TestEnumColumns:
         _write(f, [LLM_RESPONSE])
         with closing(connect(f, ["llm"])) as q:
             (col_type,) = q.con.execute(
-                "SELECT typeof(spatial_parent_spatial_type) FROM llm LIMIT 1"
+                "SELECT typeof(spatial_parent_type) FROM llm LIMIT 1"
             ).fetchone()
             assert col_type.startswith("ENUM(")
             for member in ("'none'", "'node'", "'middleware'"):
@@ -189,7 +189,7 @@ class TestEnumColumns:
         _write(f, [LLM_RESPONSE])
         with closing(connect(f, ["llm"])) as q:
             (value,) = q.con.execute(
-                "SELECT spatial_parent_spatial_type FROM llm LIMIT 1"
+                "SELECT spatial_parent_type FROM llm LIMIT 1"
             ).fetchone()
             assert value == "node"  # enum compares equal to its string value
 
@@ -201,14 +201,14 @@ class TestEnumColumns:
             "event_id": "evt_stale",
             "payload": {
                 **LLM_RESPONSE["payload"],
-                "spatial_parent_spatial_type": "some_future_kind",
+                "spatial_parent_type": "some_future_kind",
             },
         }
         f = tmp_path / "e.jsonl"
         _write(f, [LLM_RESPONSE, stale])
         with closing(connect(f, ["llm"])) as q:
             rows = q.con.execute(
-                "SELECT event_id, spatial_parent_spatial_type FROM llm ORDER BY event_id"
+                "SELECT event_id, spatial_parent_type FROM llm ORDER BY event_id"
             ).fetchall()
             assert rows == [
                 ("evt_llm_1", "node"),
@@ -222,7 +222,7 @@ class TestFlatSpatialParent:
         _write(f, [LLM_RESPONSE])
         with closing(connect(f, ["llm"])) as q:
             row = q.con.execute(
-                "SELECT spatial_parent_spatial_type, spatial_parent_node_id FROM llm"
+                "SELECT spatial_parent_type, spatial_parent_node_id FROM llm"
             ).fetchone()
             assert row == ("node", "node_root")
 
@@ -233,7 +233,7 @@ class TestFlatParent:
         _write(f, [LLM_RESPONSE])
         with closing(connect(f, ["llm"])) as q:
             row = q.con.execute(
-                "SELECT parent_parent_type, parent_llm_type_id, parent_llm_invoke_id FROM llm"
+                "SELECT parent_type, parent_llm_type_id, parent_llm_invoke_id FROM llm"
             ).fetchone()
             assert row == ("llm", "llm_type_a", "llm_invoke_b")
 

--- a/packages/railtracks/tests/unit_tests/query/test_schema.py
+++ b/packages/railtracks/tests/unit_tests/query/test_schema.py
@@ -37,14 +37,14 @@ class TestDuckdbColumnsFlattening:
 
 class TestDuckdbEnumColumns:
     def test_spatial_type_discriminator_is_enum(self):
-        col = duckdb_columns("llm")["spatial_parent_spatial_type"]
+        col = duckdb_columns("llm")["spatial_parent_type"]
         assert col.startswith("ENUM(")
         # Every SpatialParent subclass value must be represented.
         for member in ("'none'", "'node'", "'middleware'", "'node_and_middleware'", "'llm_and_middleware'"):
             assert member in col
 
     def test_parent_type_discriminator_is_enum(self):
-        col = duckdb_columns("llm")["parent_parent_type"]
+        col = duckdb_columns("llm")["parent_type"]
         assert col.startswith("ENUM(")
         for member in ("'node'", "'middleware'", "'llm'"):
             assert member in col


### PR DESCRIPTION
## Summary

We did not be extra clear to identify the type of parent since that was in the object itself when it was flattened. 

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

<!-- Optional: usage examples, screenshots, perf/security considerations. -->
