### PR TITLE
deprecate Cohere LLM support

### DIFF
--- a/docs/scripts/providers.py
+++ b/docs/scripts/providers.py
@@ -16,14 +16,6 @@ load_dotenv()  # Load environment variables from .env file
 model = rt.llm.AnthropicLLM("claude-sonnet-4-6")
 # --8<-- [end: anthropic]
 
-# --8<-- [start: cohere]
-import railtracks as rt
-from dotenv import load_dotenv
-load_dotenv()  # Load environment variables from .env file
-
-model = rt.llm.CohereLLM("command-a-03-2025")
-# --8<-- [end: cohere]
-
 # --8<-- [start: gemini]
 import railtracks as rt
 from dotenv import load_dotenv
@@ -93,6 +85,5 @@ Agent = rt.agent_node(
     system_message="You are a helpful AI assistant.",
 )
 # --8<-- [end: to_agent]
-
 
 

--- a/packages/railtracks/src/railtracks/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/llm/__init__.py
@@ -6,7 +6,6 @@ from .model import ModelBase
 from .models import (
     AnthropicLLM,
     AzureAILLM,
-    CohereLLM,
     GeminiLLM,
     HuggingFaceLLM,
     OllamaLLM,
@@ -53,7 +52,6 @@ __all__ = [
     "Tool",
     "AnthropicLLM",
     "AzureAILLM",
-    "CohereLLM",
     "HuggingFaceLLM",
     "OpenAILLM",
     "GeminiLLM",
@@ -63,7 +61,6 @@ __all__ = [
     # "TelusLLM",
     "PortKeyLLM",
     "OpenAICompatibleProvider",
-    "CohereLLM",
     # Parameter types
     "Parameter",
     "UnionParameter",

--- a/packages/railtracks/src/railtracks/llm/models/__init__.py
+++ b/packages/railtracks/src/railtracks/llm/models/__init__.py
@@ -1,6 +1,5 @@
 from .api_providers import (
     AnthropicLLM,
-    CohereLLM,
     GeminiLLM,
     HuggingFaceLLM,
     OpenAICompatibleProvider,
@@ -17,6 +16,5 @@ __all__ = [
     OllamaLLM,
     HuggingFaceLLM,
     PortKeyLLM,
-    CohereLLM,
     "OpenAICompatibleProvider",
 ]

--- a/packages/railtracks/src/railtracks/llm/models/api_providers/__init__.py
+++ b/packages/railtracks/src/railtracks/llm/models/api_providers/__init__.py
@@ -1,13 +1,11 @@
 from ._openai_compatable_provider_wrapper import OpenAICompatibleProvider
 from .anthropic import AnthropicLLM
-from .cohere import CohereLLM
 from .gemini import GeminiLLM
 from .huggingface import HuggingFaceLLM
 from .openai import OpenAILLM
 
 __all__ = [
     "AnthropicLLM",
-    "CohereLLM",
     "GeminiLLM",
     "HuggingFaceLLM",
     "OpenAILLM",

--- a/packages/railtracks/tests/llm_live_tests/llm_map.py
+++ b/packages/railtracks/tests/llm_live_tests/llm_map.py
@@ -7,5 +7,4 @@ llm_map = {
         "together/deepseek-ai/DeepSeek-R1"
     ),  # this model is a little dumb, see test_function_as_tool test case
     "gemini": rt.llm.GeminiLLM("gemini-2.5-flash"),
-    # "cohere": rt.llm.CohereLLM("command-a-03-2025"), # TODO: #uncomment after https://github.com/RailtownAI/railtracks/issues/775
 }

--- a/packages/railtracks/tests/llm_live_tests/test_basic.py
+++ b/packages/railtracks/tests/llm_live_tests/test_basic.py
@@ -5,9 +5,6 @@ from railtracks.built_nodes.llm.response import StringResponse
 
 from .llm_map import llm_map
 
-# Filter out Cohere LLMs for these tests
-llm_map_filtered = {k: v for k, v in llm_map.items() if "cohere" not in k.lower()}
-
 
 class Address(BaseModel):
     city: str = Field(description="The city the person lives in")
@@ -50,7 +47,7 @@ test_cases = [
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("llm", llm_map_filtered.values(), ids=llm_map_filtered.keys())
+@pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 async def test_terminal_llm(llm):
     """Test that a basic terminal llm can be created and used."""
 
@@ -68,7 +65,7 @@ async def test_terminal_llm(llm):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("llm", llm_map_filtered.values(), ids=llm_map_filtered.keys())
+@pytest.mark.parametrize("llm", llm_map.values(), ids=llm_map.keys())
 @pytest.mark.parametrize(
     "test_case", test_cases, ids=[case["case_id"] for case in test_cases]
 )

--- a/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_cohere.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_cohere.py
@@ -1,9 +1,0 @@
-from railtracks.llm import CohereLLM
-
-
-def test_llm_correct_init():
-    """
-    Test that Cohere initializes correctly with a valid model name.
-    """
-    model = CohereLLM("command-a-03-2025")
-    assert model is not None

--- a/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_provider_llm.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/api_providers/test_provider_llm.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import litellm
 import pytest
-from railtracks.llm import AnthropicLLM, CohereLLM, GeminiLLM, HuggingFaceLLM, OpenAILLM
+from railtracks.llm import AnthropicLLM, GeminiLLM, HuggingFaceLLM, OpenAILLM
 from railtracks.llm._exceptions import RTLLMError
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.models._model_exception_base import (
@@ -19,7 +19,6 @@ class TestInvalidModelNames:
         [
             (OpenAILLM, "claude-3-5-sonnet-20240620"),  # Anthropic model for OpenAI
             (AnthropicLLM, "gpt-4o"),  # OpenAI model for Anthropic
-            (CohereLLM, "gpt-4o"),  # OpenAI model for Cohere
             (GeminiLLM, "gpt-4o"),  # OpenAI model for Gemini
             (OpenAILLM, "gemini-pro"),  # Gemini model for OpenAI
             (AnthropicLLM, "gemini-pro"),  # Gemini model for Anthropic
@@ -74,7 +73,6 @@ class TestFunctionCallingSupport:
                 "gemini/gemini-2.0-flash-exp-image-generation",
                 "vertex_ai",
             ),  # gemini models return "vertex_ai" as the provider when we call get_llm_provider
-            (CohereLLM, "cohere/command-a-03-2025", "cohere_chat"),
         ],
     )
     def test_no_function_calling_support(


### PR DESCRIPTION
## Summary

Closes #1416

- Remove `CohereLLM` from the public LLM API and provider documentation.
- Remove Cohere-specific LLM tests while retaining generic Cohere embedding examples.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check`)
- [x] Tests added/updated and pass locally (39 focused tests)
- [x] Docs updated for user-facing behavior
- [ ] Breaking changes include migration notes (omitted at reviewer request)

## Notes

`uv run mkdocs build --strict` passes. The wider LLM unit suite has six pre-existing environment/baseline failures: five require the optional `portkey_ai` package, and one type-mapping assertion differs under Python 3.14.