### PR TITLE
1412 maximum calls middleware

### DIFF
--- a/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
@@ -1,0 +1,13 @@
+# Max Calls
+
+`Max Calls` is a middleware that limits the number of calls to a node or model. This can be useful if you want tools to be called just once per workflow, or in general if you want to limit the number of calls to a tool.
+cancels the call and raises `TimeoutError` instead of allowing a slow node or
+model request to halt the workflow indefinitely.
+
+```python
+--8<-- "docs/scripts/prebuilt_middleware.py:timeout"
+```
+
+Because it only controls the wrapped call, `Timeout` works in both
+`middleware=` and `model_middleware=`. The deadline covers the complete call in
+the selected slot.

--- a/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
@@ -1,13 +1,11 @@
 # Max Calls
 
 `Max Calls` is a middleware that limits the number of calls to a node or model. This can be useful if you want tools to be called just once per workflow, or in general if you want to limit the number of calls to a tool.
-cancels the call and raises `TimeoutError` instead of allowing a slow node or
-model request to halt the workflow indefinitely.
 
 ```python
---8<-- "docs/scripts/prebuilt_middleware.py:timeout"
+--8<-- "docs/scripts/prebuilt_middleware.py:max_calls"
 ```
 
-Because it only controls the wrapped call, `Timeout` works in both
-`middleware=` and `model_middleware=`. The deadline covers the complete call in
+Because it only controls the wrapped call, `Max Calls` works in both
+`middleware=` and `model_middleware=`. The limit is enforced on the complete call in
 the selected slot.

--- a/docs/documentation/agent_design/middleware/prebuilt/overview.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/overview.md
@@ -14,6 +14,7 @@ The **Slot** column tells you where each middleware can be attached:
 |---|---|---|
 | [Retry](list/retry.md) | Both | Re-run the wrapped call when it raises a transient error, with a configurable backoff. |
 | [Timeout](list/timeout.md) | Both | Cancel the wrapped call and raise `TimeoutError` when it exceeds a deadline. |
+| [MaxCalls](list/max_calls.md) | Both | Raise `MaxCallsExceededError` once the wrapped call has been invoked a set number of times. |
 | [ContextInjection](list/context_injection.md) | Model | Fill `{placeholder}` templates in the prompt from the active session context. |
 
 ### Guardrails

--- a/docs/scripts/prebuilt_middleware.py
+++ b/docs/scripts/prebuilt_middleware.py
@@ -44,6 +44,22 @@ TimedAgent = rt.agent_node(
 )
 # --8<-- [end: timeout]
 
+# --8<-- [start: max_calls]
+import railtracks as rt
+from railtracks.prebuilt.middleware import MaxCalls
+
+
+def some_api_call():
+    return "API response"
+
+
+# MaxCalls is slot-agnostic: use it as node middleware, model middleware, or both.
+LimitedApiCall = rt.function_node(
+    some_api_call,
+    middleware=[MaxCalls(max_calls=3, custom_message="API call budget exhausted")],
+)
+# --8<-- [end: max_calls]
+
 
 # --8<-- [start: context_injection]
 import railtracks as rt

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/__init__.py
@@ -4,8 +4,14 @@
 # ``rt.prebuilt.middleware.<Name>``.
 
 from railtracks.prebuilt.middleware.context_injection import ContextInjection
+from railtracks.prebuilt.middleware.max_calls import MaxCalls, MaxCallsExceededError
 from railtracks.prebuilt.middleware.retry import Retry
 from railtracks.prebuilt.middleware.timeout import Timeout
-from railtracks.prebuilt.middleware.max_calls import MaxCalls
 
-__all__ = ["ContextInjection", "Retry", "Timeout", "MaxCalls"]
+__all__ = [
+    "ContextInjection",
+    "MaxCalls",
+    "MaxCallsExceededError",
+    "Retry",
+    "Timeout",
+]

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/__init__.py
@@ -6,5 +6,6 @@
 from railtracks.prebuilt.middleware.context_injection import ContextInjection
 from railtracks.prebuilt.middleware.retry import Retry
 from railtracks.prebuilt.middleware.timeout import Timeout
+from railtracks.prebuilt.middleware.max_calls import MaxCalls
 
-__all__ = ["ContextInjection", "Retry", "Timeout"]
+__all__ = ["ContextInjection", "Retry", "Timeout", "MaxCalls"]

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -26,6 +26,10 @@ class MaxCalls(Middleware):
         max_calls: Number of calls allowed before the limit is enforced.
         custom_message: Message to raise once the limit is exceeded. Defaults
             to ``"Maximum number of calls exceeded"``.
+
+    Raises:
+        MaxCallsExceededError: Once ``call`` has already been invoked
+            ``max_calls`` times.
     """
 
     def __init__(self, max_calls: int, custom_message: str | None = None):
@@ -42,5 +46,6 @@ class MaxCalls(Middleware):
         self._call_count += 1
         return await call(*args, **kwargs)
 
+
 class MaxCallsExceededError(Exception):
-    """Raised when the maximum number of calls is exceeded in MaxCalls middleware."""
+    """Raised when a :class:`MaxCalls`-wrapped call is invoked past its limit."""

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,0 +1,43 @@
+from railtracks.middleware.core import Middleware
+
+
+class MaxCalls(Middleware):
+    """Fail the wrapped call once it has been invoked ``max_calls`` times.
+
+    Slot-agnostic: works both as node middleware (``middleware=``) and as model
+    middleware (``model_middleware=``) — it only counts invocations of ``call``
+    and never inspects the arguments::
+
+        import railtracks as rt
+        from railtracks.prebuilt import middleware
+
+        rt.agent_node(
+            "Agent",
+            llm=rt.llm.OpenAILLM(model_name="gpt-4o"),
+            middleware=[middleware.MaxCalls(5)],  # cap calls to the whole node
+            model_middleware=[middleware.MaxCalls(5)],  # cap raw model calls
+        )
+
+    The count is tracked per ``MaxCalls`` instance, so a single instance shared
+    across nodes enforces a combined budget, while a fresh instance per node
+    gives each its own limit.
+
+    Args:
+        max_calls: Number of calls allowed before the limit is enforced.
+        custom_message: Message to raise once the limit is exceeded. Defaults
+            to ``"Maximum number of calls exceeded"``.
+    """
+
+    def __init__(self, max_calls: int, custom_message: str | None = None):
+        self._max_calls = max_calls
+        self._call_count = 0
+        self._custom_message = custom_message
+        super().__init__(self._middleware_fn)
+
+    async def _middleware_fn(self, call, *args, **kwargs):
+        if self._call_count >= self._max_calls:
+            if self._custom_message:
+                raise Exception(self._custom_message)
+            raise Exception("Maximum number of calls exceeded")
+        self._call_count += 1
+        return await call(*args, **kwargs)

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -37,7 +37,10 @@ class MaxCalls(Middleware):
     async def _middleware_fn(self, call, *args, **kwargs):
         if self._call_count >= self._max_calls:
             if self._custom_message:
-                raise Exception(self._custom_message)
-            raise Exception("Maximum number of calls exceeded")
+                raise MaxCallsExceededError(self._custom_message)
+            raise MaxCallsExceededError("Maximum number of calls exceeded")
         self._call_count += 1
         return await call(*args, **kwargs)
+
+class MaxCallsExceededError(Exception):
+    """Raised when the maximum number of calls is exceeded in MaxCalls middleware."""

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 import pytest
 from railtracks.middleware import Middleware
-from railtracks.prebuilt.middleware.max_calls import MaxCalls
+from railtracks.prebuilt.middleware.max_calls import MaxCalls, MaxCallsExceededError
 
 
 def test_max_calls_is_a_plain_middleware():
     assert isinstance(MaxCalls(1), Middleware)
+
+
+def test_max_calls_exceeded_error_is_exported_flat():
+    from railtracks.prebuilt.middleware import MaxCallsExceededError as PublicError
+
+    assert PublicError is MaxCallsExceededError
 
 
 @pytest.mark.asyncio
@@ -30,7 +36,7 @@ async def test_call_beyond_the_limit_raises():
     max_calls = MaxCalls(1)
     await max_calls.wrap(add)(1, 2)
 
-    with pytest.raises(Exception, match="Maximum number of calls exceeded"):
+    with pytest.raises(MaxCallsExceededError, match="Maximum number of calls exceeded"):
         await max_calls.wrap(add)(1, 2)
 
 
@@ -41,7 +47,7 @@ async def test_custom_message_is_used_when_limit_exceeded():
 
     max_calls = MaxCalls(0, custom_message="budget exhausted")
 
-    with pytest.raises(Exception, match="budget exhausted"):
+    with pytest.raises(MaxCallsExceededError, match="budget exhausted"):
         await max_calls.wrap(noop)()
 
 
@@ -53,7 +59,7 @@ async def test_count_is_not_incremented_once_limit_is_hit():
     max_calls = MaxCalls(0)
 
     for _ in range(3):
-        with pytest.raises(Exception, match="Maximum number of calls exceeded"):
+        with pytest.raises(MaxCallsExceededError, match="Maximum number of calls exceeded"):
             await max_calls.wrap(noop)()
 
     assert max_calls._call_count == 0

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -1,0 +1,72 @@
+"""Unit tests for the prebuilt MaxCalls middleware."""
+
+from __future__ import annotations
+
+import pytest
+from railtracks.middleware import Middleware
+from railtracks.prebuilt.middleware.max_calls import MaxCalls
+
+
+def test_max_calls_is_a_plain_middleware():
+    assert isinstance(MaxCalls(1), Middleware)
+
+
+@pytest.mark.asyncio
+async def test_calls_within_the_limit_succeed():
+    async def add(x, *, y):
+        return x + y
+
+    max_calls = MaxCalls(2)
+
+    assert await max_calls.wrap(add)(2, y=3) == 5
+    assert await max_calls.wrap(add)(4, y=5) == 9
+
+
+@pytest.mark.asyncio
+async def test_call_beyond_the_limit_raises():
+    async def add(x, y):
+        return x + y
+
+    max_calls = MaxCalls(1)
+    await max_calls.wrap(add)(1, 2)
+
+    with pytest.raises(Exception, match="Maximum number of calls exceeded"):
+        await max_calls.wrap(add)(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_custom_message_is_used_when_limit_exceeded():
+    async def noop():
+        return None
+
+    max_calls = MaxCalls(0, custom_message="budget exhausted")
+
+    with pytest.raises(Exception, match="budget exhausted"):
+        await max_calls.wrap(noop)()
+
+
+@pytest.mark.asyncio
+async def test_count_is_not_incremented_once_limit_is_hit():
+    async def noop():
+        return None
+
+    max_calls = MaxCalls(0)
+
+    for _ in range(3):
+        with pytest.raises(Exception, match="Maximum number of calls exceeded"):
+            await max_calls.wrap(noop)()
+
+    assert max_calls._call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_wrapped_exception_propagates_and_still_counts_the_call():
+    async def broken():
+        raise ValueError("broken")
+
+    max_calls = MaxCalls(2)
+
+    with pytest.raises(ValueError, match="broken"):
+        await max_calls.wrap(broken)()
+
+    assert max_calls._call_count == 1


### PR DESCRIPTION
## Summary

A very simple Maximum calls middleware that gates node by a maximum number of calls to a node. This can be created very simply using our prebuilt middleware API. 

<img width="1473" height="918" alt="image" src="https://github.com/user-attachments/assets/ac394b95-141d-4a72-8757-08c523f80363" />


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

Let me know if you have any major comments. This is designed to be very simple middleware component.
