### PR TITLE
fix: [General] Documentation Link in Creating an issue goes to re

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: https://github.com/RailtownAI/railtracks/blob/main/README.md
+    url: https://docs.railtracks.org/
     about: Read the documentation and examples for railtracks


### PR DESCRIPTION
Fixes #956

Changed the Documentation contact link in `.github/ISSUE_TEMPLATE/config.yml` to point to the railtracks docs site (https://docs.railtracks.org/) instead of the GitHub README, so the "Creating an issue" page links to the docs as requested.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.