### PR TITLE
fix copilot and stuff

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -210,13 +210,14 @@ Steps 3 and 4 are gated on changed paths, so a docs-only PR skips the test suite
 - **Flows** wrap an agent or async function as the entry point and handle execution, config, and context.
 - **`rt.call()`** is used inside async workflows to call agents or nodes directly.
 
-### Agent Type Selection
-| Has `tool_nodes`? | Has `output_schema`? | Agent type |
-|---|---|---|
-| No | No | `TerminalLLM` — plain chat |
-| No | Yes | `StructuredLLM` — structured output, no tools |
-| Yes | No | `ToolCallLLM` — tools, text output |
-| Yes | Yes | `StructuredToolCallLLM` — tools + structured output |
+### What `agent_node` builds
+`rt.agent_node()` builds one node behind the scenes — there is no separate named type to pick. What you pass changes what the agent does at runtime:
+
+| Passed | Behaviour |
+|---|---|
+| Neither `tool_nodes` nor `output_schema` | Plain chat, text output |
+| `output_schema` only | Structured output, no tools |
+| `tool_nodes` only | Tool-calling loop, text output |
 
 ### LLM Providers
 
@@ -240,8 +241,7 @@ rt.llm.OpenAICompatibleProvider(
    - Real implementation (or a clear stub with a TODO if the user needs to fill it in)
 4. **Define the agent** — call `rt.agent_node()` with (note: it returns a class/type, so use PascalCase for the variable name):
    - A descriptive name
-   - `tool_nodes` listing the tools (if any)
-   - `output_schema` as a Pydantic `BaseModel` (if structured output is needed)
+   - `tool_nodes` listing the tools (if any), **or** `output_schema` as a Pydantic `BaseModel` for structured output — one or the other, never both
    - `llm` — default to `rt.llm.AnthropicLLM("claude-sonnet-4-6")` unless the user specifies otherwise
    - `system_message` — a clear, specific system prompt
 5. **Wrap in a Flow** — create `rt.Flow(name="...", entry_point=agent)` for simple cases. For multi-step or multi-agent workflows, define an `async def` function as the entry point and use `await rt.call(agent, ...)` inside it.
@@ -295,7 +295,6 @@ class Output(BaseModel):
 StructuredAgent = rt.agent_node(
     "Structured Agent",
     output_schema=Output,
-    tool_nodes=[my_tool],
     llm=llm,
 )
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,10 +134,6 @@ print('✓ Basic functionality test passed!')
 
 ## Common Issues and Workarounds
 
-### `RuntimeError` from `Flow.invoke()`
-
-`Flow.invoke()` is the synchronous entry point and cannot run inside an already-running event loop (Jupyter, FastAPI handlers, another async function). Use `await flow.ainvoke(...)` there instead.
-
 ### `ModuleNotFoundError` for an optional dependency
 
 Heavy dependencies are gated behind extras and exposed via lazy module-level `__getattr__` imports. If an import fails, install the extra that owns it (e.g. `railtracks[retrieval]`, `railtracks[visual]`) rather than adding a top-level import.
@@ -186,6 +182,7 @@ Steps 3 and 4 are gated on changed paths, so a docs-only PR skips the test suite
 - Add SDK dependencies in `packages/railtracks/pyproject.toml`, keeping each list sorted. Optional/heavy dependencies go under `optional-dependencies`.
 - Keep the base import light: gate heavy dependencies behind extras with module-level `__getattr__` lazy imports plus a `TYPE_CHECKING` block, not top-level imports.
 - Update `docs/` alongside any feature change.
+- Use `await flow.ainvoke(...)` in async code and `flow.invoke(...)` in sync code. `invoke()` also works inside a running event loop, dispatching to a worker thread with contextvars copied across.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,16 +1,210 @@
 # Railtracks Development Instructions
 
-**Always reference these instructions first and fallback to search or bash commands only when you encounter unexpected information that does not match the info here.**
+**Always reference these instructions first and fall back to search or bash commands only when you encounter unexpected information that does not match the info here.**
 
 ## Repository Overview
 
-Railtracks is a Python framework for building agentic systems. This is a monorepo with two packages:
-- `packages/railtracks/` - Core SDK with optional LLM, MCP, and integration features
-- `packages/railtracks-cli/` - Command-line visualization and development tools
+Railtracks is a Python framework for building agentic systems. The repository is a `uv` workspace containing a single published package:
+
+- `packages/railtracks/` — the SDK. Everything public is re-exported at the package root and used as `import railtracks as rt`.
+
+The root `pyproject.toml` holds workspace config and dev tooling only (`docs`, `test`, `lint` dependency groups). Package dependencies — including every optional extra — live in `packages/railtracks/pyproject.toml`.
+
+## Working Effectively
+
+### Prerequisites
+
+- Python 3.10+ (`requires-python = ">=3.10"`). CI runs 3.10.
+- [`uv`](https://docs.astral.sh/uv/) for dependency management.
+
+### Development Environment Setup
+
+```bash
+uv sync --group dev                              # docs + test + lint tooling
+uv pip install -e "packages/railtracks[all]"     # SDK with all optional extras
+```
+
+The SDK is deliberately thin by default; features gate behind extras declared in `packages/railtracks/pyproject.toml` (`visual`, `retrieval`, `chroma`, `portkey`, `stores-*`, …).
+
+**`retrieval` is not part of `[all]`.** Install it explicitly when working on the RAG stack:
+
+```bash
+uv pip install -e "packages/railtracks[all,retrieval]"
+```
+
+### Build and Test Commands
+
+#### Linting and formatting (runs in ~1 second)
+
+`ruff` is configured in the root `pyproject.toml`: line-length 88, target `py310`.
+
+```bash
+# What CI checks
+ruff check . --no-fix
+ruff format --check .
+
+# What you run locally to fix it
+ruff check --fix
+ruff format
+```
+
+#### Testing (pytest, `asyncio_mode = "auto"`)
+
+Live LLM tests (`tests/llm_live_tests`) and retrieval end-to-end tests are excluded by `addopts` in the root `pyproject.toml`, so a bare `pytest` never needs an API key.
+
+```bash
+# The core suite, matching CI
+pytest -s -v \
+  --ignore=packages/railtracks/tests/unit_tests/retrieval \
+  packages/railtracks/tests/unit_tests/ packages/railtracks/tests/integration_tests/
+
+# Retrieval suite (needs the retrieval extra)
+pytest -s -v packages/railtracks/tests/unit_tests/retrieval/
+
+# A single test
+pytest packages/railtracks/tests/unit_tests/path/to/test_file.py::test_name
+```
+
+**Test mode:** `packages/railtracks/tests/conftest.py` auto-sets `RAILTRACKS_TEST_MODE=1`, which disables session persistence so no `.railtracks/` directory is written during a test run. A test that must verify persistence opts back in with the `allow_persistence` fixture.
+
+#### Documentation
+
+```bash
+mkdocs build             # build the site
+mkdocs serve             # preview at localhost:8000
+./scripts/docs_validation.sh   # type-checks every script under docs/scripts/
+```
+
+Update `docs/` whenever you add or change a feature, and verify the render.
+
+#### Dependency ordering
+
+```bash
+python scripts/check_dependencies_sorted.py
+```
+
+Dependencies in `packages/railtracks/pyproject.toml` must stay sorted; CI enforces this.
+
+### CLI
+
+The CLI ships inside the SDK at `packages/railtracks/src/railtracks/cli/`.
+
+```bash
+railtracks init          # create .railtracks/ and download the visualizer UI
+railtracks update        # update the visualizer UI
+railtracks viz           # start the visualizer (requires railtracks[visual])
+railtracks add --list    # list the bundled coding-assistant skills
+railtracks add claude:agent-builder   # install a skill for a given assistant
+```
+
+`init` and `update` download UI assets from a CDN and will fail in sandboxed environments with no network access — expected, not a bug.
+
+## Validation Scenarios
+
+**Always run these after making code changes:**
+
+1. **Lint:** `ruff check . --no-fix && ruff format --check .`
+2. **Core tests:** the core-suite command above
+3. **Dependency order:** `python scripts/check_dependencies_sorted.py`
+4. **Docs:** `mkdocs build` and `./scripts/docs_validation.sh` if you touched `docs/`
+5. **Smoke test:** the snippet below
+
+**NEVER SKIP** the lint step — CI fails without it.
+
+```bash
+python -c "
+import railtracks as rt
+
+def number_of_chars(text: str) -> int:
+    '''Count the characters in some text.
+
+    Args:
+        text: The text to measure.
+    Returns:
+        The character count.
+    '''
+    return len(text)
+
+CharCount = rt.function_node(number_of_chars)
+flow = rt.Flow(name='Char Count', entry_point=CharCount)
+assert flow.invoke('hello') == 5
+print('✓ Basic functionality test passed!')
+"
+```
+
+## Common Issues and Workarounds
+
+### `RuntimeError` from `Flow.invoke()`
+
+`Flow.invoke()` is the synchronous entry point and cannot run inside an already-running event loop (Jupyter, FastAPI handlers, another async function). Use `await flow.ainvoke(...)` there instead.
+
+### `ModuleNotFoundError` for an optional dependency
+
+Heavy dependencies are gated behind extras and exposed via lazy module-level `__getattr__` imports. If an import fails, install the extra that owns it (e.g. `railtracks[retrieval]`, `railtracks[visual]`) rather than adding a top-level import.
+
+### `railtracks init` fails with a hostname error
+
+The CLI downloads visualizer assets from a CDN. This is expected in network-restricted environments.
+
+### Test failures
+
+All tests should pass. Focus on introducing no new failures; occasional flakes in LLM-touching tests come from model stochasticity.
+
+## Repository Structure Reference
+
+```
+railtracks/
+├── packages/
+│   └── railtracks/              # the SDK package
+│       ├── src/railtracks/      # Python module
+│       ├── tests/               # unit / integration / end_to_end / llm_live_tests
+│       └── pyproject.toml       # package + extras config
+├── docs/                        # MkDocs documentation
+├── examples/                    # code examples and demos
+├── scripts/                     # development and CI scripts
+├── mkdocs.yml                   # documentation config
+├── pyproject.toml               # workspace + dev tooling config (not package deps)
+└── uv.lock
+```
+
+## CI Pipeline Matching
+
+`.github/workflows/pr_tests.yaml` runs on `ubuntu-latest`:
+
+1. **Ruff lint** — `ruff check . --no-fix` and `ruff format --check .`
+2. **License check** — `scripts/check_licenses.sh`
+3. **Unit tests** — only when core source or tests changed
+4. **Retrieval tests** — only when `retrieval/` source or tests changed
+5. **Documentation validation** — `scripts/docs_validation.sh`
+6. **pyproject dependency order** — `scripts/check_dependencies_sorted.py`
+
+Steps 3 and 4 are gated on changed paths, so a docs-only PR skips the test suites.
+
+## Conventions
+
+- Branch naming: `feature/<issue_id>/<name>`.
+- Add SDK dependencies in `packages/railtracks/pyproject.toml`, keeping each list sorted. Optional/heavy dependencies go under `optional-dependencies`.
+- Keep the base import light: gate heavy dependencies behind extras with module-level `__getattr__` lazy imports plus a `TYPE_CHECKING` block, not top-level imports.
+- Update `docs/` alongside any feature change.
+
+---
 
 ## Railtracks Framework Concepts
 
-### How Railtracks Works
+<!--
+  GENERATED — do not edit by hand.
+
+  The section below is the bundled `agent-builder` skill
+  (packages/railtracks/src/railtracks/cli/skills/agent-builder.md). Edit that file,
+  then regenerate from the repository root with:
+
+      railtracks add copilot:agent-builder --force
+-->
+
+<!-- railtracks:agent-builder:start -->
+# Build a Railtracks Agent
+
+## How railtracks works
 - **Tools** are plain Python functions decorated with `@rt.function_node`. Type hints become the parameter schema; the docstring becomes the description.
 - **Agents** are created with `rt.agent_node()`. The type is auto-selected based on whether tools and/or a structured output schema are provided.
 - **Flows** wrap an agent or async function as the entry point and handle execution, config, and context.
@@ -25,16 +219,40 @@ Railtracks is a Python framework for building agentic systems. This is a monorep
 | Yes | Yes | `StructuredToolCallLLM` — tools + structured output |
 
 ### LLM Providers
+
 ```python
 rt.llm.AnthropicLLM("claude-sonnet-4-6")
 rt.llm.OpenAILLM("gpt-5")
 rt.llm.GeminiLLM("gemini-3-flash-preview")
-rt.llm.OpenAICompatibleProvider(base_url="...", model="...")
+rt.llm.OpenAICompatibleProvider(
+    "my-model", api_base="https://api.example.com/v1", api_key="..."
+)
 ```
 
-### Agent Patterns
+---
 
-#### Simple Agent with Tools
+## Steps
+1. **Read the existing code** — check what files already exist in the project. Understand the task before writing anything.
+2. **Identify what tools the agent needs** — each capability the agent should have becomes a `@rt.function_node`. Ask the user to clarify if it's not obvious from the request.
+3. **Define the tools** — write each tool as a Python function with:
+   - Full type hints on all parameters and return value
+   - A docstring with a one-line summary and `Args:` / `Returns:` sections
+   - Real implementation (or a clear stub with a TODO if the user needs to fill it in)
+4. **Define the agent** — call `rt.agent_node()` with (note: it returns a class/type, so use PascalCase for the variable name):
+   - A descriptive name
+   - `tool_nodes` listing the tools (if any)
+   - `output_schema` as a Pydantic `BaseModel` (if structured output is needed)
+   - `llm` — default to `rt.llm.AnthropicLLM("claude-sonnet-4-6")` unless the user specifies otherwise
+   - `system_message` — a clear, specific system prompt
+5. **Wrap in a Flow** — create `rt.Flow(name="...", entry_point=agent)` for simple cases. For multi-step or multi-agent workflows, define an `async def` function as the entry point and use `await rt.call(agent, ...)` inside it.
+6. **Add invocation code** — include a `if __name__ == "__main__":` block that calls `flow.invoke(...)` with a representative example so the user can run it immediately.
+7. **Check imports** — make sure `import railtracks as rt` is at the top and any Pydantic models import `from pydantic import BaseModel`.
+
+---
+
+## Patterns to Follow
+### Simple Agent with Tools
+
 ```python
 import railtracks as rt
 
@@ -64,7 +282,7 @@ if __name__ == "__main__":
     print(result)
 ```
 
-#### Structured Output
+### Structured Output
 ```python
 from pydantic import BaseModel
 
@@ -82,7 +300,7 @@ StructuredAgent = rt.agent_node(
 )
 ```
 
-#### Multi-Agent Workflow
+### Multi-Agent Workflow
 ```python
 @rt.function_node
 async def pipeline(query: str):
@@ -94,7 +312,9 @@ async def pipeline(query: str):
 flow = rt.Flow(name="Pipeline", entry_point=pipeline)
 ```
 
-#### Agent as a Tool (Multi-Agent Orchestration)
+### Agent Used as a Tool by Another Agent (Multi-Agent Orchestration)
+
+To expose an agent as a callable tool for another agent, pass a `rt.ToolManifest` to `agent_node`. The manifest defines how the agent appears in the tool list of its caller — its description and parameters. Without a manifest, railtracks won't know how to present the agent as a tool.
 ```python
 from railtracks.llm import Parameter
 
@@ -118,10 +338,14 @@ Orchestrator = rt.agent_node(
     system_message="You are an orchestrator. Delegate to sub-agents as needed.",
 )
 ```
+`Parameter` fields:
+- `name` — the argument name the orchestrator LLM passes
+- `description` — explains what to put in this argument
+- `param_type` — JSON schema type string (`"string"`, `"integer"`, `"number"`, `"boolean"`, …) **or** a Python builtin mapped the same way: `str`, `int`, `float` (→ `"number"`), `bool`, `list` / `tuple` / `set` (→ `"array"`), `dict` (→ `"object"`), `type(None)` (→ `"null"`). Unknown types fall back to `"object"`.
+- `required` — defaults to `True`
+- `enum` — optional list of allowed values
 
-`Parameter.param_type` may be a JSON schema type string (e.g. `"string"`) or a Python builtin (`str`, `int`, …) mapped to the same schema types.
-
-#### MCP Tools
+### MCP Tools
 ```python
 server = rt.connect_mcp(
     rt.MCPStdioParams(command="python", args=["-m", "my_mcp_server"])
@@ -129,210 +353,11 @@ server = rt.connect_mcp(
 agent = rt.agent_node("MCP Agent", tool_nodes=server.tools, llm=llm)
 ```
 
-### Things to Avoid
+---
+
+## Things to Avoid
 - Don't use vague docstrings — the docstring is the tool description the LLM sees.
 - Don't skip type hints — they define the tool's parameter schema.
 - Don't create a `Flow` and a manual `await rt.call()` for the same agent at the top level — pick one entry point.
 - Don't add unnecessary tools. Only give the agent what it needs.
-
----
-
-## Working Effectively
-
-### Prerequisites and Setup
-- Python 3.10+ required (tested with 3.12.3)
-
-### Development Environment Setup
-
-**Option 1: Standard Installation** (recommended when network is reliable)
-```bash
-pip install -r requirements-dev.txt
-```
-
-**Option 2: Manual Installation** (for environments with network limitations)
-```bash
-# Install core development tools first
-pip install ruff pytest pytest-asyncio pytest-cov pytest-timeout
-
-# Install core dependencies manually (due to flit build system requirements)
-pip install colorama pydantic python-dotenv litellm fastapi uvicorn watchdog mcp tomlkit
-
-# Install documentation tools
-pip install mkdocs mkdocs-material mkdocs-material-extensions mkdocs-mermaid2-plugin
-
-# Set Python path for development (use in every session)
-export PYTHONPATH=/home/runner/work/railtracks/railtracks/packages/railtracks/src:/home/runner/work/railtracks/railtracks/packages/railtracks-cli/src:$PYTHONPATH
-```
-
-
-
-### Build and Test Commands
-
-#### Linting (FAST - runs in <1 second)
-```bash
-# Check code style - runs instantly
-ruff check . --no-fix
-
-# Check formatting - runs instantly  
-ruff format --check .
-
-# Fix auto-fixable issues
-ruff check --fix
-
-# Format code
-ruff format
-```
-
-#### Testing (NEVER CANCEL - takes ~10 seconds)
-```bash
-# Run unit tests - NEVER CANCEL, completes in ~10 seconds
-pytest packages/railtracks/tests/unit_tests/ -v --tb=short --timeout=30
-
-# Run all tests including integration tests (requires OPENAI_API_KEY)
-export OPENAI_API_KEY=your_key_here
-pytest -s -v --junit-xml=test-results.xml --timeout=200
-```
-
-**Expected Results**: All 601+ tests should pass, ~9 second runtime. Any failures are typically due to LLM stochasticity and should be minor.
-
-#### Documentation (NEVER CANCEL - takes ~5 seconds)
-```bash
-# Build documentation - NEVER CANCEL, completes in ~5 seconds  
-mkdocs build --strict --verbose
-
-# Serve documentation locally (when not in CI)
-mkdocs serve
-```
-
-#### Dependency Validation
-```bash
-# Check dependency sorting (required for CI)
-python scripts/check_dependencies_sorted.py
-```
-
-### CLI Development and Testing
-
-#### Basic CLI Testing
-```bash
-# Test CLI import
-python -c "import railtracks_cli; print('CLI imported successfully')"
-
-# Show available CLI commands
-python -m railtracks_cli
-
-# Initialize railtracks (fails in limited network environments due to CDN access)
-railtracks init
-
-# Start visualizer (requires successful init first)
-railtracks viz
-```
-
-**Known Issue**: CLI `init` command fails in environments with limited internet access due to CDN dependency for UI components.
-
-### Core Functionality Validation
-
-#### Test Basic Railtracks Operations
-```bash
-# Test basic function nodes
-python -c "
-import railtracks as rt
-
-def multiply(a: float, b: float) -> float:
-    return a * b
-
-MultiplyNode = rt.function_node(multiply)
-result = rt.call_sync(MultiplyNode, a=5.0, b=3.0)
-print(f'Result: {result}')
-assert result == 15.0
-print('✓ Basic functionality test passed!')
-"
-```
-
-#### Test Function Node Creation (from README example)
-```bash
-python -c "
-import railtracks as rt
-
-def number_of_chars(text: str) -> int:
-    return len(text)
-
-def number_of_words(text: str) -> int:
-    return len(text.split())
-
-TotalNumberChars = rt.function_node(number_of_chars)
-TotalNumberWords = rt.function_node(number_of_words)
-print('✓ Function nodes created successfully')
-"
-```
-
-## Validation Scenarios
-
-**ALWAYS run these validation steps after making code changes:**
-
-1. **Linting validation**: `ruff check . --no-fix && ruff format --check .` (takes <1 second)
-2. **Unit tests**: `pytest packages/railtracks/tests/unit_tests/ -v --timeout=30` (takes ~10 seconds)
-3. **Dependency check**: `python scripts/check_dependencies_sorted.py` (takes <1 second)
-4. **Basic functionality**: Run the core functionality validation scripts above
-5. **Documentation build**: `mkdocs build` (takes ~5 seconds)
-
-**NEVER SKIP** the linting validation - the CI will fail without it.
-
-## Common Issues and Workarounds
-
-### Installation Issues
-- **Problem**: `pip install -r requirements-dev.txt` fails with network timeouts  
-- **Solution**: Use manual dependency installation as shown in setup section when network connectivity is limited
-
-### CLI Issues  
-- **Problem**: `railtracks init` fails with "No address associated with hostname"
-- **Explanation**: CLI requires CDN access to download UI components, fails in limited network environments
-- **Workaround**: This is expected in sandboxed environments, document as known limitation
-
-### Import Issues
-- **Problem**: `ModuleNotFoundError: No module named 'railtracks'`
-- **Solution**: Always set PYTHONPATH as shown in setup section for development
-
-### Test Failures
-- **Action**: All tests should pass. Focus on ensuring no new test failures are introduced. Any occasional failures are typically due to LLM stochasticity and should be minor.
-
-## Package Structure Reference
-
-```
-railtracks/
-├── packages/
-│   ├── railtracks/              # Core SDK package  
-│   │   ├── src/railtracks/      # Python module (underscore)
-│   │   ├── tests/               # SDK tests
-│   │   └── pyproject.toml       # Core package config
-│   └── railtracks-cli/          # CLI package
-│       ├── src/railtracks_cli/  # Python module (underscore) 
-│       └── pyproject.toml       # CLI package config
-├── docs/                        # Shared documentation
-├── examples/                    # Code examples and demos
-├── scripts/                     # Development scripts
-├── requirements-dev.txt         # Development dependencies
-├── mkdocs.yml                   # Documentation config
-└── pyproject.toml              # Root workspace config
-```
-
-**Important**: Package names use dashes (`railtracks-cli`) but Python modules use underscores (`railtracks_cli`).
-
-## CI Pipeline Matching
-
-The GitHub Actions workflow runs on Windows and executes:
-1. `ruff check . --no-fix` (linting)  
-2. `ruff format --check .` (formatting)
-3. `python scripts/check_dependencies_sorted.py` (dependency validation)
-4. `pytest -s -v --junit-xml=test-results.xml --timeout=200` (full test suite)
-
-**ALWAYS** run these same commands locally before committing to ensure CI success.
-
-## Time Expectations and Timeouts
-
-- **Linting**: <1 second - no timeout needed
-- **Unit tests**: ~10 seconds - use 30+ second timeout
-- **Full test suite**: ~3-5 minutes - use 200+ second timeout  
-- **Documentation build**: ~5 seconds - use 30+ second timeout
-- **Manual dependency install**: ~2-3 minutes when network is available
-
-**NEVER CANCEL** running builds or tests - they complete quickly. Long timeouts are for safety only.
+<!-- railtracks:agent-builder:end -->

--- a/docs/documentation/getting_started/ai_setup.md
+++ b/docs/documentation/getting_started/ai_setup.md
@@ -84,12 +84,19 @@ pip install 'railtracks[visual]'
 | Flag | Description |
 |---|---|
 | `--force` | Overwrite an existing skill without prompting |
+| `--list` | Print every bundled skill and supported assistant, then exit |
 
 ```bash
 railtracks add --force claude:agent-builder
 ```
 
 ## Available Skills
+
+To see what ships with the version you have installed, ask the CLI:
+
+```bash
+railtracks add --list
+```
 
 | Skill | Description |
 |---|---|

--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -277,6 +277,40 @@ def _load_skill_content(skill_name: str) -> str:
     return skill_file.read_text(encoding="utf-8")
 
 
+def _strip_skill_arguments(content: str) -> str:
+    """Resolve the `$ARGUMENTS` placeholder for targets that never substitute it.
+
+    Claude Code and Codex invoke a skill with arguments, so `$ARGUMENTS` is filled in
+    at call time. Copilot reads `copilot-instructions.md` as always-on repository
+    context instead, so the placeholder would ship to the model literally.
+    """
+    kept: list[str] = []
+    drop_next_blank = False
+    for line in content.splitlines():
+        if drop_next_blank and not line.strip():
+            drop_next_blank = False
+            continue
+        drop_next_blank = False
+
+        if "$ARGUMENTS" not in line:
+            kept.append(line)
+            continue
+
+        # A whole line that only exists to introduce the argument is dropped, along
+        # with the blank line it would otherwise leave behind; an inline mention is
+        # reworded in place.
+        if line.rstrip().endswith(": $ARGUMENTS"):
+            drop_next_blank = bool(kept) and not kept[-1].strip()
+            continue
+
+        kept.append(
+            line.replace("`$ARGUMENTS`", "the request").replace(
+                "$ARGUMENTS", "the request"
+            )
+        )
+    return "\n".join(kept)
+
+
 def _confirm_overwrite(file_path: Path) -> bool:
     """Prompt the user to confirm overwriting an existing file. Returns True to proceed."""
     try:
@@ -344,15 +378,20 @@ def _add_copilot(skill_name: str, meta: dict, content: str, force: bool) -> None
                 sys.exit(0)
             start_idx = existing.index(start_marker)
             end_idx = existing.index(end_marker) + len(end_marker)
-            existing = existing[:start_idx].rstrip() + existing[end_idx:]
-            target.write_text(existing, encoding="utf-8")
+            existing = existing[:start_idx] + existing[end_idx:]
     else:
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text("", encoding="utf-8")
+        existing = ""
 
-    section = f"\n\n{start_marker}\n{content.strip()}\n{end_marker}\n"
-    with open(target, "a", encoding="utf-8") as f:
-        f.write(section)
+    # Rewrite rather than append, so regenerating a skill in place is byte-identical
+    # to installing it fresh and repeated --force runs don't accumulate blank lines.
+    preamble = existing.rstrip()
+    section = (
+        f"{start_marker}\n{_strip_skill_arguments(content).strip()}\n{end_marker}\n"
+    )
+    target.write_text(
+        f"{preamble}\n\n{section}" if preamble else section, encoding="utf-8"
+    )
     print_success(f"Installed '{skill_name}' for GitHub Copilot -> {target}")
 
 
@@ -410,6 +449,27 @@ def add_skill(spec: str, force: bool = False) -> None:
     _TOOL_HANDLERS[tool](skill_name, meta, content, force)
 
 
+def list_skills() -> None:
+    """Print the bundled skills and the assistants they can be installed for."""
+    rst = Style.RESET_ALL
+    bold = Style.BRIGHT
+    dim = Style.DIM
+    cyan = Fore.CYAN
+    green = Fore.GREEN
+
+    print()
+    print(f"  {bold}Available skills:{rst}")
+    print()
+    for skill_name, meta in SKILLS.items():
+        print(f"  {cyan}{bold}{skill_name}{rst}  {dim}{meta['argument_hint']}{rst}")
+        print(f"    {meta['description']}")
+        print()
+    print(f"  {bold}Supported tools:{rst}  {', '.join(SUPPORTED_TOOLS)}")
+    print()
+    print(f"  {dim}Install with:{rst}  {green}{cli_name} add <tool>:<skill>{rst}")
+    print()
+
+
 def _print_help():
     """Print styled help output."""
     rst = Style.RESET_ALL
@@ -442,7 +502,7 @@ def _print_help():
     print(
         cmd(
             "add",
-            f"Install an AI coding assistant skill  {dim}(e.g. {cli_name} add claude:agent-builder){rst}",
+            f"Install an AI coding assistant skill  {dim}(--list to see them all){rst}",
         )
     )
     print()
@@ -475,14 +535,8 @@ def _print_help():
     )
     print(
         example(
-            f"{cli_name} add claude:rag-pipeline",
-            "Install RAG pipeline skill for Claude Code",
-        )
-    )
-    print(
-        example(
-            f"{cli_name} add copilot:rag-pipeline",
-            "Install RAG pipeline skill for GitHub Copilot",
+            f"{cli_name} add --list",
+            "List every bundled skill and supported tool",
         )
     )
     print()
@@ -492,6 +546,25 @@ def _exit_visual_deps_missing() -> None:
     print_error("The visualizer requires optional dependencies.")
     print_status("Install with: pip install 'railtracks[visual]'")
     sys.exit(1)
+
+
+def _run_add(args: list[str]) -> None:
+    """Handle `railtracks add`: either list the bundled skills or install one."""
+    if any(a in ("--list", "-l") for a in args):
+        list_skills()
+        return
+
+    if not args or args[0].startswith("-"):
+        print_error(
+            "Usage: railtracks add [--force] <tool>:<skill> | railtracks add --list"
+        )
+        print_status(f"Supported tools: {', '.join(SUPPORTED_TOOLS)}")
+        print_status(f"Available skills: {', '.join(SKILLS)}")
+        sys.exit(1)
+
+    force = "--force" in args
+    spec = next((a for a in args if not a.startswith("-")), None)
+    add_skill(spec, force=force)
 
 
 def main():
@@ -530,15 +603,7 @@ def main():
         server = RailtracksServer()
         server.start()
     elif command == "add":
-        args = sys.argv[2:]
-        if not args or args[0].startswith("-"):
-            print_error("Usage: railtracks add [--force] <tool>:<skill>")
-            print_status(f"Supported tools: {', '.join(SUPPORTED_TOOLS)}")
-            print_status(f"Available skills: {', '.join(SKILLS)}")
-            sys.exit(1)
-        force = "--force" in args
-        spec = next((a for a in args if not a.startswith("-")), None)
-        add_skill(spec, force=force)
+        _run_add(sys.argv[2:])
     else:
         print(f"{Fore.RED}Unknown command: {command}{Style.RESET_ALL}")
         print(f"{Style.DIM}Available commands: init, update, viz, add{Style.RESET_ALL}")

--- a/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
+++ b/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
@@ -8,13 +8,14 @@ The user wants to build an agent using the railtracks framework: $ARGUMENTS
 - **Flows** wrap an agent or async function as the entry point and handle execution, config, and context.
 - **`rt.call()`** is used inside async workflows to call agents or nodes directly.
 
-### Agent Type Selection
-| Has `tool_nodes`? | Has `output_schema`? | Agent type |
-|---|---|---|
-| No | No | `TerminalLLM` — plain chat |
-| No | Yes | `StructuredLLM` — structured output, no tools |
-| Yes | No | `ToolCallLLM` — tools, text output |
-| Yes | Yes | `StructuredToolCallLLM` — tools + structured output |
+### What `agent_node` builds
+`rt.agent_node()` builds one node behind the scenes — there is no separate named type to pick. What you pass changes what the agent does at runtime:
+
+| Passed | Behaviour |
+|---|---|
+| Neither `tool_nodes` nor `output_schema` | Plain chat, text output |
+| `output_schema` only | Structured output, no tools |
+| `tool_nodes` only | Tool-calling loop, text output |
 
 ### LLM Providers
 
@@ -38,8 +39,7 @@ rt.llm.OpenAICompatibleProvider(
    - Real implementation (or a clear stub with a TODO if the user needs to fill it in)
 4. **Define the agent** — call `rt.agent_node()` with (note: it returns a class/type, so use PascalCase for the variable name):
    - A descriptive name
-   - `tool_nodes` listing the tools (if any)
-   - `output_schema` as a Pydantic `BaseModel` (if structured output is needed)
+   - `tool_nodes` listing the tools (if any), **or** `output_schema` as a Pydantic `BaseModel` for structured output — one or the other, never both
    - `llm` — default to `rt.llm.AnthropicLLM("claude-sonnet-4-6")` unless the user specifies otherwise
    - `system_message` — a clear, specific system prompt
 5. **Wrap in a Flow** — create `rt.Flow(name="...", entry_point=agent)` for simple cases. For multi-step or multi-agent workflows, define an `async def` function as the entry point and use `await rt.call(agent, ...)` inside it.
@@ -93,7 +93,6 @@ class Output(BaseModel):
 StructuredAgent = rt.agent_node(
     "Structured Agent",
     output_schema=Output,
-    tool_nodes=[my_tool],
     llm=llm,
 )
 ```

--- a/packages/railtracks/tests/unit_tests/cli/test_cli.py
+++ b/packages/railtracks/tests/unit_tests/cli/test_cli.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import socket
+import sys
 import tempfile
 import threading
 import unittest
@@ -16,6 +17,8 @@ from unittest.mock import MagicMock, patch
 
 from fastapi.testclient import TestClient
 from railtracks.cli import (
+    SKILLS,
+    SUPPORTED_TOOLS,
     _visual_dependencies_available,
     add_skill,
     check_for_ui_update,
@@ -24,6 +27,7 @@ from railtracks.cli import (
     get_script_directory,
     get_stored_ui_version,
     is_port_in_use,
+    list_skills,
     main,
     save_ui_version,
 )
@@ -341,6 +345,93 @@ class TestSkillInstallers(unittest.TestCase):
 
         self.assertFalse(Path(".claude").exists())
         self.assertFalse(Path(".cursor").exists())
+
+    def test_copilot_resolves_argument_placeholder(self):
+        """Copilot instructions are always-on context, so $ARGUMENTS never survives."""
+        add_skill("copilot:agent-builder")
+
+        content = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
+        self.assertNotIn("$ARGUMENTS", content)
+        self.assertIn("<!-- railtracks:agent-builder:start -->", content)
+        self.assertIn("<!-- railtracks:agent-builder:end -->", content)
+
+    def test_copilot_reinstall_is_idempotent(self):
+        """Regenerating a skill in place must not duplicate it or add blank lines."""
+        add_skill("copilot:agent-builder")
+        first = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
+
+        add_skill("copilot:agent-builder", force=True)
+        second = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
+
+        self.assertEqual(first, second)
+
+    def test_copilot_preserves_surrounding_content(self):
+        """Hand-maintained sections around the markers must survive a regeneration."""
+        target = Path(".github/copilot-instructions.md")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# Hand written preamble\n", encoding="utf-8")
+
+        add_skill("copilot:agent-builder")
+        add_skill("copilot:agent-builder", force=True)
+
+        content = target.read_text(encoding="utf-8")
+        self.assertTrue(content.startswith("# Hand written preamble\n"))
+        self.assertEqual(content.count("<!-- railtracks:agent-builder:start -->"), 1)
+
+    def test_claude_keeps_argument_placeholder(self):
+        """Claude Code substitutes $ARGUMENTS at invocation, so it must be preserved."""
+        add_skill("claude:agent-builder")
+
+        content = Path(".claude/skills/agent-builder/SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("$ARGUMENTS", content)
+
+
+class TestListSkills(unittest.TestCase):
+    """Test `railtracks add --list`"""
+
+    @patch('builtins.print')
+    def test_list_skills_prints_every_registered_skill(self, mock_print):
+        """Every skill in the registry shows up with its description"""
+        list_skills()
+
+        output = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+        for skill_name, meta in SKILLS.items():
+            self.assertIn(skill_name, output)
+            self.assertIn(meta["description"], output)
+
+    @patch('builtins.print')
+    def test_list_skills_prints_supported_tools(self, mock_print):
+        """The skill list is only actionable alongside the tools it installs for"""
+        list_skills()
+
+        output = "\n".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+        for tool in SUPPORTED_TOOLS:
+            self.assertIn(tool, output)
+
+    @patch('railtracks.cli.list_skills')
+    def test_add_list_flag_lists_instead_of_installing(self, mock_list):
+        """`add --list` short-circuits before the <tool>:<skill> requirement"""
+        with patch.object(sys, 'argv', ['railtracks', 'add', '--list']):
+            main()
+
+        mock_list.assert_called_once()
+
+    @patch('railtracks.cli.list_skills')
+    def test_add_short_list_flag(self, mock_list):
+        """`-l` is accepted as the short form"""
+        with patch.object(sys, 'argv', ['railtracks', 'add', '-l']):
+            main()
+
+        mock_list.assert_called_once()
+
+    @patch('railtracks.cli.print_error')
+    def test_add_without_spec_still_errors(self, mock_error):
+        """A bare `add`, or a lone unrelated flag, remains a usage error"""
+        with patch.object(sys, 'argv', ['railtracks', 'add', '--force']):
+            with self.assertRaises(SystemExit):
+                main()
+
+        mock_error.assert_called_once()
 
 
 class TestPortChecking(unittest.TestCase):


### PR DESCRIPTION
## Summary

Repairs `.github/copilot-instructions.md`, which had drifted badly: it documented `packages/railtracks-cli/` (deleted), told contributors to install from a `requirements-dev.txt` that doesn't exist, and shipped a validation snippet calling `rt.call_sync`, which isn't in the public API.

Rather than hand-fix a file that had already rotted once, the framework-concepts half is now **generated** from the bundled
`agent-builder` skill via `railtracks add copilot:agent-builder --force`, so it can't
fork again; the contributor half was rewritten against the live repo and CI config.

Making that generation viable required two fixes to the copilot install handler, and
turned up a correction to the `agent-builder` skill itself (the four named agent classes
it documented were removed in 1.5.0). Also adds `railtracks add --list`.

Part of the coding-assistant review in #1343.

Closes #1448 .

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

**`railtracks add --list`** prints every bundled skill with its argument hint and
description, plus the supported tools.

