### PR TITLE
bump pydantic minimum to 2.11

### DIFF
--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "colorama >= 0.4.6",
     "litellm >= 1.84.0, <= 1.89.0",
     "mcp >= 1.23.0, <2",
-    "pydantic >= 2.5.3, <3",
+    "pydantic >= 2.11, <3",
     "python-dotenv >= 1.0.0",
     "PyYAML >= 6.0",
     "rich>=13.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -4418,7 +4418,7 @@ requires-dist = [
     { name = "pgvector", marker = "extra == 'stores-vector'", specifier = ">=0.3" },
     { name = "pillow", marker = "extra == 'ocr'", specifier = ">=10.0.0" },
     { name = "portkey-ai", marker = "extra == 'portkey'", specifier = ">=2.0.2" },
-    { name = "pydantic", specifier = ">=2.5.3,<3" },
+    { name = "pydantic", specifier = ">=2.11,<3" },
     { name = "pypdf", marker = "extra == 'ocr'", specifier = ">=4.0.0,<=6.14.2" },
     { name = "pypdf", marker = "extra == 'pdf'", specifier = ">=4.0.0,<=6.14.2" },
     { name = "pypdfium2", marker = "extra == 'ocr'", specifier = ">=4.30.0" },


### PR DESCRIPTION
## Summary

Closes #1031 

`PydanticSerializationUnexpectedValue` warning from `evaluate()` appeared on older models that won't build our aggregate schema anyway so updating the minimum version in toml.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [x] Breaking changes include migration note