### PR TITLE
Default writer config

### DIFF
--- a/docs/observability/agenthub/local_v2.md
+++ b/docs/observability/agenthub/local_v2.md
@@ -51,9 +51,9 @@ To use your own writer set (or add more alongside the default), call
 ```
 
 !!! warning "`configure_writers`"
-    `configure_writers` overwrites the default behaviour so if you'd like
-    to still have the local events files, you need the pass the `JsonlWriter()` as well as
-    any new or custom writers
+    `configure_writers` replaces the auto-registered default, so if you'd like
+    to still have the local event files, you need to pass `JsonlWriter()` as
+    well as any new or custom writers.
 
 ### Use another event directory
 

--- a/docs/observability/agenthub/local_v2.md
+++ b/docs/observability/agenthub/local_v2.md
@@ -69,13 +69,13 @@ railtracks viz --beta
 
 ### Deployed environments with no writable disk
 
-Set `RAILTRACKS_DISABLE_EVENTS=1` on hosts where Railtracks can't (or
+Set `RAILTRACKS_DISABLE_EVENTS=True` on hosts where Railtracks can't (or
 shouldn't) write to disk. It skips **both** the auto-registered event
 writer and the legacy `save_state` session dump, regardless of what
 `save_state=` is set to.
 
 ```bash title="Turn off Railtracks-owned disk writes"
-export RAILTRACKS_DISABLE_EVENTS=1
+export RAILTRACKS_DISABLE_EVENTS=True
 ```
 
 For hosted observability in these environments, use Conductr.

--- a/docs/observability/agenthub/local_v2.md
+++ b/docs/observability/agenthub/local_v2.md
@@ -38,8 +38,7 @@ routes, and interactive API documentation is available at
 
 ## Record event-stream data
 
-Events are recorded automatically to `.railtracks/data/events` when you
-invoke a flow — no writer setup required. The beta visualizer reads from the
+Events are recorded automatically to `.railtracks/data/events` with no setup required. The beta visualizer reads from the
 same directory.
 
 ### Customize event writers
@@ -51,13 +50,10 @@ To use your own writer set (or add more alongside the default), call
 --8<-- "docs/scripts/observability/events.py:v2-viz"
 ```
 
-Passing any list — including `configure_writers([])` — suppresses the
-auto-injected default. This is the escape hatch when you want zero event
-writers for a specific run.
-
-!!! warning "Configure writers before running a flow"
-    `configure_writers(...)` must run before observability starts. Put it in
-    your application startup code, before the first flow or agent invocation.
+!!! warning "`configure_writers`"
+    `configure_writers` overwrites the default behaviour so if you'd like
+    to still have the local events files, you need the pass the `JsonlWriter()` as well as
+    any new or custom writers
 
 ### Use another event directory
 
@@ -84,7 +80,7 @@ export RAILTRACKS_DISABLE_EVENTS=1
 
 For hosted observability in these environments, use Conductr.
 
-!!! info "`save_state` default is changing"
+!!! warning "`save_state` default is changing"
     `save_state=True` still writes `.railtracks/data/sessions/*.json` for the
     stable (v1) visualizer this release. When it's not set explicitly, a
     `DeprecationWarning` is emitted; the default flips to `False` in the next

--- a/docs/observability/agenthub/local_v2.md
+++ b/docs/observability/agenthub/local_v2.md
@@ -38,16 +38,24 @@ routes, and interactive API documentation is available at
 
 ## Record event-stream data
 
-Configure the JSONL writer before the first agent run in your process:
+Events are recorded automatically to `.railtracks/data/events` when you
+invoke a flow — no writer setup required. The beta visualizer reads from the
+same directory.
+
+### Customize event writers
+
+To use your own writer set (or add more alongside the default), call
+`configure_writers(...)` before the first flow invocation in your process:
 
 ```python title="Configure local event storage"
 --8<-- "docs/scripts/observability/events.py:v2-viz"
 ```
 
-`JsonlWriter()` and the beta visualizer use the same event directory:
-`.railtracks/data/events` under the resolved Railtracks project root.
+Passing any list — including `configure_writers([])` — suppresses the
+auto-injected default. This is the escape hatch when you want zero event
+writers for a specific run.
 
-!!! warning "Configure writers before running an agent"
+!!! warning "Configure writers before running a flow"
     `configure_writers(...)` must run before observability starts. Put it in
     your application startup code, before the first flow or agent invocation.
 
@@ -55,13 +63,33 @@ Configure the JSONL writer before the first agent run in your process:
 
 Set `RAILTRACKS_EVENTS_DIR` in both the process recording events and the
 visualizer process. Relative paths are resolved from the current working
-directory.
+directory. This redirects the auto-injected writer without any code change.
 
 ```bash title="Record and view another event store"
 export RAILTRACKS_EVENTS_DIR=./saved-events
 python my_agent.py
 railtracks viz --beta
 ```
+
+### Deployed environments with no writable disk
+
+Set `RAILTRACKS_DISABLE_EVENTS=1` on hosts where Railtracks can't (or
+shouldn't) write to disk. It skips **both** the auto-registered event
+writer and the legacy `save_state` session dump, regardless of what
+`save_state=` is set to.
+
+```bash title="Turn off Railtracks-owned disk writes"
+export RAILTRACKS_DISABLE_EVENTS=1
+```
+
+For hosted observability in these environments, use Conductr.
+
+!!! info "`save_state` default is changing"
+    `save_state=True` still writes `.railtracks/data/sessions/*.json` for the
+    stable (v1) visualizer this release. When it's not set explicitly, a
+    `DeprecationWarning` is emitted; the default flips to `False` in the next
+    release. Pass `save_state=True` or `save_state=False` explicitly to lock
+    in the behavior you want.
 
 !!! tip "Running from multiple directories?"
     Run `railtracks init` once from your project root, at the same level as

--- a/docs/observability/agenthub/local_v2.md
+++ b/docs/observability/agenthub/local_v2.md
@@ -80,12 +80,13 @@ export RAILTRACKS_DISABLE_EVENTS=1
 
 For hosted observability in these environments, use Conductr.
 
-!!! warning "`save_state` default is changing"
+!!! warning "`save_state` is deprecated"
     `save_state=True` still writes `.railtracks/data/sessions/*.json` for the
-    stable (v1) visualizer this release. When it's not set explicitly, a
-    `DeprecationWarning` is emitted; the default flips to `False` in the next
-    release. Pass `save_state=True` or `save_state=False` explicitly to lock
-    in the behavior you want.
+    stable (v1) visualizer this release, but passing the argument at all now
+    emits a `DeprecationWarning`. The file dump is being replaced by the
+    event stream (`.railtracks/data/events/`). Default: `True` this release,
+    flips to `False` next release. Remove the argument to let the framework
+    default take over.
 
 !!! tip "Running from multiple directories?"
     Run `railtracks init` once from your project root, at the same level as

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -20,7 +20,7 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .observability.configure import _disable_events, add_inline_listener
+from .observability.configure import add_inline_listener
 from .observability.node_internals import NodeInternalsCollector
 from .pubsub import RTPublisher, event_subscriber
 from .state.info import (
@@ -67,7 +67,7 @@ class Session:
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Explicitly setting this argument emits a DeprecationWarning. 
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Explicitly setting this argument emits a DeprecationWarning.
             Default: True. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
     """
 
@@ -180,7 +180,7 @@ class Session:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.executor_config.save_state and not _disable_events():
+        if self.executor_config.save_state:
             try:
                 railtracks_dir = resolve_railtracks_home()
                 sessions_dir = railtracks_dir / "data" / "sessions"
@@ -218,7 +218,8 @@ class Session:
                 logger.warning(
                     "Could not persist session state to disk (%s: %s). "
                     "Set RAILTRACKS_DISABLE_EVENTS=True to silence this warning.",
-                    type(exc).__name__, exc,
+                    type(exc).__name__,
+                    exc,
                 )
             except Exception as e:
                 logger.error(

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -57,7 +57,7 @@ class Session:
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
     - `broadcast_callback`: None (no event listener)
-    - `save_state`: True (writes `.railtracks/data/sessions/*.json` at the end of the run). Deprecated as an implicit default — see the per-arg note; flips to False in the next release.
+    - `save_state`: True (writes `.railtracks/data/sessions/*.json` at the end of the run). The whole parameter is deprecated — see the per-arg note; default flips to False in the next release.
 
 
     Args:
@@ -68,7 +68,7 @@ class Session:
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
     """
 
     def __init__(
@@ -396,7 +396,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream.
 
     Returns:
         A decorator function that takes an async function and returns a new async function
@@ -445,7 +445,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
 
     Returns:
         When used as @session (without parentheses): Returns the decorated function that returns (result, session).

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+import os
 import time
 import uuid
 import warnings
@@ -20,7 +21,7 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .observability.configure import add_inline_listener
+from .observability.configure import _warn_readonly_disk_once, add_inline_listener
 from .observability.node_internals import NodeInternalsCollector
 from .pubsub import RTPublisher, event_subscriber
 from .state.info import (
@@ -56,7 +57,7 @@ class Session:
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
     - `broadcast_callback`: None (no event listener)
-    - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
+    - `save_state`: True (writes `.railtracks/data/sessions/*.json` at the end of the run). Deprecated as an implicit default — see the per-arg note; flips to False in the next release.
 
 
     Args:
@@ -67,7 +68,7 @@ class Session:
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
     """
 
     def __init__(
@@ -179,7 +180,9 @@ class Session:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.executor_config.save_state:
+        if self.executor_config.save_state and not os.environ.get(
+            "RAILTRACKS_DISABLE_EVENTS"
+        ):
             try:
                 railtracks_dir = resolve_railtracks_home()
                 sessions_dir = railtracks_dir / "data" / "sessions"
@@ -213,6 +216,8 @@ class Session:
                 content = json.dumps(self.payload())
                 file_path.write_text(content)
 
+            except OSError as exc:
+                _warn_readonly_disk_once("session state save", exc)
             except Exception as e:
                 logger.error(
                     "Error while saving execution info to file: %s",
@@ -391,7 +396,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
 
     Returns:
         A decorator function that takes an async function and returns a new async function
@@ -440,7 +445,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
 
     Returns:
         When used as @session (without parentheses): Returns the decorated function that returns (result, session).

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -1,6 +1,5 @@
 import inspect
 import json
-import os
 import time
 import uuid
 import warnings
@@ -21,7 +20,11 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .observability.configure import _warn_readonly_disk_once, add_inline_listener
+from .observability.configure import (
+    _disable_events,
+    _warn_readonly_disk_once,
+    add_inline_listener,
+)
 from .observability.node_internals import NodeInternalsCollector
 from .pubsub import RTPublisher, event_subscriber
 from .state.info import (
@@ -68,7 +71,8 @@ class Session:
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Explicitly setting this argument emits a DeprecationWarning. 
+            Default: True. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
     """
 
     def __init__(
@@ -180,9 +184,7 @@ class Session:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.executor_config.save_state and not os.environ.get(
-            "RAILTRACKS_DISABLE_EVENTS"
-        ):
+        if self.executor_config.save_state and not _disable_events():
             try:
                 railtracks_dir = resolve_railtracks_home()
                 sessions_dir = railtracks_dir / "data" / "sessions"
@@ -445,7 +447,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
 
     Returns:
         When used as @session (without parentheses): Returns the decorated function that returns (result, session).

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -56,7 +56,7 @@ class Session:
     - `timeout`: 150.0 seconds
     - `end_on_error`: False
     - `broadcast_callback`: None (no event listener)
-    - `save_state`: True (writes `.railtracks/data/sessions/*.json` at the end of the run). The whole parameter is deprecated — see the per-arg note; default flips to False in the next release.
+    - `save_state`: True (the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory)
 
 
     Args:
@@ -67,8 +67,7 @@ class Session:
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Explicitly setting this argument emits a DeprecationWarning.
-            Default: True. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
     """
 
     def __init__(
@@ -399,7 +398,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
     Returns:
         A decorator function that takes an async function and returns a new async function
@@ -448,7 +447,7 @@ def session(
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A callback function that will be called with the broadcast messages.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
 
     Returns:
         When used as @session (without parentheses): Returns the decorated function that returns (result, session).

--- a/packages/railtracks/src/railtracks/_session.py
+++ b/packages/railtracks/src/railtracks/_session.py
@@ -20,11 +20,7 @@ from .context.central import (
 )
 from .execution.coordinator import Coordinator
 from .execution.execution_strategy import AsyncioExecutionStrategy
-from .observability.configure import (
-    _disable_events,
-    _warn_readonly_disk_once,
-    add_inline_listener,
-)
+from .observability.configure import _disable_events, add_inline_listener
 from .observability.node_internals import NodeInternalsCollector
 from .pubsub import RTPublisher, event_subscriber
 from .state.info import (
@@ -219,7 +215,11 @@ class Session:
                 file_path.write_text(content)
 
             except OSError as exc:
-                _warn_readonly_disk_once("session state save", exc)
+                logger.warning(
+                    "Could not persist session state to disk (%s: %s). "
+                    "Set RAILTRACKS_DISABLE_EVENTS=True to silence this warning.",
+                    type(exc).__name__, exc,
+                )
             except Exception as e:
                 logger.error(
                     "Error while saving execution info to file: %s",

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -164,7 +164,7 @@ async def _start(
             entry_point_name=node.name() if hasattr(node, "name") else "Unknown",
             timeout=config.timeout,
             end_on_error=config.end_on_error,
-            save_state=config.save_state,
+            save_state=config._save_state_silently(),
         )
     )
     start_time = time.perf_counter()

--- a/packages/railtracks/src/railtracks/interaction/_call.py
+++ b/packages/railtracks/src/railtracks/interaction/_call.py
@@ -164,7 +164,7 @@ async def _start(
             entry_point_name=node.name() if hasattr(node, "name") else "Unknown",
             timeout=config.timeout,
             end_on_error=config.end_on_error,
-            save_state=config._save_state_silently(),
+            save_state=config.save_state,
         )
     )
     start_time = time.perf_counter()

--- a/packages/railtracks/src/railtracks/observability/configure.py
+++ b/packages/railtracks/src/railtracks/observability/configure.py
@@ -34,7 +34,9 @@ def _warn_readonly_disk_once(context: str, exc: OSError) -> None:
     logger.warning(
         "railtracks could not write to disk during %s (%s: %s). "
         "Set RAILTRACKS_DISABLE_EVENTS=1 to silence this warning.",
-        context, type(exc).__name__, exc,
+        context,
+        type(exc).__name__,
+        exc,
     )
 
 

--- a/packages/railtracks/src/railtracks/observability/configure.py
+++ b/packages/railtracks/src/railtracks/observability/configure.py
@@ -2,16 +2,40 @@
 
 from __future__ import annotations
 
+import os
 from typing import Callable
 
+from ..utils.logging.create import get_rt_logger
 from .models import Event
 from .observer import Observer
 from .writers.base import Writer
+from .writers.jsonl import JsonlWriter
+
+logger = get_rt_logger(__name__)
 
 observer: Observer = Observer()
 
 # Called synchronously before the event reaches the Observer's per-writer queues
 _inline_listeners: list[Callable[[Event], None]] = []
+
+_readonly_warning_emitted = False
+
+
+def _disable_events() -> bool:
+    return bool(os.environ.get("RAILTRACKS_DISABLE_EVENTS"))
+
+
+def _warn_readonly_disk_once(context: str, exc: OSError) -> None:
+    """Emit at most one WARN per process when railtracks can't write to disk."""
+    global _readonly_warning_emitted
+    if _readonly_warning_emitted:
+        return
+    _readonly_warning_emitted = True
+    logger.warning(
+        "railtracks could not write to disk during %s (%s: %s). "
+        "Set RAILTRACKS_DISABLE_EVENTS=1 to silence this warning.",
+        context, type(exc).__name__, exc,
+    )
 
 
 def configure_writers(writers: list[Writer]) -> None:
@@ -36,7 +60,18 @@ def inline_listeners() -> list[Callable[[Event], None]]:
 
 
 async def ensure_started() -> Observer:
-    """Start the singleton observer if not already started, return it."""
+    """Start the singleton observer if not already started, return it.
+
+    Auto-registers a default `JsonlWriter` when no writers have been configured
+    and `RAILTRACKS_DISABLE_EVENTS` is unset. Explicit `configure_writers(...)`
+    calls — including `configure_writers([])` — suppress the auto-default.
+    """
+    if (
+        not observer.is_running()
+        and not observer.has_explicit_writers()
+        and not _disable_events()
+    ):
+        observer.configure_writers([JsonlWriter()])
     await observer.start()
     return observer
 
@@ -55,6 +90,7 @@ def reset_for_tests() -> None:
     Swaps in a fresh `Observer` so consumer tasks from a previous test's event
     loop don't leak into the next one.
     """
-    global observer
+    global observer, _readonly_warning_emitted
     observer = Observer()
     _inline_listeners.clear()
+    _readonly_warning_emitted = False

--- a/packages/railtracks/src/railtracks/observability/configure.py
+++ b/packages/railtracks/src/railtracks/observability/configure.py
@@ -22,7 +22,9 @@ _readonly_warning_emitted = False
 
 
 def _disable_events() -> bool:
-    return bool(os.environ.get("RAILTRACKS_DISABLE_EVENTS"))
+    """Parse RAILTRACKS_DISABLE_EVENTS as a strict True/False env var
+    (case-insensitive). Anything else, including unset, is False."""
+    return os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true"
 
 
 def _warn_readonly_disk_once(context: str, exc: OSError) -> None:
@@ -33,7 +35,7 @@ def _warn_readonly_disk_once(context: str, exc: OSError) -> None:
     _readonly_warning_emitted = True
     logger.warning(
         "railtracks could not write to disk during %s (%s: %s). "
-        "Set RAILTRACKS_DISABLE_EVENTS=1 to silence this warning.",
+        "Set RAILTRACKS_DISABLE_EVENTS=True to silence this warning.",
         context,
         type(exc).__name__,
         exc,

--- a/packages/railtracks/src/railtracks/observability/configure.py
+++ b/packages/railtracks/src/railtracks/observability/configure.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import os
 from typing import Callable
 
+from ..utils.config import _disable_events
 from ..utils.logging.create import get_rt_logger
 from .models import Event
 from .observer import Observer
@@ -17,12 +17,6 @@ observer: Observer = Observer()
 
 # Called synchronously before the event reaches the Observer's per-writer queues
 _inline_listeners: list[Callable[[Event], None]] = []
-
-
-def _disable_events() -> bool:
-    """Parse RAILTRACKS_DISABLE_EVENTS as a strict True/False env var
-    (case-insensitive). Anything else, including unset, is False."""
-    return os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true"
 
 
 def configure_writers(writers: list[Writer]) -> None:

--- a/packages/railtracks/src/railtracks/observability/configure.py
+++ b/packages/railtracks/src/railtracks/observability/configure.py
@@ -18,28 +18,11 @@ observer: Observer = Observer()
 # Called synchronously before the event reaches the Observer's per-writer queues
 _inline_listeners: list[Callable[[Event], None]] = []
 
-_readonly_warning_emitted = False
-
 
 def _disable_events() -> bool:
     """Parse RAILTRACKS_DISABLE_EVENTS as a strict True/False env var
     (case-insensitive). Anything else, including unset, is False."""
     return os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true"
-
-
-def _warn_readonly_disk_once(context: str, exc: OSError) -> None:
-    """Emit at most one WARN per process when railtracks can't write to disk."""
-    global _readonly_warning_emitted
-    if _readonly_warning_emitted:
-        return
-    _readonly_warning_emitted = True
-    logger.warning(
-        "railtracks could not write to disk during %s (%s: %s). "
-        "Set RAILTRACKS_DISABLE_EVENTS=True to silence this warning.",
-        context,
-        type(exc).__name__,
-        exc,
-    )
 
 
 def configure_writers(writers: list[Writer]) -> None:
@@ -67,12 +50,11 @@ async def ensure_started() -> Observer:
     """Start the singleton observer if not already started, return it.
 
     Auto-registers a default `JsonlWriter` when no writers have been configured
-    and `RAILTRACKS_DISABLE_EVENTS` is unset. Explicit `configure_writers(...)`
-    calls — including `configure_writers([])` — suppress the auto-default.
+    and `RAILTRACKS_DISABLE_EVENTS` is unset.
     """
     if (
-        not observer.is_running()
-        and not observer.has_explicit_writers()
+        not observer._running
+        and not observer._pending_writers
         and not _disable_events()
     ):
         observer.configure_writers([JsonlWriter()])
@@ -94,7 +76,6 @@ def reset_for_tests() -> None:
     Swaps in a fresh `Observer` so consumer tasks from a previous test's event
     loop don't leak into the next one.
     """
-    global observer, _readonly_warning_emitted
+    global observer
     observer = Observer()
     _inline_listeners.clear()
-    _readonly_warning_emitted = False

--- a/packages/railtracks/src/railtracks/observability/observer.py
+++ b/packages/railtracks/src/railtracks/observability/observer.py
@@ -40,7 +40,15 @@ class Observer:
         self._drops: dict[str, int] = {}  # dropped events per writer
         self._running = False
         self._pending_writers: list[Writer] = []
+        self._writers_explicitly_configured: bool = False
         self._start_lock: asyncio.Lock = asyncio.Lock()
+
+    def is_running(self) -> bool:
+        return self._running
+
+    def has_explicit_writers(self) -> bool:
+        """True once `configure_writers` has been called, regardless of list length."""
+        return self._writers_explicitly_configured
 
     # async context manager support added for now, this will become more clear
     # once we move to integrating with the other modules
@@ -62,6 +70,7 @@ class Observer:
                 "configure_writers must be called before start(); use register() to add writers after."
             )
         self._pending_writers = list(writers)
+        self._writers_explicitly_configured = True
 
     async def start(self) -> None:
         """Bring up the observer.
@@ -73,8 +82,18 @@ class Observer:
         async with self._start_lock:
             if self._running:
                 return
+            from .configure import _warn_readonly_disk_once
             for i, writer in enumerate(self._pending_writers):
-                await self._register_impl(writer, f"writer-{i}")
+                name = f"writer-{i}"
+                try:
+                    await self._register_impl(writer, name)
+                except OSError as exc:
+                    _warn_readonly_disk_once(f"writer {name!r} start", exc)
+                except Exception as exc:
+                    logger.warning(
+                        "observability writer %r failed to start: %s: %s",
+                        name, type(exc).__name__, exc,
+                    )
             self._running = True
 
     async def shutdown(self) -> None:

--- a/packages/railtracks/src/railtracks/observability/observer.py
+++ b/packages/railtracks/src/railtracks/observability/observer.py
@@ -40,15 +40,7 @@ class Observer:
         self._drops: dict[str, int] = {}  # dropped events per writer
         self._running = False
         self._pending_writers: list[Writer] = []
-        self._writers_explicitly_configured: bool = False
         self._start_lock: asyncio.Lock = asyncio.Lock()
-
-    def is_running(self) -> bool:
-        return self._running
-
-    def has_explicit_writers(self) -> bool:
-        """True once `configure_writers` has been called, regardless of list length."""
-        return self._writers_explicitly_configured
 
     # async context manager support added for now, this will become more clear
     # once we move to integrating with the other modules
@@ -70,7 +62,6 @@ class Observer:
                 "configure_writers must be called before start(); use register() to add writers after."
             )
         self._pending_writers = list(writers)
-        self._writers_explicitly_configured = True
 
     async def start(self) -> None:
         """Bring up the observer.
@@ -82,20 +73,15 @@ class Observer:
         async with self._start_lock:
             if self._running:
                 return
-            from .configure import _warn_readonly_disk_once
-
             for i, writer in enumerate(self._pending_writers):
                 name = f"writer-{i}"
                 try:
                     await self._register_impl(writer, name)
-                except OSError as exc:
-                    _warn_readonly_disk_once(f"writer {name!r} start", exc)
                 except Exception as exc:
                     logger.warning(
-                        "observability writer %r failed to start: %s: %s",
-                        name,
-                        type(exc).__name__,
-                        exc,
+                        "observability writer %r failed to start (%s: %s); "
+                        "continuing without it.",
+                        name, type(exc).__name__, exc,
                     )
             self._running = True
 

--- a/packages/railtracks/src/railtracks/observability/observer.py
+++ b/packages/railtracks/src/railtracks/observability/observer.py
@@ -81,7 +81,9 @@ class Observer:
                     logger.warning(
                         "observability writer %r failed to start (%s: %s); "
                         "continuing without it.",
-                        name, type(exc).__name__, exc,
+                        name,
+                        type(exc).__name__,
+                        exc,
                     )
             self._running = True
 

--- a/packages/railtracks/src/railtracks/observability/observer.py
+++ b/packages/railtracks/src/railtracks/observability/observer.py
@@ -83,6 +83,7 @@ class Observer:
             if self._running:
                 return
             from .configure import _warn_readonly_disk_once
+
             for i, writer in enumerate(self._pending_writers):
                 name = f"writer-{i}"
                 try:
@@ -92,7 +93,9 @@ class Observer:
                 except Exception as exc:
                     logger.warning(
                         "observability writer %r failed to start: %s: %s",
-                        name, type(exc).__name__, exc,
+                        name,
+                        type(exc).__name__,
+                        exc,
                     )
             self._running = True
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -33,7 +33,7 @@ class Flow(Generic[_P, _TOutput]):
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
     """
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -33,7 +33,8 @@ class Flow(Generic[_P, _TOutput]):
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. This argument emits a DeprecationWarning.
+            Default: True. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip saving state regardless of this argument. If both are set, the environment variable takes precedence.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
     """
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -33,7 +33,7 @@ class Flow(Generic[_P, _TOutput]):
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write regardless.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Deprecated — passing this argument emits a DeprecationWarning; the file dump is being replaced by the event stream. Default: True this release, flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=True` to skip the write regardless.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
     """
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -33,7 +33,7 @@ class Flow(Generic[_P, _TOutput]):
         timeout (float, optional): The maximum number of seconds to wait for a response to your top-level request.
         end_on_error (bool, optional): If True, the execution will stop when an exception is encountered.
         broadcast_callback (Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None, optional): A passive listener for one-off events published with `rt.broadcast`.
-        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory.
+        save_state (bool, optional): If True, the state of the execution will be saved to a file at the end of the run in the `.railtracks/data/sessions/` directory. Ships True this release but emits DeprecationWarning when left implicit; default flips to False next release. Set `RAILTRACKS_DISABLE_EVENTS=1` to skip the write even when True.
         payload_callback (Callable[[dict[str, Any]], None], optional): A callback function that will run upon completion of the flow with the final payload as an argument.
     """
 

--- a/packages/railtracks/src/railtracks/orchestration/flow.py
+++ b/packages/railtracks/src/railtracks/orchestration/flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import warnings
 from copy import deepcopy
 from typing import Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
 
@@ -58,6 +59,14 @@ class Flow(Generic[_P, _TOutput]):
             self.entry_point = entry_point.node_type
         else:
             self.entry_point = entry_point
+
+        if save_state is not None:
+            warnings.warn(
+                "The save_state parameter is being deprecated. Use the "
+                "RAILTRACKS_DISABLE_EVENTS env var instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         self.name = name
         self._context: dict[str, Any] = context or {}

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -24,18 +24,17 @@ class ExecutorConfig:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
             broadcast_callback (Callable or Coroutine): A function or coroutine that receives items published with `rt.broadcast`.
-            save_state (bool | None): If true, the executor state is saved to disk at the end of the run. Pass None (or omit) to use the current implicit default (True); a DeprecationWarning fires and the default flips to False in the next release.
+            save_state (bool | None): Deprecated. If passed, emits a DeprecationWarning. `RAILTRACKS_DISABLE_EVENTS=True` skips the write regardless. Otherwise, explicit value wins; when unset, defaults to True (save).
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.subscriber = broadcast_callback
         if save_state is not None:
             warnings.warn(
-                "The save_state parameter is deprecated and will be removed in "
-                "a future release. The .railtracks/data/sessions/*.json dump is "
-                "being replaced by the event stream (.railtracks/data/events/). "
-                "Remove the save_state argument to let the framework default "
-                "take over; the default flips from True to False next release.",
+                "The save_state parameter is deprecated. Use the "
+                "RAILTRACKS_DISABLE_EVENTS env var instead — it controls "
+                "whether railtracks writes to disk, and takes precedence "
+                "over save_state when set.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -50,6 +49,8 @@ class ExecutorConfig:
         if os.getenv("RAILTRACKS_TEST_MODE") and not os.getenv(
             "RAILTRACKS_ALLOW_PERSISTENCE"
         ):
+            return False
+        if os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true":
             return False
         return True if self._user_save_state is None else self._user_save_state
 

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import Any, Callable, Coroutine
 
 
@@ -13,7 +14,7 @@ class ExecutorConfig:
         broadcast_callback: (
             Callable[[str], None] | Callable[[str], Coroutine[None, None, None]] | None
         ) = None,
-        save_state: bool = True,
+        save_state: bool | None = None,
         payload_callback: Callable[[dict[str, Any]], None] | None = None,
     ):
         """
@@ -23,12 +24,11 @@ class ExecutorConfig:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
             broadcast_callback (Callable or Coroutine): A function or coroutine that receives items published with `rt.broadcast`.
-            save_state (bool): If true, the state of the executor will be saved to disk.
+            save_state (bool | None): If true, the executor state is saved to disk at the end of the run. Pass None (or omit) to use the current implicit default (True); a DeprecationWarning fires and the default flips to False in the next release.
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.subscriber = broadcast_callback
-        # During test runs, disable save_state by default unless RAILTRACKS_ALLOW_PERSISTENCE is set
         self._user_save_state = save_state
 
         self.payload_callback = payload_callback
@@ -41,7 +41,30 @@ class ExecutorConfig:
             "RAILTRACKS_ALLOW_PERSISTENCE"
         ):
             return False
+        if self._user_save_state is None:
+            warnings.warn(
+                "save_state was not set explicitly on your Flow/Session; it "
+                "currently defaults to True. In the next release the default "
+                "will change to False. Pass save_state=True or save_state=False "
+                "explicitly to silence this warning and lock in the behavior "
+                "you want.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return True
         return self._user_save_state
+
+    def _save_state_silently(self) -> bool:
+        """Resolved save_state without emitting the deprecation warning.
+
+        For internal telemetry paths that need the value but shouldn't be the
+        thing that surfaces the deprecation to users.
+        """
+        if os.getenv("RAILTRACKS_TEST_MODE") and not os.getenv(
+            "RAILTRACKS_ALLOW_PERSISTENCE"
+        ):
+            return False
+        return True if self._user_save_state is None else self._user_save_state
 
     def precedence_overwritten(
         self,
@@ -65,7 +88,7 @@ class ExecutorConfig:
             broadcast_callback=subscriber
             if subscriber is not None
             else self.subscriber,
-            save_state=save_state if save_state is not None else self.save_state,
+            save_state=save_state if save_state is not None else self._user_save_state,
             payload_callback=payload_callback
             if payload_callback is not None
             else self.payload_callback,
@@ -74,5 +97,5 @@ class ExecutorConfig:
     def __repr__(self):
         return (
             f"ExecutorConfig(timeout={self.timeout}, end_on_error={self.end_on_error}, "
-            f"save_state={self.save_state}, payload_callback={self.payload_callback})"
+            f"save_state={self._user_save_state}, payload_callback={self.payload_callback})"
         )

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -5,6 +5,12 @@ import warnings
 from typing import Any, Callable, Coroutine
 
 
+def _disable_events() -> bool:
+    """Parse RAILTRACKS_DISABLE_EVENTS as a strict True/False env var
+    (case-insensitive). Anything else, including unset, is False."""
+    return os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true"
+
+
 class ExecutorConfig:
     def __init__(
         self,
@@ -36,6 +42,8 @@ class ExecutorConfig:
                 DeprecationWarning,
                 stacklevel=2,
             )
+        # During test runs, disable save_state by default unless
+        # RAILTRACKS_ALLOW_PERSISTENCE is set (see `save_state` property).
         self._user_save_state = save_state
 
         self.payload_callback = payload_callback
@@ -48,7 +56,7 @@ class ExecutorConfig:
             "RAILTRACKS_ALLOW_PERSISTENCE"
         ):
             return False
-        if os.environ.get("RAILTRACKS_DISABLE_EVENTS", "").strip().lower() == "true":
+        if _disable_events():
             return False
         return True if self._user_save_state is None else self._user_save_state
 
@@ -66,7 +74,7 @@ class ExecutorConfig:
         """
         If any of the parameters are provided (not None), it will create a new update the current instance with the new values and return a deep copied reference to it.
         """
-        return ExecutorConfig(
+        new = ExecutorConfig(
             timeout=timeout,
             end_on_error=end_on_error
             if end_on_error is not None
@@ -74,11 +82,14 @@ class ExecutorConfig:
             broadcast_callback=subscriber
             if subscriber is not None
             else self.subscriber,
-            save_state=save_state if save_state is not None else self._user_save_state,
+            save_state=save_state,
             payload_callback=payload_callback
             if payload_callback is not None
             else self.payload_callback,
         )
+        if save_state is None:
+            new._user_save_state = self._user_save_state
+        return new
 
     def __repr__(self):
         return (

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -37,7 +37,7 @@ class ExecutorConfig:
         self.subscriber = broadcast_callback
         if save_state is not None:
             warnings.warn(
-                "The save_state parameter is deprecated. Use the "
+                "The save_state parameter is being deprecated. Use the "
                 "RAILTRACKS_DISABLE_EVENTS env var instead",
                 DeprecationWarning,
                 stacklevel=2,

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -41,18 +41,18 @@ class ExecutorConfig:
             "RAILTRACKS_ALLOW_PERSISTENCE"
         ):
             return False
-        if self._user_save_state is None:
+        if self._user_save_state is not None:
             warnings.warn(
-                "save_state was not set explicitly on your Flow/Session; it "
-                "currently defaults to True. In the next release the default "
-                "will change to False. Pass save_state=True or save_state=False "
-                "explicitly to silence this warning and lock in the behavior "
-                "you want.",
+                "The save_state parameter is deprecated and will be removed in "
+                "a future release. The .railtracks/data/sessions/*.json dump is "
+                "being replaced by the event stream (.railtracks/data/events/). "
+                "Remove the save_state argument to let the framework default "
+                "take over; the default flips from True to False next release.",
                 DeprecationWarning,
                 stacklevel=3,
             )
-            return True
-        return self._user_save_state
+            return self._user_save_state
+        return True
 
     def _save_state_silently(self) -> bool:
         """Resolved save_state without emitting the deprecation warning.

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -32,9 +32,7 @@ class ExecutorConfig:
         if save_state is not None:
             warnings.warn(
                 "The save_state parameter is deprecated. Use the "
-                "RAILTRACKS_DISABLE_EVENTS env var instead — it controls "
-                "whether railtracks writes to disk, and takes precedence "
-                "over save_state when set.",
+                "RAILTRACKS_DISABLE_EVENTS env var instead",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -29,6 +29,16 @@ class ExecutorConfig:
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.subscriber = broadcast_callback
+        if save_state is not None:
+            warnings.warn(
+                "The save_state parameter is deprecated and will be removed in "
+                "a future release. The .railtracks/data/sessions/*.json dump is "
+                "being replaced by the event stream (.railtracks/data/events/). "
+                "Remove the save_state argument to let the framework default "
+                "take over; the default flips from True to False next release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self._user_save_state = save_state
 
         self.payload_callback = payload_callback
@@ -37,29 +47,6 @@ class ExecutorConfig:
     # later when we want to allow a few tests to actually run persistance, they wont be able to do so
     @property
     def save_state(self) -> bool:
-        if os.getenv("RAILTRACKS_TEST_MODE") and not os.getenv(
-            "RAILTRACKS_ALLOW_PERSISTENCE"
-        ):
-            return False
-        if self._user_save_state is not None:
-            warnings.warn(
-                "The save_state parameter is deprecated and will be removed in "
-                "a future release. The .railtracks/data/sessions/*.json dump is "
-                "being replaced by the event stream (.railtracks/data/events/). "
-                "Remove the save_state argument to let the framework default "
-                "take over; the default flips from True to False next release.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            return self._user_save_state
-        return True
-
-    def _save_state_silently(self) -> bool:
-        """Resolved save_state without emitting the deprecation warning.
-
-        For internal telemetry paths that need the value but shouldn't be the
-        thing that surfaces the deprecation to users.
-        """
         if os.getenv("RAILTRACKS_TEST_MODE") and not os.getenv(
             "RAILTRACKS_ALLOW_PERSISTENCE"
         ):

--- a/packages/railtracks/tests/conftest.py
+++ b/packages/railtracks/tests/conftest.py
@@ -236,8 +236,10 @@ def disable_persistence_for_tests():
     to override the default disable behavior.
     """
     os.environ["RAILTRACKS_TEST_MODE"] = "1"
+    os.environ["RAILTRACKS_DISABLE_EVENTS"] = "1"
     yield
     os.environ.pop("RAILTRACKS_TEST_MODE", None)
+    os.environ.pop("RAILTRACKS_DISABLE_EVENTS", None)
 
 
 @pytest.fixture
@@ -254,9 +256,12 @@ def allow_persistence():
             pass
     """
     previous_home = os.environ.pop("RAILTRACKS_HOME", None)
+    previous_disable_events = os.environ.pop("RAILTRACKS_DISABLE_EVENTS", None)
     os.environ["RAILTRACKS_ALLOW_PERSISTENCE"] = "1"
     yield
     os.environ.pop("RAILTRACKS_ALLOW_PERSISTENCE", None)
     if previous_home is not None:
         os.environ["RAILTRACKS_HOME"] = previous_home
+    if previous_disable_events is not None:
+        os.environ["RAILTRACKS_DISABLE_EVENTS"] = previous_disable_events
 

--- a/packages/railtracks/tests/conftest.py
+++ b/packages/railtracks/tests/conftest.py
@@ -236,7 +236,7 @@ def disable_persistence_for_tests():
     to override the default disable behavior.
     """
     os.environ["RAILTRACKS_TEST_MODE"] = "1"
-    os.environ["RAILTRACKS_DISABLE_EVENTS"] = "1"
+    os.environ["RAILTRACKS_DISABLE_EVENTS"] = "True"
     yield
     os.environ.pop("RAILTRACKS_TEST_MODE", None)
     os.environ.pop("RAILTRACKS_DISABLE_EVENTS", None)

--- a/packages/railtracks/tests/conftest.py
+++ b/packages/railtracks/tests/conftest.py
@@ -267,4 +267,3 @@ def allow_persistence():
         os.environ["RAILTRACKS_HOME"] = previous_home
     if previous_disable_events is not None:
         os.environ["RAILTRACKS_DISABLE_EVENTS"] = previous_disable_events
-

--- a/packages/railtracks/tests/unit_tests/observability/test_jsonl_writer.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_jsonl_writer.py
@@ -162,3 +162,23 @@ async def test_write_rejects_unsafe_scope_id(tmp_path: Path, bad_scope_id: str):
         assert list(tmp_path.iterdir()) == []
     finally:
         await writer.shutdown()
+
+
+async def test_start_propagates_mkdir_oserror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """JsonlWriter.start() surfaces the mkdir OSError to its caller. Higher
+    layers (Observer.start) are what catch it and route to the shared helper."""
+    target = tmp_path / "unwritable" / "events"
+    writer = JsonlWriter(target)
+
+    original_mkdir = Path.mkdir
+
+    def _refuse(self, *args, **kwargs):
+        if self == target:
+            raise OSError(30, "Read-only file system")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _refuse)
+    with pytest.raises(OSError, match="Read-only file system"):
+        await writer.start()

--- a/packages/railtracks/tests/unit_tests/observability/test_observer.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_observer.py
@@ -293,7 +293,7 @@ async def test_start_skips_writer_that_fails_with_oserror(caplog):
             r for r in caplog.records if "could not write to disk" in r.getMessage()
         ]
         assert len(readonly_warnings) == 1
-        assert "RAILTRACKS_DISABLE_EVENTS=1" in readonly_warnings[0].getMessage()
+        assert "RAILTRACKS_DISABLE_EVENTS=True" in readonly_warnings[0].getMessage()
     finally:
         await obs.shutdown()
 

--- a/packages/railtracks/tests/unit_tests/observability/test_observer.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_observer.py
@@ -218,3 +218,151 @@ async def test_drop_oldest_when_queue_full():
     finally:
         gate.set()
         await obs.shutdown()
+
+
+# ------------------------------------------------------------------------
+# Sentinel: distinguishes "configure_writers never called" from "called with []"
+# ------------------------------------------------------------------------
+
+
+def test_has_explicit_writers_false_on_fresh_observer():
+    assert Observer().has_explicit_writers() is False
+
+
+def test_has_explicit_writers_true_after_configure_writers():
+    obs = Observer()
+    obs.configure_writers([MemoryWriter()])
+    assert obs.has_explicit_writers() is True
+
+
+def test_has_explicit_writers_true_after_configure_writers_empty():
+    """configure_writers([]) is an explicit 'no writers' — must be
+    distinguishable from 'never called'. This is the whole point of the sentinel."""
+    obs = Observer()
+    obs.configure_writers([])
+    assert obs.has_explicit_writers() is True
+
+
+def test_is_running_reflects_start_shutdown_state():
+    obs = Observer()
+    assert obs.is_running() is False
+
+
+# ------------------------------------------------------------------------
+# Writer-start resilience (#1049)
+# ------------------------------------------------------------------------
+
+
+class _RaisingStartWriter:
+    """Writer whose start() raises. Post-start / write / shutdown never fire."""
+
+    def __init__(self, exc: BaseException):
+        self._exc = exc
+
+    async def start(self) -> None:
+        raise self._exc
+
+    async def write(self, event: Event) -> None:  # pragma: no cover — never called
+        raise AssertionError("write() should not be reached")
+
+    async def shutdown(self) -> None:  # pragma: no cover — never called
+        raise AssertionError("shutdown() should not be reached")
+
+
+async def test_start_skips_writer_that_fails_with_oserror(caplog):
+    """A pending writer whose start() raises OSError does not tank observer
+    bring-up. The good writer still registers; a single WARN is emitted."""
+    import logging
+
+    from railtracks.observability import configure
+
+    configure.reset_for_tests()  # reset the once-per-process warning flag
+    good = MemoryWriter()
+    bad = _RaisingStartWriter(OSError(30, "Read-only file system"))
+
+    obs = Observer()
+    obs.configure_writers([bad, good])
+    try:
+        with caplog.at_level(logging.WARNING, logger="railtracks"):
+            await obs.start()
+        assert obs.is_running() is True
+        assert "writer-0" not in obs._writers
+        assert "writer-1" in obs._writers
+        assert good.started is True
+        readonly_warnings = [
+            r for r in caplog.records if "could not write to disk" in r.getMessage()
+        ]
+        assert len(readonly_warnings) == 1
+        assert "RAILTRACKS_DISABLE_EVENTS=1" in readonly_warnings[0].getMessage()
+    finally:
+        await obs.shutdown()
+
+
+async def test_start_flips_running_when_all_writers_fail(caplog):
+    """Even with every writer failing, the observer must reach _running=True so
+    later publish() calls fail loudly instead of silently blocking."""
+    import logging
+
+    from railtracks.observability import configure
+
+    configure.reset_for_tests()
+    obs = Observer()
+    obs.configure_writers([_RaisingStartWriter(OSError("nope"))])
+    try:
+        with caplog.at_level(logging.WARNING, logger="railtracks"):
+            await obs.start()
+        assert obs.is_running() is True
+        assert obs._writers == {}
+        # publish() should raise RuntimeError, not hang or drop silently.
+        # (Observer._writers is empty, so it fans out to zero queues.)
+        await obs.publish(_event("e1"))
+    finally:
+        await obs.shutdown()
+
+
+async def test_readonly_disk_warning_emitted_only_once(caplog):
+    """Two failing writers in one start() batch → still just one WARN. The
+    helper's once-per-process guard prevents log spam."""
+    import logging
+
+    from railtracks.observability import configure
+
+    configure.reset_for_tests()
+    obs = Observer()
+    obs.configure_writers(
+        [
+            _RaisingStartWriter(OSError("first")),
+            _RaisingStartWriter(OSError("second")),
+        ]
+    )
+    try:
+        with caplog.at_level(logging.WARNING, logger="railtracks"):
+            await obs.start()
+        readonly_warnings = [
+            r for r in caplog.records if "could not write to disk" in r.getMessage()
+        ]
+        assert len(readonly_warnings) == 1
+    finally:
+        await obs.shutdown()
+
+
+async def test_start_logs_wider_warning_for_non_oserror_startup_failure(caplog):
+    """A non-OSError writer.start() failure gets a plain WARN (not the shared
+    'read-only disk' message)."""
+    import logging
+
+    from railtracks.observability import configure
+
+    configure.reset_for_tests()
+    obs = Observer()
+    obs.configure_writers([_RaisingStartWriter(RuntimeError("bad wiring"))])
+    try:
+        with caplog.at_level(logging.WARNING, logger="railtracks"):
+            await obs.start()
+        assert obs.is_running() is True
+        assert obs._writers == {}
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("failed to start" in m and "RuntimeError" in m for m in msgs)
+        assert not any("could not write to disk" in m for m in msgs)
+    finally:
+        await obs.shutdown()

--- a/packages/railtracks/tests/unit_tests/observability/test_observer.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_observer.py
@@ -221,148 +221,36 @@ async def test_drop_oldest_when_queue_full():
 
 
 # ------------------------------------------------------------------------
-# Sentinel: distinguishes "configure_writers never called" from "called with []"
-# ------------------------------------------------------------------------
-
-
-def test_has_explicit_writers_false_on_fresh_observer():
-    assert Observer().has_explicit_writers() is False
-
-
-def test_has_explicit_writers_true_after_configure_writers():
-    obs = Observer()
-    obs.configure_writers([MemoryWriter()])
-    assert obs.has_explicit_writers() is True
-
-
-def test_has_explicit_writers_true_after_configure_writers_empty():
-    """configure_writers([]) is an explicit 'no writers' — must be
-    distinguishable from 'never called'. This is the whole point of the sentinel."""
-    obs = Observer()
-    obs.configure_writers([])
-    assert obs.has_explicit_writers() is True
-
-
-def test_is_running_reflects_start_shutdown_state():
-    obs = Observer()
-    assert obs.is_running() is False
-
-
-# ------------------------------------------------------------------------
 # Writer-start resilience (#1049)
 # ------------------------------------------------------------------------
 
 
 class _RaisingStartWriter:
-    """Writer whose start() raises. Post-start / write / shutdown never fire."""
-
-    def __init__(self, exc: BaseException):
-        self._exc = exc
-
     async def start(self) -> None:
-        raise self._exc
+        raise OSError(30, "Read-only file system")
 
-    async def write(self, event: Event) -> None:  # pragma: no cover — never called
+    async def write(self, event: Event) -> None:  # pragma: no cover
         raise AssertionError("write() should not be reached")
 
-    async def shutdown(self) -> None:  # pragma: no cover — never called
+    async def shutdown(self) -> None:  # pragma: no cover
         raise AssertionError("shutdown() should not be reached")
 
 
-async def test_start_skips_writer_that_fails_with_oserror(caplog):
-    """A pending writer whose start() raises OSError does not tank observer
-    bring-up. The good writer still registers; a single WARN is emitted."""
+async def test_start_skips_writer_whose_start_fails(caplog):
+    """A pending writer whose start() raises does not tank observer bring-up.
+    The good writer still registers and a WARN is logged."""
     import logging
 
-    from railtracks.observability import configure
-
-    configure.reset_for_tests()  # reset the once-per-process warning flag
     good = MemoryWriter()
-    bad = _RaisingStartWriter(OSError(30, "Read-only file system"))
-
     obs = Observer()
-    obs.configure_writers([bad, good])
+    obs.configure_writers([_RaisingStartWriter(), good])
     try:
         with caplog.at_level(logging.WARNING, logger="railtracks"):
             await obs.start()
-        assert obs.is_running() is True
+        assert obs._running is True
         assert "writer-0" not in obs._writers
         assert "writer-1" in obs._writers
         assert good.started is True
-        readonly_warnings = [
-            r for r in caplog.records if "could not write to disk" in r.getMessage()
-        ]
-        assert len(readonly_warnings) == 1
-        assert "RAILTRACKS_DISABLE_EVENTS=True" in readonly_warnings[0].getMessage()
-    finally:
-        await obs.shutdown()
-
-
-async def test_start_flips_running_when_all_writers_fail(caplog):
-    """Even with every writer failing, the observer must reach _running=True so
-    later publish() calls fail loudly instead of silently blocking."""
-    import logging
-
-    from railtracks.observability import configure
-
-    configure.reset_for_tests()
-    obs = Observer()
-    obs.configure_writers([_RaisingStartWriter(OSError("nope"))])
-    try:
-        with caplog.at_level(logging.WARNING, logger="railtracks"):
-            await obs.start()
-        assert obs.is_running() is True
-        assert obs._writers == {}
-        # publish() should raise RuntimeError, not hang or drop silently.
-        # (Observer._writers is empty, so it fans out to zero queues.)
-        await obs.publish(_event("e1"))
-    finally:
-        await obs.shutdown()
-
-
-async def test_readonly_disk_warning_emitted_only_once(caplog):
-    """Two failing writers in one start() batch → still just one WARN. The
-    helper's once-per-process guard prevents log spam."""
-    import logging
-
-    from railtracks.observability import configure
-
-    configure.reset_for_tests()
-    obs = Observer()
-    obs.configure_writers(
-        [
-            _RaisingStartWriter(OSError("first")),
-            _RaisingStartWriter(OSError("second")),
-        ]
-    )
-    try:
-        with caplog.at_level(logging.WARNING, logger="railtracks"):
-            await obs.start()
-        readonly_warnings = [
-            r for r in caplog.records if "could not write to disk" in r.getMessage()
-        ]
-        assert len(readonly_warnings) == 1
-    finally:
-        await obs.shutdown()
-
-
-async def test_start_logs_wider_warning_for_non_oserror_startup_failure(caplog):
-    """A non-OSError writer.start() failure gets a plain WARN (not the shared
-    'read-only disk' message)."""
-    import logging
-
-    from railtracks.observability import configure
-
-    configure.reset_for_tests()
-    obs = Observer()
-    obs.configure_writers([_RaisingStartWriter(RuntimeError("bad wiring"))])
-    try:
-        with caplog.at_level(logging.WARNING, logger="railtracks"):
-            await obs.start()
-        assert obs.is_running() is True
-        assert obs._writers == {}
-        msgs = [r.getMessage() for r in caplog.records]
-        assert any("failed to start" in m and "RuntimeError" in m for m in msgs)
-        assert not any("could not write to disk" in m for m in msgs)
+        assert any("failed to start" in r.getMessage() for r in caplog.records)
     finally:
         await obs.shutdown()

--- a/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
@@ -126,7 +126,7 @@ async def test_publish_after_shutdown_raises():
 
 
 async def test_ensure_started_with_events_disabled_skips_auto_default(caplog):
-    """With RAILTRACKS_DISABLE_EVENTS=1 (set by conftest) and no explicit
+    """With RAILTRACKS_DISABLE_EVENTS=True (set by conftest) and no explicit
     configure_writers, ensure_started() starts with zero pending writers.
     Subsequent publishes fan out to nothing."""
     await ensure_started()

--- a/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
@@ -12,6 +12,7 @@ from railtracks.observability import (
     publish_event,
     shutdown,
 )
+from railtracks.observability.writers.jsonl import JsonlWriter
 
 
 class _CollectingWriter:
@@ -124,11 +125,55 @@ async def test_publish_after_shutdown_raises():
     assert [e.event_type for e in writer.events] == ["first"]
 
 
-async def test_ensure_started_before_configure_writers_starts_with_no_writers(caplog):
-    """Calling ensure_started() with no prior configure_writers() is fine —
-    the observer starts with zero pending writers. Subsequent publishes just
-    fan out to nothing."""
+async def test_ensure_started_with_events_disabled_skips_auto_default(caplog):
+    """With RAILTRACKS_DISABLE_EVENTS=1 (set by conftest) and no explicit
+    configure_writers, ensure_started() starts with zero pending writers.
+    Subsequent publishes fan out to nothing."""
     await ensure_started()
-    assert configure.observer._running is True
+    assert configure.observer.is_running() is True
+    assert configure.observer._writers == {}
     await publish_event(_make_session_event())
     await shutdown()
+
+
+async def test_ensure_started_auto_injects_default_writer_when_events_enabled(
+    monkeypatch, tmp_path
+):
+    """With RAILTRACKS_DISABLE_EVENTS unset, ensure_started() auto-registers a
+    default JsonlWriter that writes to the resolved events directory."""
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
+    monkeypatch.setenv("RAILTRACKS_EVENTS_DIR", str(tmp_path / "events"))
+    await ensure_started()
+    try:
+        assert len(configure.observer._writers) == 1
+        entry = next(iter(configure.observer._writers.values()))
+        assert isinstance(entry.writer, JsonlWriter)
+    finally:
+        await shutdown()
+
+
+async def test_explicit_configure_writers_wins_over_auto_default(monkeypatch):
+    """A user's explicit configure_writers([...]) suppresses the auto-default
+    even when the env var is unset."""
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
+    user_writer = _CollectingWriter()
+    configure_writers([user_writer])
+    await ensure_started()
+    try:
+        entries = list(configure.observer._writers.values())
+        assert len(entries) == 1
+        assert entries[0].writer is user_writer
+    finally:
+        await shutdown()
+
+
+async def test_explicit_empty_writers_suppresses_auto_default(monkeypatch):
+    """configure_writers([]) is an explicit 'no writers' — the sentinel prevents
+    the auto-default from filling in."""
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
+    configure_writers([])
+    await ensure_started()
+    try:
+        assert configure.observer._writers == {}
+    finally:
+        await shutdown()

--- a/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
@@ -130,7 +130,7 @@ async def test_ensure_started_with_events_disabled_skips_auto_default(caplog):
     configure_writers, ensure_started() starts with zero pending writers.
     Subsequent publishes fan out to nothing."""
     await ensure_started()
-    assert configure.observer.is_running() is True
+    assert configure.observer._running is True
     assert configure.observer._writers == {}
     await publish_event(_make_session_event())
     await shutdown()
@@ -167,13 +167,3 @@ async def test_explicit_configure_writers_wins_over_auto_default(monkeypatch):
         await shutdown()
 
 
-async def test_explicit_empty_writers_suppresses_auto_default(monkeypatch):
-    """configure_writers([]) is an explicit 'no writers' — the sentinel prevents
-    the auto-default from filling in."""
-    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    configure_writers([])
-    await ensure_started()
-    try:
-        assert configure.observer._writers == {}
-    finally:
-        await shutdown()

--- a/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
+++ b/packages/railtracks/tests/unit_tests/observability/test_publish_event.py
@@ -165,5 +165,3 @@ async def test_explicit_configure_writers_wins_over_auto_default(monkeypatch):
         assert entries[0].writer is user_writer
     finally:
         await shutdown()
-
-

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -230,10 +230,10 @@ def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch
 def test_session_exit_skips_save_when_disable_events_env_set(
     tmp_path, monkeypatch
 ):
-    """RAILTRACKS_DISABLE_EVENTS=1 wins over save_state=True. Nothing written,
+    """RAILTRACKS_DISABLE_EVENTS=True wins over save_state=True. Nothing written,
     no log noise."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
-    monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "1")
+    monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
     monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
     monkeypatch.chdir(tmp_path)
 
@@ -281,7 +281,7 @@ def test_session_exit_swallows_oserror_on_readonly_disk(
 
     readonly = [rec for rec in caplog.records if "could not write to disk" in rec.getMessage()]
     assert len(readonly) == 1
-    assert "RAILTRACKS_DISABLE_EVENTS=1" in readonly[0].getMessage()
+    assert "RAILTRACKS_DISABLE_EVENTS=True" in readonly[0].getMessage()
     errors = [rec for rec in caplog.records if rec.levelname == "ERROR"]
     assert errors == []
 

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -139,6 +139,7 @@ def test_session_saves_data(tmp_path, monkeypatch):
     """Test that session saves execution data to JSON file in temp directory."""
     name = "abs53562j12h267"
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
     monkeypatch.chdir(tmp_path)
 
@@ -190,9 +191,104 @@ def test_session_not_saves_data(tmp_path, monkeypatch):
     # If directory doesn't exist, that's also fine - nothing was saved
 
 
+# ================= Deprecation lane for save_state default (#1049) =================
+
+
+def test_session_implicit_default_save_state_is_still_true(monkeypatch):
+    """This release: implicit save_state resolves to True (with a DeprecationWarning).
+    Next release: this flips to False. Test guards the current release's behavior."""
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    r = Session()
+    with pytest.warns(DeprecationWarning, match="save_state was not set explicitly"):
+        assert r.executor_config.save_state is True
+
+
+def test_session_explicit_save_state_true_no_warning(monkeypatch, recwarn):
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    r = Session(save_state=True)
+    assert r.executor_config.save_state is True
+    save_state_warnings = [
+        w for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning)
+        and "save_state was not set explicitly" in str(w.message)
+    ]
+    assert save_state_warnings == []
+
+
+def test_session_explicit_save_state_false_no_warning(recwarn):
+    r = Session(save_state=False)
+    assert r.executor_config.save_state is False
+    save_state_warnings = [
+        w for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning)
+        and "save_state was not set explicitly" in str(w.message)
+    ]
+    assert save_state_warnings == []
+
+
+def test_session_exit_skips_save_when_disable_events_env_set(
+    tmp_path, monkeypatch
+):
+    """RAILTRACKS_DISABLE_EVENTS=1 wins over save_state=True. Nothing written,
+    no log noise."""
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "1")
+    monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(Session, "info", new_callable=PropertyMock) as mock_info:
+        mock_info.return_value.graph_serialization.return_value = {"Key": "Value"}
+
+        r = Session(name="disabled", save_state=True)
+        r.__exit__(None, None, None)
+
+    sessions_dir = tmp_path / ".railtracks" / "data" / "sessions"
+    assert not sessions_dir.exists() or not list(sessions_dir.glob("*.json"))
+
+
+def test_session_exit_swallows_oserror_on_readonly_disk(
+    tmp_path, monkeypatch, caplog
+):
+    """When save_state=True and the filesystem is read-only, __exit__ returns
+    cleanly with a single WARN from the shared once-per-process helper.
+    No ERROR, no traceback."""
+    import logging
+
+    from railtracks.observability import configure
+
+    configure.reset_for_tests()  # clear the once-per-process warning latch
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
+    monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    original_mkdir = Path.mkdir
+
+    def _refuse(self, *args, **kwargs):
+        if "sessions" in self.parts:
+            raise OSError(30, "Read-only file system")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _refuse)
+
+    with patch.object(Session, "info", new_callable=PropertyMock) as mock_info:
+        mock_info.return_value.graph_serialization.return_value = {"Key": "Value"}
+
+        r = Session(name="ro", save_state=True)
+        with caplog.at_level(logging.WARNING, logger="railtracks"):
+            r.__exit__(None, None, None)
+
+    readonly = [rec for rec in caplog.records if "could not write to disk" in rec.getMessage()]
+    assert len(readonly) == 1
+    assert "RAILTRACKS_DISABLE_EVENTS=1" in readonly[0].getMessage()
+    errors = [rec for rec in caplog.records if rec.levelname == "ERROR"]
+    assert errors == []
+
+
 def test_session_fallback_on_invalid_name(tmp_path, monkeypatch):
     """Test that session falls back to identifier-only filename when name causes issues."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
     monkeypatch.chdir(tmp_path)
     

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -194,12 +194,12 @@ def test_session_not_saves_data(tmp_path, monkeypatch):
 # ================= Deprecation lane for save_state default (#1049) =================
 
 
-def test_session_implicit_default_save_state_is_still_true_and_no_warning(
+def test_session_implicit_default_save_state_is_true_and_no_warning(
     monkeypatch, recwarn
 ):
-    """This release: implicit save_state resolves to True silently. Next release
-    it flips to False. Users who never touched the argument get no warning."""
+    """Implicit save_state resolves to True (save) silently."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     r = Session()
     assert r.executor_config.save_state is True
     save_state_warnings = [
@@ -211,27 +211,38 @@ def test_session_implicit_default_save_state_is_still_true_and_no_warning(
 
 
 def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch):
-    """Passing save_state at all is deprecated (the file dump is being replaced
-    by the event stream). Explicit True still resolves to True this release."""
+    """Passing save_state at all is deprecated. Without the env var, explicit
+    True still resolves to True."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
         r = Session(save_state=True)
     assert r.executor_config.save_state is True
 
 
 def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
-    """Same rule for explicit False — the parameter itself is on the way out."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
         r = Session(save_state=False)
+    assert r.executor_config.save_state is False
+
+
+def test_env_var_wins_over_explicit_save_state_true(monkeypatch):
+    """RAILTRACKS_DISABLE_EVENTS=True beats an explicit save_state=True — the
+    env var is the ops-level kill switch and takes precedence."""
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
+    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+        r = Session(save_state=True)
     assert r.executor_config.save_state is False
 
 
 def test_session_exit_skips_save_when_disable_events_env_set(
     tmp_path, monkeypatch
 ):
-    """RAILTRACKS_DISABLE_EVENTS=True wins over save_state=True. Nothing written,
-    no log noise."""
+    """RAILTRACKS_DISABLE_EVENTS=True wins over save_state=True at __exit__ time
+    too. Nothing is written, no log noise."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
     monkeypatch.delenv("RAILTRACKS_HOME", raising=False)

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -214,17 +214,17 @@ def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch)
     """Passing save_state at all is deprecated (the file dump is being replaced
     by the event stream). Explicit True still resolves to True this release."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
-    r = Session(save_state=True)
     with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
-        assert r.executor_config.save_state is True
+        r = Session(save_state=True)
+    assert r.executor_config.save_state is True
 
 
 def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
     """Same rule for explicit False — the parameter itself is on the way out."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
-    r = Session(save_state=False)
     with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
-        assert r.executor_config.save_state is False
+        r = Session(save_state=False)
+    assert r.executor_config.save_state is False
 
 
 def test_session_exit_skips_save_when_disable_events_env_set(
@@ -251,13 +251,9 @@ def test_session_exit_swallows_oserror_on_readonly_disk(
     tmp_path, monkeypatch, caplog
 ):
     """When save_state=True and the filesystem is read-only, __exit__ returns
-    cleanly with a single WARN from the shared once-per-process helper.
-    No ERROR, no traceback."""
+    cleanly with a WARN and no ERROR / traceback."""
     import logging
 
-    from railtracks.observability import configure
-
-    configure.reset_for_tests()  # clear the once-per-process warning latch
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
     monkeypatch.delenv("RAILTRACKS_HOME", raising=False)
@@ -279,11 +275,10 @@ def test_session_exit_swallows_oserror_on_readonly_disk(
         with caplog.at_level(logging.WARNING, logger="railtracks"):
             r.__exit__(None, None, None)
 
-    readonly = [rec for rec in caplog.records if "could not write to disk" in rec.getMessage()]
-    assert len(readonly) == 1
-    assert "RAILTRACKS_DISABLE_EVENTS=True" in readonly[0].getMessage()
-    errors = [rec for rec in caplog.records if rec.levelname == "ERROR"]
-    assert errors == []
+    warns = [rec for rec in caplog.records if "Could not persist session state to disk" in rec.getMessage()]
+    assert warns, "expected a warning about the failed session save"
+    assert "RAILTRACKS_DISABLE_EVENTS=True" in warns[0].getMessage()
+    assert [rec for rec in caplog.records if rec.levelname == "ERROR"] == []
 
 
 def test_session_fallback_on_invalid_name(tmp_path, monkeypatch):

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -205,7 +205,7 @@ def test_session_implicit_default_save_state_is_true_and_no_warning(
     save_state_warnings = [
         w for w in recwarn.list
         if issubclass(w.category, DeprecationWarning)
-        and "save_state parameter is deprecated" in str(w.message)
+        and "save_state parameter is being deprecated" in str(w.message)
     ]
     assert save_state_warnings == []
 
@@ -215,7 +215,7 @@ def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch)
     True still resolves to True."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
         r = Session(save_state=True)
     assert r.executor_config.save_state is True
 
@@ -223,7 +223,7 @@ def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch)
 def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
         r = Session(save_state=False)
     assert r.executor_config.save_state is False
 
@@ -233,7 +233,7 @@ def test_env_var_wins_over_explicit_save_state_true(monkeypatch):
     env var is the ops-level kill switch and takes precedence."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
-    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
         r = Session(save_state=True)
     assert r.executor_config.save_state is False
 

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -231,7 +231,8 @@ def test_session_implicit_default_save_state_is_true_and_no_warning(
     r = Session()
     assert r.executor_config.save_state is True
     save_state_warnings = [
-        w for w in recwarn.list
+        w
+        for w in recwarn.list
         if issubclass(w.category, DeprecationWarning)
         and "save_state parameter is being deprecated" in str(w.message)
     ]
@@ -243,7 +244,9 @@ def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch)
     True still resolves to True."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="save_state parameter is being deprecated"
+    ):
         r = Session(save_state=True)
     assert r.executor_config.save_state is True
 
@@ -251,7 +254,9 @@ def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch)
 def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="save_state parameter is being deprecated"
+    ):
         r = Session(save_state=False)
     assert r.executor_config.save_state is False
 
@@ -261,14 +266,14 @@ def test_env_var_wins_over_explicit_save_state_true(monkeypatch):
     env var is the ops-level kill switch and takes precedence."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
-    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="save_state parameter is being deprecated"
+    ):
         r = Session(save_state=True)
     assert r.executor_config.save_state is False
 
 
-def test_session_exit_skips_save_when_disable_events_env_set(
-    tmp_path, monkeypatch
-):
+def test_session_exit_skips_save_when_disable_events_env_set(tmp_path, monkeypatch):
     """RAILTRACKS_DISABLE_EVENTS=True wins over save_state=True at __exit__ time
     too. Nothing is written, no log noise."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
@@ -286,9 +291,7 @@ def test_session_exit_skips_save_when_disable_events_env_set(
     assert not sessions_dir.exists() or not list(sessions_dir.glob("*.json"))
 
 
-def test_session_exit_swallows_oserror_on_readonly_disk(
-    tmp_path, monkeypatch, caplog
-):
+def test_session_exit_swallows_oserror_on_readonly_disk(tmp_path, monkeypatch, caplog):
     """When save_state=True and the filesystem is read-only, __exit__ returns
     cleanly with a WARN and no ERROR / traceback."""
     import logging
@@ -314,7 +317,11 @@ def test_session_exit_swallows_oserror_on_readonly_disk(
         with caplog.at_level(logging.WARNING, logger="railtracks"):
             r.__exit__(None, None, None)
 
-    warns = [rec for rec in caplog.records if "Could not persist session state to disk" in rec.getMessage()]
+    warns = [
+        rec
+        for rec in caplog.records
+        if "Could not persist session state to disk" in rec.getMessage()
+    ]
     assert warns, "expected a warning about the failed session save"
     assert "RAILTRACKS_DISABLE_EVENTS=True" in warns[0].getMessage()
     assert [rec for rec in caplog.records if rec.levelname == "ERROR"] == []

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -194,36 +194,37 @@ def test_session_not_saves_data(tmp_path, monkeypatch):
 # ================= Deprecation lane for save_state default (#1049) =================
 
 
-def test_session_implicit_default_save_state_is_still_true(monkeypatch):
-    """This release: implicit save_state resolves to True (with a DeprecationWarning).
-    Next release: this flips to False. Test guards the current release's behavior."""
+def test_session_implicit_default_save_state_is_still_true_and_no_warning(
+    monkeypatch, recwarn
+):
+    """This release: implicit save_state resolves to True silently. Next release
+    it flips to False. Users who never touched the argument get no warning."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     r = Session()
-    with pytest.warns(DeprecationWarning, match="save_state was not set explicitly"):
-        assert r.executor_config.save_state is True
-
-
-def test_session_explicit_save_state_true_no_warning(monkeypatch, recwarn):
-    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
-    r = Session(save_state=True)
     assert r.executor_config.save_state is True
     save_state_warnings = [
         w for w in recwarn.list
         if issubclass(w.category, DeprecationWarning)
-        and "save_state was not set explicitly" in str(w.message)
+        and "save_state parameter is deprecated" in str(w.message)
     ]
     assert save_state_warnings == []
 
 
-def test_session_explicit_save_state_false_no_warning(recwarn):
+def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch):
+    """Passing save_state at all is deprecated (the file dump is being replaced
+    by the event stream). Explicit True still resolves to True this release."""
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
+    r = Session(save_state=True)
+    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+        assert r.executor_config.save_state is True
+
+
+def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
+    """Same rule for explicit False — the parameter itself is on the way out."""
+    monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     r = Session(save_state=False)
-    assert r.executor_config.save_state is False
-    save_state_warnings = [
-        w for w in recwarn.list
-        if issubclass(w.category, DeprecationWarning)
-        and "save_state was not set explicitly" in str(w.message)
-    ]
-    assert save_state_warnings == []
+    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+        assert r.executor_config.save_state is False
 
 
 def test_session_exit_skips_save_when_disable_events_env_set(

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -99,3 +99,24 @@ def test_precedence_overwritten_timeout_float_enables(base_config):
     """Calling precedence_overwritten(timeout=float) should set the timeout to that float."""
     updated_config = base_config.precedence_overwritten(timeout=42.0)
     assert updated_config.timeout == 42.0
+
+
+def test_save_state_explicit_emits_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+        ExecutorConfig(save_state=False)
+
+
+def test_save_state_unset_emits_no_deprecation_warning(recwarn):
+    ExecutorConfig()
+    assert not [
+        w for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning)
+        and "save_state" in str(w.message)
+    ]
+
+
+def test_save_state_property_false_when_disable_events_env_set(monkeypatch):
+    monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "true")
+    monkeypatch.delenv("RAILTRACKS_TEST_MODE", raising=False)
+    config = ExecutorConfig()
+    assert config.save_state is False

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -102,7 +102,7 @@ def test_precedence_overwritten_timeout_float_enables(base_config):
 
 
 def test_save_state_explicit_emits_deprecation_warning():
-    with pytest.warns(DeprecationWarning, match="save_state parameter is deprecated"):
+    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
         ExecutorConfig(save_state=False)
 
 

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -112,16 +112,18 @@ def test_precedence_overwritten_timeout_float_enables(base_config):
 
 
 def test_save_state_explicit_emits_deprecation_warning():
-    with pytest.warns(DeprecationWarning, match="save_state parameter is being deprecated"):
+    with pytest.warns(
+        DeprecationWarning, match="save_state parameter is being deprecated"
+    ):
         ExecutorConfig(save_state=False)
 
 
 def test_save_state_unset_emits_no_deprecation_warning(recwarn):
     ExecutorConfig()
     assert not [
-        w for w in recwarn.list
-        if issubclass(w.category, DeprecationWarning)
-        and "save_state" in str(w.message)
+        w
+        for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning) and "save_state" in str(w.message)
     ]
 
 

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -316,10 +316,9 @@ class TestPublisherOrdering:
         assert _message[0][1] == "hello world"
         assert _message[1][1] == "second"
         assert _message[0][0] < _message[1][0], "Messages should be processed in order."
-        assert (
-            abs(_message[1][0] - _message[0][0] - 0.1) < 0.05
-        ), "Messages should be processed with a delay of 0.1 seconds roughly"
-
+        assert abs(_message[1][0] - _message[0][0] - 0.1) < 0.05, (
+            "Messages should be processed with a delay of 0.1 seconds roughly"
+        )
 
     @pytest.mark.asyncio
     async def test_multiple_subs_with_blocking(self, started_publisher):
@@ -351,9 +350,9 @@ class TestPublisherOrdering:
 
         # Between message 1 and message 2, callback1 runs with a 0.1s sleep,
         # so there should be a delay of roughly 0.1s between callback2 timestamps.
-        assert (
-            abs(_message_2[1][0] - _message_2[0][0] - 0.1) < 0.05
-        ), "Second message should be delayed by callback1's sleep time"
+        assert abs(_message_2[1][0] - _message_2[0][0] - 0.1) < 0.05, (
+            "Second message should be delayed by callback1's sleep time"
+        )
 
 
 # ================ END Publisher ordering/blocking tests ===============

--- a/packages/railtracks/tests/unit_tests/utils/test_publisher.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_publisher.py
@@ -317,7 +317,7 @@ class TestPublisherOrdering:
         assert _message[1][1] == "second"
         assert _message[0][0] < _message[1][0], "Messages should be processed in order."
         assert (
-            abs(_message[1][0] - _message[0][0] - 0.1) < 0.02
+            abs(_message[1][0] - _message[0][0] - 0.1) < 0.05
         ), "Messages should be processed with a delay of 0.1 seconds roughly"
 
 
@@ -350,7 +350,7 @@ class TestPublisherOrdering:
         # Between message 1 and message 2, callback1 runs with a 0.1s sleep,
         # so there should be a delay of roughly 0.1s between callback2 timestamps.
         assert (
-            abs(_message_2[1][0] - _message_2[0][0] - 0.1) < 0.02
+            abs(_message_2[1][0] - _message_2[0][0] - 0.1) < 0.05
         ), "Second message should be delayed by callback1's sleep time"
 
 


### PR DESCRIPTION
## Summary

Closes #1447

This PR solves two issues relating to "saving state" of agent sessions. Previously `save_state` would flag whether or not the session tree json files would get saved or not. As session trees are a legacy concept and event emission is the new way we're doing things, I introduced the following ways of turning local event saving as jsonl files:

- Auto-register JsonlWriter in ensure_started; skip when RAILTRACKS_DISABLE_EVENTS=True or writers configured (#1447)
- Session.__exit__ downgrades save failure to one warn line (#1049) in case users forget to set the env var
- RAILTRACKS_DISABLE_EVENTS=True also skips session-state disk write via ExecutorConfig.save_state
- save_state emits DeprecationWarning on explicit set on Flow only

## Type of change

- [ ] Bug fix
- [] Feature
- [ ] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [x] Breaking changes include migration notes

## Permutations to play with

1) Nothing set, everything is saved
- events and session tree saved
```python
import railtracks as rt

rt.enable_logging()

Assistant = rt.agent_node(
    name="Assistant",
    system_message="You are a helpful assistant",
    llm=rt.llm.OpenAILLM("gpt-5.4"),
)

invoker_flow = rt.Flow(
    name="Persistence Test",
    entry_point=Assistant,
)

print(invoker_flow.invoke("How do I make scrambled eggs"))
```

2) `save_state=False` or `save_state=True`
- events saved, session tree skipped, deprecation warning
```python
import railtracks as rt

rt.enable_logging()

Assistant = rt.agent_node(
    name="Assistant",
    system_message="You are a helpful assistant",
    llm=rt.llm.OpenAILLM("gpt-5.4"),
)

invoker_flow = rt.Flow(
    name="Persistence Test",
    entry_point=Assistant,
    save_state=False,
)

print(invoker_flow.invoke("How do I make scrambled eggs"))
```
```bash
agent/stream-test.py:9: DeprecationWarning: The save_state parameter is being deprecated. Use the RAILTRACKS_DISABLE_EVENTS env var instead
  invoker_flow = rt.Flow(
```
2) `RAILTRACKS_DISABLE_EVENTS=False`
- both events and session tree skipped
```python
import railtracks as rt

rt.enable_logging()

Assistant = rt.agent_node(
    name="Assistant",
    system_message="You are a helpful assistant",
    llm=rt.llm.OpenAILLM("gpt-5.4"),
)

invoker_flow = rt.Flow(
    name="Persistence Test",
    entry_point=Assistant,
)

print(invoker_flow.invoke("How do I make scrambled eggs"))