### PR TITLE
Add field docstrings to Metric

### DIFF
--- a/packages/railtracks/src/railtracks/evaluations/evaluators/metrics.py
+++ b/packages/railtracks/src/railtracks/evaluations/evaluators/metrics.py
@@ -23,11 +23,15 @@ def _json_default(value):
 
 
 class Metric(BaseModel):
-    name: str
-    metric_type: Literal["Metric"] = "Metric"
-    identifier: str = ""
+    name: str = Field(description="Name of the metric.")
+    metric_type: Literal["Metric"] = Field(default="Metric", description="Type of the metric.")
+    identifier: str = Field(
+        default="", description="Unique identifier generated from metric configuration."
+    )
     model_config = ConfigDict(frozen=True)
-    description: str | None = None
+    description: str | None = Field(
+        default=None, description="Optional human-readable description of the metric."
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/railtracks/src/railtracks/evaluations/evaluators/metrics.py
+++ b/packages/railtracks/src/railtracks/evaluations/evaluators/metrics.py
@@ -24,7 +24,9 @@ def _json_default(value):
 
 class Metric(BaseModel):
     name: str = Field(description="Name of the metric.")
-    metric_type: Literal["Metric"] = Field(default="Metric", description="Type of the metric.")
+    metric_type: Literal["Metric"] = Field(
+        default="Metric", description="Type of the metric."
+    )
     identifier: str = Field(
         default="", description="Unique identifier generated from metric configuration."
     )

--- a/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_metrics.py
+++ b/packages/railtracks/tests/unit_tests/evaluations/evaluators/test_metrics.py
@@ -52,6 +52,19 @@ def test_metric_explicit_identifier_preserved():
     assert m.identifier == "custom-id"
 
 
+def test_metric_fields_have_descriptions():
+    fields = Metric.model_fields
+    assert fields["name"].description == "Name of the metric."
+    assert fields["metric_type"].description == "Type of the metric."
+    assert (
+        fields["identifier"].description
+        == "Unique identifier generated from metric configuration."
+    )
+    assert fields["description"].description == (
+        "Optional human-readable description of the metric."
+    )
+
+
 # ── Numerical ─────────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Add Pydantic Field descriptions to Metric fields and verify them with a unit test.

Fixes #1016