### PR TITLE
fix: stop hardcoding openai/ prefix in OpenAICompatibleProvider (#1437)

### DIFF
--- a/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
@@ -38,14 +38,9 @@ class OpenAICompatibleProvider(ProviderLLMWrapper, ABC):
             every hyperparameter, valid or not, is passed straight through and any
             error surfaces from the gateway or upstream provider directly.
         """
-        # litellm's own routing (get_llm_provider) hard-fails on model names it
-        # doesn't recognize unless told what protocol to use, and gateway model
-        # names (Portkey, Telus, arbitrary custom deployments) are never in its
-        # catalog. custom_llm_provider is that hint, forced here (not left to
-        # kwargs) since "openai" is the entire premise of this wrapper class.
-        # Passed as a completion kwarg rather than baked into the model name
-        # string, so self._model_name stays the true model name for telemetry
-        # and visualization (see #1437).
+        # litellm needs to be told this is an OpenAI-compatible endpoint to route the
+        # call at all. Forced as a kwarg here instead of baked into the model name
+        # string, so the true model name survives for telemetry/visualization (#1437).
         kwargs["custom_llm_provider"] = "openai"
         super().__init__(
             model_name,

--- a/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
@@ -40,7 +40,7 @@ class OpenAICompatibleProvider(ProviderLLMWrapper, ABC):
         """
         # litellm needs to be told this is an OpenAI-compatible endpoint to route the
         # call at all. Forced as a kwarg here instead of baked into the model name
-        # string, so the true model name survives for telemetry/visualization (#1437).
+        # string, so the true model name survives for telemetry/visualization.
         kwargs["custom_llm_provider"] = "openai"
         super().__init__(
             model_name,

--- a/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/api_providers/_openai_compatable_provider_wrapper.py
@@ -38,6 +38,15 @@ class OpenAICompatibleProvider(ProviderLLMWrapper, ABC):
             every hyperparameter, valid or not, is passed straight through and any
             error surfaces from the gateway or upstream provider directly.
         """
+        # litellm's own routing (get_llm_provider) hard-fails on model names it
+        # doesn't recognize unless told what protocol to use, and gateway model
+        # names (Portkey, Telus, arbitrary custom deployments) are never in its
+        # catalog. custom_llm_provider is that hint, forced here (not left to
+        # kwargs) since "openai" is the entire premise of this wrapper class.
+        # Passed as a completion kwarg rather than baked into the model name
+        # string, so self._model_name stays the true model name for telemetry
+        # and visualization (see #1437).
+        kwargs["custom_llm_provider"] = "openai"
         super().__init__(
             model_name,
             api_base=api_base,
@@ -55,7 +64,7 @@ class OpenAICompatibleProvider(ProviderLLMWrapper, ABC):
         )
 
     def full_model_name(self, model_name: str) -> str:
-        return f"openai/{model_name}"
+        return model_name
 
     @classmethod
     def model_gateway(cls) -> ModelProvider:

--- a/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_openai_compatible_provider.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_openai_compatible_provider.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+
+import litellm
+from railtracks.llm.models.api_providers._openai_compatable_provider_wrapper import (
+    OpenAICompatibleProvider,
+)
+from railtracks.llm.providers import ModelProvider
+
+MODEL_NAME = "mistral-large-custom-deploy"
+API_BASE = "https://gw.example.com/v1"
+
+
+def test_model_gateway_is_unknown():
+    assert OpenAICompatibleProvider.model_gateway() == ModelProvider.UNKNOWN
+
+
+def test_full_model_name_is_identity():
+    """The model name reported to callers/telemetry must be exactly what the user
+    configured - OpenAICompatibleProvider must not inject a fake `openai/` prefix,
+    since there's no real "openai" model behind these gateways (see #1437)."""
+    llm = OpenAICompatibleProvider(MODEL_NAME, api_base=API_BASE, api_key="test-key")
+    assert llm.model_name() == MODEL_NAME
+
+
+def test_custom_llm_provider_passed_to_litellm_completion(message_history):
+    """litellm's own routing (get_llm_provider) hard-fails on unrecognized model
+    names without a provider hint. OpenAICompatibleProvider must supply that hint
+    via the `custom_llm_provider` completion kwarg, not by mutating the model
+    name string (see #1437)."""
+    with patch.object(litellm, "completion") as mock_completion:
+        mock_completion.return_value = litellm.utils.ModelResponse(
+            choices=[{"message": {"content": "ok"}}]
+        )
+        llm = OpenAICompatibleProvider(MODEL_NAME, api_base=API_BASE, api_key="test-key")
+        llm.chat(message_history)
+
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs.get("model") == MODEL_NAME
+        assert mock_completion.call_args.kwargs.get("custom_llm_provider") == "openai"
+
+
+def test_custom_llm_provider_cannot_be_overridden(message_history):
+    """`custom_llm_provider` is the entire mechanism keeping litellm routing
+    working for this class - a caller passing a different value must not be able
+    to break it."""
+    with patch.object(litellm, "completion") as mock_completion:
+        mock_completion.return_value = litellm.utils.ModelResponse(
+            choices=[{"message": {"content": "ok"}}]
+        )
+        llm = OpenAICompatibleProvider(
+            MODEL_NAME,
+            api_base=API_BASE,
+            api_key="test-key",
+            custom_llm_provider="anthropic",
+        )
+        llm.chat(message_history)
+
+        assert mock_completion.call_args.kwargs.get("custom_llm_provider") == "openai"

--- a/packages/railtracks/tests/unit_tests/llm/models/cloud/test_portkey.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/cloud/test_portkey.py
@@ -55,3 +55,34 @@ def test_temperature_passed_to_litellm_completion(message_history):
             mock_completion.assert_called_once()
             assert mock_completion.call_args.kwargs.get("temperature") == 0.6
 
+
+def test_model_name_has_no_fake_openai_prefix():
+    """PortKeyLLM must report the model name the caller configured - not a fake
+    'openai/' prefix baked in for litellm's routing (see #1437)."""
+    mock_portkey = MagicMock()
+    mock_portkey.base_url = "https://api.portkey.ai"
+    mock_portkey.api_key = "test_key"
+    with patch("portkey_ai.Portkey", return_value=mock_portkey):
+        llm = PortKeyLLM(model_name=MODEL_NAME, api_key="test_key")
+        assert llm.model_name() == MODEL_NAME
+
+
+def test_custom_llm_provider_passed_to_litellm_completion(message_history):
+    """The 'openai' routing hint litellm needs for gateway calls must be sent as
+    a completion kwarg, not baked into the model name string (see #1437)."""
+    mock_portkey = MagicMock()
+    mock_portkey.base_url = "https://api.portkey.ai"
+    mock_portkey.api_key = "test_key"
+    with patch("portkey_ai.Portkey", return_value=mock_portkey):
+        with patch.object(litellm, "completion") as mock_completion:
+            mock_completion.return_value = litellm.utils.ModelResponse(
+                choices=[{"message": {"content": "ok"}}]
+            )
+            llm = PortKeyLLM(model_name=MODEL_NAME, api_key="test_key")
+            llm.chat(message_history)
+            mock_completion.assert_called_once()
+            assert mock_completion.call_args.kwargs.get("model") == MODEL_NAME
+            assert (
+                mock_completion.call_args.kwargs.get("custom_llm_provider") == "openai"
+            )
+

--- a/packages/railtracks/tests/unit_tests/llm/models/cloud/test_telus.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/cloud/test_telus.py
@@ -1,0 +1,62 @@
+import os
+from unittest.mock import patch
+
+import litellm
+import pytest
+from railtracks.llm.models.cloud import TelusLLM
+from railtracks.llm.providers import ModelProvider
+
+MODEL_NAME = "telus/llama-3-70b"
+API_BASE = "https://telus.example.com/v1"
+
+
+def test_model_gateway():
+    assert TelusLLM.model_gateway() == ModelProvider.TELUS
+
+
+def test_init_success_with_env_api_key():
+    with patch.dict(os.environ, {"TELUS_API_KEY": "hello world"}, clear=True):
+        llm = TelusLLM(model_name=MODEL_NAME, api_base=API_BASE)
+        assert llm.api_key == "hello world"
+
+
+def test_init_missing_api_key():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(
+            KeyError, match="Please set the TELUS_API_KEY environment variable"
+        ):
+            TelusLLM(model_name=MODEL_NAME, api_base=API_BASE)
+
+
+def test_model_name_has_no_fake_openai_prefix():
+    """TelusLLM must report the model name the caller configured - not a fake
+    'openai/' prefix baked in for litellm's routing (see #1437)."""
+    llm = TelusLLM(model_name=MODEL_NAME, api_base=API_BASE, api_key="test_key")
+    assert llm.model_name() == MODEL_NAME
+
+
+def test_custom_llm_provider_passed_to_litellm_completion(message_history):
+    """The 'openai' routing hint litellm needs for gateway calls must be sent as
+    a completion kwarg, not baked into the model name string (see #1437)."""
+    with patch.object(litellm, "completion") as mock_completion:
+        mock_completion.return_value = litellm.utils.ModelResponse(
+            choices=[{"message": {"content": "ok"}}]
+        )
+        llm = TelusLLM(model_name=MODEL_NAME, api_base=API_BASE, api_key="test_key")
+        llm.chat(message_history)
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs.get("model") == MODEL_NAME
+        assert mock_completion.call_args.kwargs.get("custom_llm_provider") == "openai"
+
+
+def test_temperature_passed_to_litellm_completion(message_history):
+    with patch.object(litellm, "completion") as mock_completion:
+        mock_completion.return_value = litellm.utils.ModelResponse(
+            choices=[{"message": {"content": "ok"}}]
+        )
+        llm = TelusLLM(
+            model_name=MODEL_NAME, api_base=API_BASE, api_key="test_key", temperature=0.6
+        )
+        llm.chat(message_history)
+        mock_completion.assert_called_once()
+        assert mock_completion.call_args.kwargs.get("temperature") == 0.6


### PR DESCRIPTION
## What
`OpenAICompatibleProvider.full_model_name` baked a fake `openai/` prefix into the configured model name so litellm could route calls to gateway-style endpoints (Portkey, Telus, custom deployments). That mutated name is what
`model.model_name()` reports for telemetry, and what visualization falls back to before a real response lands, so every gateway-routed model showed up as `openai/<model>` regardless of what was actually behind the gateway.

## Fix
`full_model_name` is now identity. The `openai` routing hint litellm needs is passed separately as a `custom_llm_provider` completion kwarg instead (routes identically on the wire, verified against litellm 1.89.0) — so `self._model_name`
stays the true configured name everywhere it's read.

## Tests
Added coverage for `OpenAICompatibleProvider` and `PortKeyLLM`/`TelusLLM` model name + routing behavior. 

**Note**: `TelusLLM` had zero test coverage before this, those tests are incidental coverage added alongside the fix, not themselves part of the bug.

Fixes #1437