### PR TITLE
refactor: unify context injection naming

### DIFF
--- a/docs/documentation/advanced/context.md
+++ b/docs/documentation/advanced/context.md
@@ -37,12 +37,12 @@ In agentic systems, you can use context to store important facts or constraints 
     ```
 
 
-### Prompt Injection
+### Context Injection
 
-One of the most powerful features built on top of the context system is "prompt injection" (also called "context injection"). This allows dynamically inserting values from the global context into prompts for LLMs:
+One of the most powerful features built on top of the context system is "context injection". This allows dynamically inserting values from the global context into prompts for LLMs:
 
 !!! tip
-    For more details on prompt injection, see the [Prompts and Context Injection Tutorial](../../tutorials/walkthroughs/prompts_and_context.md) documentation.
+    For more details on context injection, see the [Prompts and Context Injection Tutorial](../../tutorials/walkthroughs/prompts_and_context.md) documentation.
 
 ## Benefits of Using Context
 

--- a/docs/tutorials/concepts/RAG.md
+++ b/docs/tutorials/concepts/RAG.md
@@ -56,7 +56,7 @@ sequenceDiagram
 sequenceDiagram
     participant U as User Prompt
     participant C as  Store
-    participant E as  Prompt Injection
+    participant E as  Context Injection
     participant L as  LLM
 
     U->>C: Search Store for similarity 

--- a/docs/tutorials/concepts/prompts_and_context.md
+++ b/docs/tutorials/concepts/prompts_and_context.md
@@ -9,7 +9,7 @@ In Railtracks, prompts are provided as system messages or user messages when int
 
 ## Context Injection
 
-Railtracks provides a powerful feature called "context injection" (also referred to as "prompt injection") that allows you to dynamically insert values from the global context into your prompts. This makes your prompts more flexible and reusable across different scenarios.
+Railtracks provides a powerful feature called "context injection" (also referred to as "prompt injection", "variable insertion", etc. in literature) that allows you to dynamically insert values from the global context into your prompts. This makes your prompts more flexible and reusable across different scenarios.
 
 ### What is Context Injection?
 

--- a/docs/tutorials/walkthroughs/prompts_and_context.md
+++ b/docs/tutorials/walkthroughs/prompts_and_context.md
@@ -38,7 +38,7 @@ prompt = f"The current time is {{time}}:\nUser Message:\n{rt.escape_braces(user_
 If your prompts aren't producing the expected results:
 
 1. **Check context values**: Ensure the context contains the expected values for your placeholders
-2. **Verify prompt injection is enabled**: It is not on by default — check that the agent's `model_middleware` includes `rt.prebuilt.middleware.ContextInjection()` ([how to add it](../../documentation/agent_design/middleware/prebuilt/list/context_injection.md))
+2. **Verify context injection is enabled**: It is not on by default — check that the agent's `model_middleware` includes `rt.prebuilt.middleware.ContextInjection()` ([how to add it](../../documentation/agent_design/middleware/prebuilt/list/context_injection.md))
 3. **Look for syntax errors**: Ensure your placeholders use the correct format `{variable_name}`
 
 

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -84,7 +84,7 @@ from .built_nodes.llm.middleware import after_llm, before_llm, wrap_llm
 from .context.central import session_id, set_config
 from .guardrails import input_guard, output_guard
 from .interaction import astream, broadcast, call, call_batch, couple
-from .llm.prompt_injection_utils import escape_braces
+from .llm.context_injection_utils import escape_braces
 from .middleware import after_node, wrap_node
 from .nodes.manifest import ToolManifest
 from .orchestration.connection import FlowConnection, NodeMessageHistory

--- a/packages/railtracks/src/railtracks/llm/context_injection_utils.py
+++ b/packages/railtracks/src/railtracks/llm/context_injection_utils.py
@@ -3,12 +3,12 @@ import string
 from typing import Any, Mapping
 
 _PARSER = string.Formatter()
-_logger = logging.getLogger("RT.prompt_injection")
+_logger = logging.getLogger("RT.context_injection")
 
 
 def escape_braces(text: str) -> str:
     """
-    Escape the braces in `text` so that prompt injection treats it as data.
+    Escape the braces in `text` so that context injection treats it as data.
 
     Apply this to untrusted or arbitrary strings before embedding them in a message that
     will have context values injected into it. Injecting the returned string yields

--- a/packages/railtracks/src/railtracks/llm/message.py
+++ b/packages/railtracks/src/railtracks/llm/message.py
@@ -11,8 +11,8 @@ from urllib import request as urllib_request
 from urllib.parse import urlparse
 
 from .content import Content, ToolCall, ToolCalls, ToolResponse
+from .context_injection_utils import ValueDict, fill_template
 from .encoding import detect_source, encode, ensure_data_uri
-from .prompt_injection_utils import ValueDict, fill_template
 
 logger = logging.getLogger(__name__)
 

--- a/packages/railtracks/src/railtracks/prompts/prompt.py
+++ b/packages/railtracks/src/railtracks/prompts/prompt.py
@@ -1,6 +1,6 @@
 import railtracks.context as context
 from railtracks.llm import MessageHistory
-from railtracks.utils.prompt_injection import ValueDict, inject_values
+from railtracks.utils.context_injection import ValueDict, inject_values
 
 
 class _ContextDict(ValueDict):

--- a/packages/railtracks/src/railtracks/utils/context_injection.py
+++ b/packages/railtracks/src/railtracks/utils/context_injection.py
@@ -1,5 +1,5 @@
 from railtracks.llm import MessageHistory, SystemMessage, UserMessage
-from railtracks.llm.prompt_injection_utils import ValueDict
+from railtracks.llm.context_injection_utils import ValueDict
 
 
 def inject_values(message_history: MessageHistory, value_dict: ValueDict):

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
@@ -13,7 +13,7 @@ def _return_message(messages: MessageHistory) -> Response:
     return Response(message=Message(role=Role.assistant, content=messages[-1].content))
 
 
-def test_prompt_injection(mock_llm):
+def test_context_injection(mock_llm):
     prompt = "{secret}"
 
     model = mock_llm()
@@ -34,7 +34,7 @@ def test_prompt_injection(mock_llm):
     assert response.content == "tomato"
 
 
-def test_prompt_injection_bypass(mock_llm):
+def test_context_injection_bypass(mock_llm):
     prompt = "{{secret_value}}"
 
     model = mock_llm()
@@ -123,7 +123,7 @@ def test_no_injection_without_middleware(mock_llm):
     assert response.content == "{secret_value}"
 
 
-def test_prompt_injection_shared_middleware_list_stays_independent(mock_llm):
+def test_context_injection_shared_middleware_list_stays_independent(mock_llm):
     """Regression: one user middleware list reused across nodes must not be mutated
     by node construction, and injection applies only to nodes whose list actually
     contains a ContextInjection entry."""

--- a/packages/railtracks/tests/unit_tests/utils/test_context_injection.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_context_injection.py
@@ -1,11 +1,11 @@
 from railtracks.llm import Message, MessageHistory, SystemMessage, UserMessage
-from railtracks.llm.message import Role
-from railtracks.llm.prompt_injection_utils import (
+from railtracks.llm.context_injection_utils import (
     ValueDict,
     escape_braces,
     fill_template,
 )
-from railtracks.utils import prompt_injection
+from railtracks.llm.message import Role
+from railtracks.utils import context_injection
 
 
 class _Holder:
@@ -97,11 +97,11 @@ def test_escape_braces_protects_only_the_escaped_fragment():
 # ================= START ValueDict tests ====================
 
 def test_valuedict_returns_value_if_exists():
-    d = prompt_injection.ValueDict(name="Bob")
+    d = context_injection.ValueDict(name="Bob")
     assert d["name"] == "Bob"
 
 def test_valuedict_missing_returns_placeholder():
-    d = prompt_injection.ValueDict()
+    d = context_injection.ValueDict()
     assert d["missing"] == "{missing}"
 
 # ================ END ValueDict tests =======================
@@ -115,7 +115,7 @@ def test_inject_values_injects_value():
     history = MessageHistory([smsg, msg])
     value_dict = ValueDict({"name": "Alice", "system_info": "All systems operational"})
 
-    result = prompt_injection.inject_values(history, value_dict)
+    result = context_injection.inject_values(history, value_dict)
     assert result[0].content == "System says All systems operational"
     assert result[1].content == "Hello, Alice!"
 
@@ -124,7 +124,7 @@ def test_inject_values_ignores_other_roles():
     history = MessageHistory([msg])
     value_dict = ValueDict({"name": "Alice"})
 
-    result = prompt_injection.inject_values(history, value_dict)
+    result = context_injection.inject_values(history, value_dict)
     assert result[0].content == "Hello, {name}!"
 
 def test_inject_values_ignores_non_string_content():
@@ -132,7 +132,7 @@ def test_inject_values_ignores_non_string_content():
     history = MessageHistory([msg])
     value_dict = ValueDict({"name": "Alice"})
 
-    result = prompt_injection.inject_values(history, value_dict)
+    result = context_injection.inject_values(history, value_dict)
     assert result[0].content == 12345
 
 def test_inject_values_passes_through_unfillable_placeholders():
@@ -146,7 +146,7 @@ def test_inject_values_passes_through_unfillable_placeholders():
     history = MessageHistory([UserMessage(content=c) for c in contents])
     value_dict = ValueDict({"holder": _Holder(), "name": "Alice"})
 
-    result = prompt_injection.inject_values(history, value_dict)
+    result = context_injection.inject_values(history, value_dict)
     for message, original in zip(result, contents):
         assert message.content == original
 


### PR DESCRIPTION
Closes #1170

`context_injection` was referred to as `prompt_injection` in several places. Standardizes on "context injection" for the templating feature.

- Rename `llm/prompt_injection_utils.py` → `llm/context_injection_utils.py`
- Rename `utils/prompt_injection.py` → `utils/context_injection.py`
- Rename the matching unit test module and three `test_prompt_injection*` test names
- Rename logger `RT.prompt_injection` → `RT.context_injection`
- Update docs to lead with "context injection"; the concepts page still notes that outside literature uses other terms for it

`SECURITY.md` is left as-is — it uses "prompt injection" in the industry sense of an attack, which is the distinction this rename exists to preserve.

No public API change: `escape_braces` is the only re-export from the package root and keeps its name. Both renamed modules were internal (`railtracks/utils/__init__.py` is empty, so neither was reachable except by direct submodule path).
