### PR TITLE
fix: treat docstring continuation lines as description text

### DIFF
--- a/packages/railtracks/src/railtracks/llm/tools/docstring_parser.py
+++ b/packages/railtracks/src/railtracks/llm/tools/docstring_parser.py
@@ -94,11 +94,12 @@ def parse_args_section(args_section: str) -> Dict[str, str]:
     # This handles both formats:
     # - param_name: Description
     # - param_name (type): Description
-    pattern = re.compile(r"^\s*(\w+)(?:\s*\([^)]+\))?:\s*(.+)$")
+    pattern = re.compile(r"^(\s*)(\w+)(?:\s*\([^)]+\))?:\s*(.+)$")
 
     arg_descriptions = {}
     current_arg = None
     current_description = []
+    param_indent = None
 
     for line in args_section.splitlines():
         # Skip empty lines
@@ -108,12 +109,24 @@ def parse_args_section(args_section: str) -> Dict[str, str]:
         # Check if this is a new parameter definition
         match = pattern.match(line)
         if match:
+            indent = len(match.group(1))
+            if param_indent is None:
+                param_indent = indent
+
+            if indent != param_indent:
+                # Deeper-indented line that looks like a parameter definition
+                # (e.g. "Note: keys are case-insensitive.") is continuation text.
+                if current_arg:
+                    current_description.append(line.strip())
+                continue
+
             # If we were processing a previous parameter, save it
             if current_arg and current_description:
                 arg_descriptions[current_arg] = " ".join(current_description).strip()
 
             # Start a new parameter
-            arg_name, arg_desc = match.groups()
+            arg_name = match.group(2)
+            arg_desc = match.group(3)
             current_arg = arg_name
             current_description = [arg_desc.strip()]
         elif current_arg:

--- a/packages/railtracks/tests/unit_tests/llm/tools/test_docstring_parser.py
+++ b/packages/railtracks/tests/unit_tests/llm/tools/test_docstring_parser.py
@@ -6,10 +6,10 @@ railtracks.llm.tools.docstring_parser module.
 """
 
 from railtracks.llm.tools.docstring_parser import (
-    parse_docstring_args,
     extract_args_section,
-    parse_args_section,
     extract_main_description,
+    parse_args_section,
+    parse_docstring_args,
 )
 
 
@@ -128,6 +128,19 @@ class TestParseArgsSection:
         }
         assert parse_args_section(args_section) == expected
 
+    def test_continuation_line_starting_with_word(self):
+        """Continuation lines starting with ``Word:`` are not new parameters."""
+        args_section = """
+            headers: Optional dict of extra headers.
+                Note: keys are case-insensitive.
+            timeout: Optional request timeout.
+        """
+        expected = {
+            "headers": "Optional dict of extra headers. Note: keys are case-insensitive.",
+            "timeout": "Optional request timeout.",
+        }
+        assert parse_args_section(args_section) == expected
+
 
 class TestParseDocstringArgs:
     """Tests for the parse_docstring_args function."""
@@ -181,6 +194,23 @@ class TestParseDocstringArgs:
         expected = {
             "param1": "Description of param1 that spans multiple lines.",
             "param2": "Description of param2.",
+        }
+        assert parse_docstring_args(docstring) == expected
+
+    def test_continuation_line_starting_with_word(self):
+        """Continuation lines starting with ``Word:`` are kept as description text."""
+        docstring = """
+        Fetches a URL.
+
+        Args:
+            headers: Optional dict of extra headers.
+                Note: keys are case-insensitive.
+
+        Returns:
+            The response body.
+        """
+        expected = {
+            "headers": "Optional dict of extra headers. Note: keys are case-insensitive.",
         }
         assert parse_docstring_args(docstring) == expected
 


### PR DESCRIPTION
## Summary

Fixes #1476.

`parse_args_section` treated any indented line matching `Word:` as a new parameter definition, so continuation lines like `Note: keys are case-insensitive.` minted a phantom `Note` parameter and dropped the text from the real parameter's description.

## Change

Anchor new-parameter detection to the indent level of the first parameter line in the `Args:` section. Only lines indented at that same level start a new parameter; deeper-indented lines that look like parameter definitions are kept as continuation text.

## Verification

- Added regression tests covering the `Note:` continuation-line case at both `parse_args_section` and `parse_docstring_args` levels.
- `uv run pytest packages/railtracks/tests/unit_tests/llm/tools/ -q` → 51 passed.
- `uv run ruff check ...` on the two changed files → All checks passed.

The repro from the issue now returns:

```python
{'headers': 'Optional dict of extra headers. Note: keys are case-insensitive.'}
```