### PR TITLE
Timeout+remove typseract.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,7 @@ jobs:
   end_to_end_tests:
     name: End to End Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -16,6 +16,7 @@ jobs:
   ruff-lint:
     name: Check Code Formatting and Linting with Ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout Code
@@ -38,6 +39,7 @@ jobs:
   check-licenses:
     name: Check Licenses
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -74,6 +76,7 @@ jobs:
   changes:
     name: Detect Changed Areas
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       core: ${{ steps.filter.outputs.core }}
       retrieval: ${{ steps.filter.outputs.retrieval }}
@@ -105,6 +108,7 @@ jobs:
   unit_tests:
     name: Unit Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - ruff-lint
       - check-licenses
@@ -143,6 +147,7 @@ jobs:
   retrieval_tests:
     name: Retrieval Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - ruff-lint
       - check-licenses
@@ -157,11 +162,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
-
-      - name: Install Tesseract OCR binary
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tesseract-ocr
 
       - name: Install dependencies
         uses: ./.github/actions/install-deps
@@ -178,6 +178,7 @@ jobs:
   documentation_validation:
     name: Documentation Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - ruff-lint
       - check-licenses
@@ -207,6 +208,7 @@ jobs:
   pyproject_dependency_order:
     name: Validate pyproject.toml Dependency Order
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - ruff-lint
       - check-licenses

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -15,6 +15,7 @@ jobs:
   ruff-lint:
     name: Check Code Formatting and Linting with Ruff
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout Code
@@ -37,6 +38,7 @@ jobs:
   check-licenses:
     name: Check Licenses
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v5
@@ -64,6 +66,7 @@ jobs:
   documentation_validation:
     name: Documentation Validation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - ruff-lint
       - check-licenses
@@ -90,6 +93,7 @@ jobs:
   pyproject_dependency_order:
     name: Validate pyproject.toml Dependency Order
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs:
       - ruff-lint
       - check-licenses
@@ -118,6 +122,7 @@ jobs:
   tests:
     name: Tests
     runs-on: windows-latest
+    timeout-minutes: 30
     needs:
       - ruff-lint
       - check-licenses
@@ -152,6 +157,7 @@ jobs:
   retrieval_tests:
     name: Retrieval Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - ruff-lint
       - check-licenses
@@ -166,11 +172,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
-
-      - name: Install Tesseract OCR binary
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tesseract-ocr
 
       - name: Install dependencies
         uses: ./.github/actions/install-deps


### PR DESCRIPTION
Removing Tesseract OCR binary because 1. we are not using it, 2. sometime it hangs indefinity. 

We also added timeout to each component to ensure infinite runs no longer occur, 

Closes #1418 