### PR TITLE
1466 async guardrails

### DIFF
--- a/docs/documentation/agent_design/middleware/guardrails/contributions.md
+++ b/docs/documentation/agent_design/middleware/guardrails/contributions.md
@@ -2,11 +2,11 @@
 
 A guardrail is a middleware specialized for LLM input/output. If you have built a reusable rail; a new PII entity, a domain-specific content filter, or a policy check, contributing it as a prebuilt guard makes it importable from `rt.prebuilt.guardrails`.
 
-To author a rail, subclass `InputGuard` or `OutputGuard` and implement `__call__(self, event) -> GuardrailDecision`; see [Custom Guards](overview.md#custom-guards) for the pattern (and the decorator API for quick, local guards). To make it a shipped guardrail:
+To author a rail, subclass `InputGuard` or `OutputGuard` and implement `__call__(self, event) -> GuardrailDecision` (sync or `async def`); see [Custom Guards](overview.md#custom-guards) for the pattern (and the decorator API for quick, local guards). To make it a shipped guardrail:
 
 1. Implement the guard under `packages/railtracks/src/railtracks/prebuilt/guardrails/` (input/output modules; shared logic in a private subpackage such as `_pii/`).
 2. Re-export the public name from `prebuilt/guardrails/__init__.py`.
-3. Add unit tests under `packages/railtracks/tests/unit_tests/guardrails/`, using `decide()` for isolated assertions.
+3. Add unit tests under `packages/railtracks/tests/unit_tests/guardrails/`, using `decide()` (or `adecide()` for an async rail) for isolated assertions.
 4. Add a dedicated page under `docs/.../middleware/prebuilt/list/` with a runnable snippet in `docs/scripts/`.
 
 Keep dependencies optional or zero unless the feature truly needs them, and document behavior, limits, and false-positive/false-negative tradeoffs briefly.

--- a/docs/documentation/agent_design/middleware/guardrails/overview.md
+++ b/docs/documentation/agent_design/middleware/guardrails/overview.md
@@ -58,8 +58,22 @@ Attach them like any model middleware:
 --8<-- "docs/scripts/custom_guardrails.py:decorator_attach"
 ```
 
-!!! note "Guard functions are synchronous"
-    A guard is called synchronously while the rail is evaluated, so the decorated function must be a regular `def`, not `async def`.
+### Async guards
+
+A guard may be a regular `def` or an `async def`. An async rail is awaited while it is evaluated, so it can `await` anything, including `rt.call` into another agent. That is how you build an LLM-judge rail, where the decision is delegated to a second agent:
+
+```python
+--8<-- "docs/scripts/custom_guardrails.py:decorator_async"
+```
+
+Give the judge an `output_schema` rather than parsing its prose: the rail then branches on a typed field instead of substring-matching a reply that can be reworded at any time, and the judge's own `reason` carries straight into the block.
+
+The same holds when subclassing: define `async def __call__(self, event)` and everything downstream of the decision is identical.
+
+!!! warning "An async rail runs once per model round-trip"
+    Guards are model middleware, so a rail fires on every model call, not once per agent call. On a tool-calling agent that means once per iteration of the tool loop: an input rail on an agent that takes three tool turns fires four times, each seeing a longer history. That is free for a regex check but not for a rail that makes its own LLM call. Output rails are exempt from intermediate tool-call turns and fire only on the final reply.
+
+    If a rail only needs to screen the user's original request, consider attaching it as node-level middleware ([`wrap_node`](../overview.md)) instead, which runs once per agent call.
 
 ### Subclassing
 
@@ -74,7 +88,7 @@ For a reusable, configurable rail, subclass `InputGuard` or `OutputGuard` and im
 ```
 
 !!! tip "Testing a guard in isolation"
-    Both bases provide `decide(value)`, which builds the event for you from a `str`, `Message`, or `MessageHistory` and returns the `GuardrailDecision`, handy for unit tests without running a model.
+    Both bases provide `decide(value)`, which builds the event for you from a `str`, `Message`, or `MessageHistory` and returns the `GuardrailDecision`, handy for unit tests without running a model. For an async guard use `await guard.adecide(value)`; `decide()` raises `TypeError` on one, since it would otherwise hand back an un-awaited coroutine.
 
 To publish a guard for others to reuse, see [Contributing a Guardrail](contributions.md).
 

--- a/docs/scripts/custom_guardrails.py
+++ b/docs/scripts/custom_guardrails.py
@@ -4,6 +4,8 @@ Two ways to build a guard:
   1. the decorator API (``@rt.input_guard`` / ``@rt.output_guard``), quickest,
   2. subclassing ``InputGuard`` / ``OutputGuard``, for reusable, configurable rails.
 
+Either kind may be sync or ``async def``; an async rail can ``await rt.call(...)``.
+
 Snippet regions (--8<-- [start:name]) are pulled into the guardrails docs by
 MkDocs. Type-checked in CI via scripts/docs_validation.sh.
 """
@@ -55,6 +57,38 @@ Agent = rt.agent_node(
     model_middleware=[block_passwords, strip_sign_off],
 )
 # --8<-- [end: decorator_attach]
+
+
+# --8<-- [start: decorator_async]
+from pydantic import BaseModel
+
+
+class SafetyReport(BaseModel):
+    """The judge's verdict on one request."""
+
+    safe_request: bool
+    reason: str
+
+
+Judge = rt.agent_node(
+    name="safety-judge",
+    llm=rt.llm.OpenAILLM("gpt-4o"),
+    output_schema=SafetyReport,
+    system_message="You decide whether a user request is safe to answer.",
+)
+
+
+@rt.input_guard(name="llm_judge")
+async def llm_judge(event: LLMGuardrailEvent) -> GuardrailDecision:
+    """Delegate the decision to a second agent."""
+    verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
+    if not verdict.structured.safe_request:
+        return GuardrailDecision.block(
+            reason=f"The judge flagged this request: {verdict.structured.reason}",
+            user_facing_message="I can't help with that.",
+        )
+    return GuardrailDecision.allow()
+# --8<-- [end: decorator_async]
 
 
 # --8<-- [start: subclass_imports]

--- a/packages/railtracks/src/railtracks/guardrails/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     LLMGuardrailEvent,
     LLMGuardrailPhase,
 )
+from .llm.concrete import InputGuard, OutputGuard
 from .llm.decorators import input_guard, output_guard
 
 __all__ = [
@@ -20,8 +21,10 @@ __all__ = [
     "GuardrailBlockedError",
     "GuardrailDecision",
     "GuardrailTrace",
+    "InputGuard",
     "LLMGuardrailEvent",
     "LLMGuardrailPhase",
+    "OutputGuard",
     "input_guard",
     "output_guard",
     "llm",

--- a/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
+++ b/packages/railtracks/src/railtracks/guardrails/core/interfaces.py
@@ -21,7 +21,9 @@ class Guardrail(Protocol):
 
     name: str
 
-    def __call__(self, event: Any) -> GuardrailDecision: ...
+    def __call__(
+        self, event: Any
+    ) -> GuardrailDecision | Awaitable[GuardrailDecision]: ...
 
 
 class BaseGuardrail(ABC, Middleware[_P, _R], Generic[_P, _R]):

--- a/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/__init__.py
@@ -1,6 +1,1 @@
 # LLM-level guardrail internals. The authoring bases live in llm/concrete.py
-# (InputGuard, OutputGuard) and llm/llm_guard.py (BaseLLMGuardrail). Neither is
-# re-exported from railtracks.guardrails or railtracks.guardrails.core -- import
-# them from railtracks.guardrails.llm.concrete directly, or author guards with
-# the decorator API (railtracks.guardrails.input_guard / .output_guard) instead.
-

--- a/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/concrete.py
@@ -77,7 +77,7 @@ class InputGuard(BaseLLMGuardrail[MessageHistory]):
         await emit(input_event)
 
         try:
-            new_messages, traces, decision = self.run(
+            new_messages, traces, decision = await self.run(
                 event=event, value=message_history
             )
         except Exception as e:
@@ -206,7 +206,9 @@ class OutputGuard(BaseLLMGuardrail[Message]):
 
         await emit(input_event)
         try:
-            new_message, traces, decision = self.run(event=event, value=result.message)
+            new_message, traces, decision = await self.run(
+                event=event, value=result.message
+            )
         except Exception as e:
             failure_event = MiddlewareGuardOutputFailureEvent.from_exception(e)
             await emit(failure_event)

--- a/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
@@ -24,21 +24,35 @@ guard's middleware invokes it) and with a raw ``str`` / :class:`~railtracks.llm.
 / :class:`~railtracks.llm.history.MessageHistory`, which is coerced to the correct
 event for the phase via :meth:`convert` before the function sees it.
 
-The wrapped function must be synchronous: a guard's ``__call__`` is invoked
-synchronously while its middleware evaluates the rail (``_eval_one_rail``), so an
-``async def`` would return an un-awaited coroutine.
+The wrapped function may be sync or async. An ``async def`` guard is awaited while
+its middleware evaluates the rail (``_eval_one_rail``), so it can ``await`` anything
+-- including ``rt.call`` into another agent, which is how you build an LLM-judge
+rail::
+
+    @rt.input_guard
+    async def llm_judge(event):
+        verdict = await rt.call(Judge, event.messages[-1].content)
+        if "UNSAFE" in str(verdict):
+            return rt.guardrails.GuardrailDecision.block(reason="judge flagged input")
+        return rt.guardrails.GuardrailDecision.allow()
+
+Note that a rail runs once per *model round-trip*, not once per agent call, so an
+async rail on a tool-calling agent fires on every iteration of the tool loop.
 """
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar, cast, overload
+import inspect
+from typing import Awaitable, Callable, TypeVar, cast, overload
 
 from railtracks.guardrails.core.decision import GuardrailDecision
 from railtracks.guardrails.core.event import LLMGuardrailEvent
 from railtracks.guardrails.llm.concrete import InputGuard, OutputGuard
 from railtracks.guardrails.llm.llm_guard import BaseLLMGuardrail
 
-_GuardFn = Callable[[LLMGuardrailEvent], GuardrailDecision]
+_GuardFn = Callable[
+    [LLMGuardrailEvent], GuardrailDecision | Awaitable[GuardrailDecision]
+]
 _GuardT = TypeVar("_GuardT", bound=BaseLLMGuardrail)
 
 
@@ -54,14 +68,28 @@ def _make_guard(
     The generated guard coerces any non-event input to an event via the base's
     phase-aware :meth:`convert`, so ``fn`` always receives an
     :class:`LLMGuardrailEvent`.
+
+    An ``async def`` ``fn`` produces a guard with an ``async def __call__``, which the
+    rail evaluator awaits. Everything downstream of the decision is identical either
+    way.
     """
     guard_name = name or fn.__name__
 
-    class _FunctionGuard(base):  # type: ignore[valid-type, misc]
-        def __call__(self, event) -> GuardrailDecision:
-            if not isinstance(event, LLMGuardrailEvent):
-                event = self.convert(event)
-            return fn(event)
+    if inspect.iscoroutinefunction(fn):
+
+        class _FunctionGuard(base):  # type: ignore[valid-type, misc]
+            async def __call__(self, event) -> GuardrailDecision:
+                if not isinstance(event, LLMGuardrailEvent):
+                    event = self.convert(event)
+                return await fn(event)
+
+    else:
+
+        class _FunctionGuard(base):  # type: ignore[valid-type, misc, no-redef]
+            def __call__(self, event) -> GuardrailDecision:
+                if not isinstance(event, LLMGuardrailEvent):
+                    event = self.convert(event)
+                return cast(GuardrailDecision, fn(event))
 
     _FunctionGuard.__name__ = f"{base.__name__}[{guard_name}]"
     _FunctionGuard.__qualname__ = _FunctionGuard.__name__
@@ -86,7 +114,8 @@ def input_guard(
     """Turn a function into an :class:`InputGuard` instance.
 
     The function receives an :class:`LLMGuardrailEvent` (INPUT phase; inspect
-    ``event.messages``) and returns a :class:`GuardrailDecision`.
+    ``event.messages``) and returns a :class:`GuardrailDecision`. It may be sync or
+    ``async def``; an async rail is awaited, so it can ``await rt.call(...)``.
 
     Usable bare or parameterized::
 
@@ -95,7 +124,7 @@ def input_guard(
 
 
         @rt.input_guard(name="my_rail", fail_open=True)
-        def guard(event): ...
+        async def guard(event): ...
 
     Args:
         fn: The guard function (supplied automatically in the bare form).
@@ -130,7 +159,8 @@ def output_guard(
     """Turn a function into an :class:`OutputGuard` instance.
 
     The function receives an :class:`LLMGuardrailEvent` (OUTPUT phase; inspect
-    ``event.output_message``) and returns a :class:`GuardrailDecision`.
+    ``event.output_message``) and returns a :class:`GuardrailDecision`. It may be
+    sync or ``async def``; an async rail is awaited, so it can ``await rt.call(...)``.
     Intermediate tool-call turns are skipped by :class:`OutputGuard`, so the
     function fires only on the final reply.
 
@@ -141,7 +171,7 @@ def output_guard(
 
 
         @rt.output_guard(name="my_rail", fail_open=True)
-        def guard(event): ...
+        async def guard(event): ...
 
     Args:
         fn: The guard function (supplied automatically in the bare form).

--- a/packages/railtracks/src/railtracks/guardrails/llm/llm_guard.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/llm_guard.py
@@ -1,5 +1,6 @@
+import inspect
 from abc import abstractmethod
-from typing import Any, Generic, TypeVar
+from typing import Any, Awaitable, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 from typing_extensions import Literal
@@ -15,6 +16,7 @@ from railtracks.llm.message import Message, UserMessage
 from railtracks.llm.response import Response
 from railtracks.llm.tools.tool import Tool
 from railtracks.utils.logging.create import get_rt_logger
+from railtracks.utils.unpack import unpack_async_sync
 
 logger = get_rt_logger("guardrails")
 
@@ -47,8 +49,15 @@ class BaseLLMGuardrail(
         self.fail_open = fail_open
 
     @abstractmethod
-    def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
-        """Evaluate the event and return a decision. Implemented by each concrete guard."""
+    def __call__(
+        self, event: LLMGuardrailEvent
+    ) -> GuardrailDecision | Awaitable[GuardrailDecision]:
+        """Evaluate the event and return a decision. Implemented by each concrete guard.
+
+        May be sync or async. An ``async def`` implementation is awaited before its
+        decision is dispatched, so a guard is free to ``await rt.call(...)`` and
+        delegate the judgement to another agent.
+        """
         pass
 
     @abstractmethod
@@ -61,10 +70,31 @@ class BaseLLMGuardrail(
     def decide(
         self, value: str | Message | MessageHistory | LLMGuardrailEvent, /
     ) -> GuardrailDecision:
-        """Convert value to an event and run this guard on it directly, outside a chain."""
+        """Convert value to an event and run this guard on it directly, outside a chain.
+
+        Synchronous guards only. An ``async def`` guard would return an un-awaited
+        coroutine here, so use :meth:`adecide` for those.
+        """
+        if self._is_async():
+            raise TypeError(
+                f"Guardrail {self._rail_name()} is async; "
+                f"use `await {type(self).__name__}.adecide(...)` instead of `.decide(...)`."
+            )
         converted_event = self.convert(value)
 
-        return self(converted_event)
+        return cast(GuardrailDecision, self(converted_event))
+
+    async def adecide(
+        self, value: str | Message | MessageHistory | LLMGuardrailEvent, /
+    ) -> GuardrailDecision:
+        """Async counterpart to :meth:`decide`; accepts sync and async guards alike."""
+        converted_event = self.convert(value)
+
+        return await unpack_async_sync(self(converted_event))
+
+    def _is_async(self) -> bool:
+        """Whether this guard's ``__call__`` is a coroutine function."""
+        return inspect.iscoroutinefunction(type(self).__call__)
 
     @staticmethod
     def _coerce_to_message_history(
@@ -134,7 +164,7 @@ class BaseLLMGuardrail(
         )
         return ("stop", value, block)
 
-    def run(
+    async def run(
         self,
         *,
         event: LLMGuardrailEvent,
@@ -152,7 +182,7 @@ class BaseLLMGuardrail(
         """
         traces: list[GuardrailTrace] = []
 
-        step = self._eval_one_rail(
+        step = await self._eval_one_rail(
             event=event,
             value=value,
             traces=traces,
@@ -169,7 +199,7 @@ class BaseLLMGuardrail(
             decision if decision is not None else GuardrailDecision.allow(),
         )
 
-    def _eval_one_rail(
+    async def _eval_one_rail(
         self,
         event: LLMGuardrailEvent,
         value: _TValue,
@@ -178,9 +208,9 @@ class BaseLLMGuardrail(
         tuple[Literal["continue"], _TValue, LLMGuardrailEvent, GuardrailDecision | None]
         | tuple[Literal["stop"], _TValue, GuardrailDecision]
     ):
-        """Call this guard, validate the returned decision, and dispatch it."""
+        """Call this guard, await it if async, validate the decision, and dispatch it."""
         try:
-            decision = self(event)
+            decision = await unpack_async_sync(self(event))
             if not isinstance(decision, GuardrailDecision):
                 raise TypeError(
                     f"Guardrail {self._rail_name()} returned {type(decision).__name__}, expected GuardrailDecision."

--- a/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
@@ -31,13 +31,13 @@ def _counting_chat(llm: rt.llm.ModelBase):
 async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
     """The judge says UNSAFE, so the guarded agent's own LLM is never reached."""
     judge_llm = mock_llm(custom_response="UNSAFE")
-    Judge = rt.agent_node(name="judge", llm=judge_llm, system_message="judge the input")
+    judge = rt.agent_node(name="judge", llm=judge_llm, system_message="judge the input")
 
     seen = {}
 
     @input_guard
     async def llm_judge(event) -> GuardrailDecision:
-        verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
+        verdict = await rt.call(judge, user_input=str(event.messages[-1].content))
         seen["verdict"] = verdict.text
         if "UNSAFE" in verdict.text:
             return GuardrailDecision.block(
@@ -47,13 +47,11 @@ async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
 
     guarded_llm = mock_llm(custom_response="should never be reached")
     counts = _counting_chat(guarded_llm)
-    Agent = rt.agent_node(
-        name="guarded", llm=guarded_llm, model_middleware=[llm_judge]
-    )
+    agent = rt.agent_node(name="guarded", llm=guarded_llm, model_middleware=[llm_judge])
 
     with rt.Session():
         with pytest.raises(GuardrailBlockedError) as exc:
-            await rt.call(Agent, user_input="something sketchy")
+            await rt.call(agent, user_input="something sketchy")
 
     assert counts["n"] == 0
     assert "UNSAFE" in seen["verdict"]
@@ -64,25 +62,25 @@ async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
 @pytest.mark.asyncio
 async def test_async_input_guard_allows_using_a_judge_agent(mock_llm):
     """The judge says SAFE, so the guarded agent runs normally."""
-    Judge = rt.agent_node(
+    judge = rt.agent_node(
         name="judge-ok", llm=mock_llm(custom_response="SAFE"), system_message="judge"
     )
 
     @input_guard
     async def llm_judge(event) -> GuardrailDecision:
-        verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
+        verdict = await rt.call(judge, user_input=str(event.messages[-1].content))
         if "UNSAFE" in verdict.text:
             return GuardrailDecision.block(reason="flagged")
         return GuardrailDecision.allow()
 
     guarded_llm = mock_llm(custom_response="the real answer")
     counts = _counting_chat(guarded_llm)
-    Agent = rt.agent_node(
+    agent = rt.agent_node(
         name="guarded-ok", llm=guarded_llm, model_middleware=[llm_judge]
     )
 
     with rt.Session():
-        out = await rt.call(Agent, user_input="a normal question")
+        out = await rt.call(agent, user_input="a normal question")
 
     assert counts["n"] == 1
     assert isinstance(out, StringResponse)
@@ -92,18 +90,18 @@ async def test_async_input_guard_allows_using_a_judge_agent(mock_llm):
 @pytest.mark.asyncio
 async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
     """An async rail works on the output phase too."""
-    Judge = rt.agent_node(
+    judge = rt.agent_node(
         name="judge-out", llm=mock_llm(custom_response="LEAK"), system_message="judge"
     )
 
     @output_guard
     async def llm_judge(event) -> GuardrailDecision:
-        verdict = await rt.call(Judge, user_input=str(event.output_message.content))
+        verdict = await rt.call(judge, user_input=str(event.output_message.content))
         if "LEAK" in verdict.text:
             return GuardrailDecision.block(reason="judge flagged output")
         return GuardrailDecision.allow()
 
-    Agent = rt.agent_node(
+    agent = rt.agent_node(
         name="guarded-out",
         llm=mock_llm(custom_response="here is your api key"),
         model_middleware=[llm_judge],
@@ -111,7 +109,7 @@ async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
 
     with rt.Session():
         with pytest.raises(GuardrailBlockedError) as exc:
-            await rt.call(Agent, user_input="tell me a secret")
+            await rt.call(agent, user_input="tell me a secret")
 
     assert exc.value.reason == "judge flagged output"
 
@@ -119,7 +117,7 @@ async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
 @pytest.mark.asyncio
 async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
     """An async rail can TRANSFORM using the result of a nested agent call."""
-    Rewriter = rt.agent_node(
+    rewriter = rt.agent_node(
         name="rewriter",
         llm=mock_llm(custom_response="sanitized question"),
         system_message="rewrite",
@@ -127,10 +125,8 @@ async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
 
     @input_guard
     async def rewrite(event) -> GuardrailDecision:
-        rewritten = await rt.call(Rewriter, user_input="anything")
-        new_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage(rewritten.text)]
-        )
+        rewritten = await rt.call(rewriter, user_input="anything")
+        new_history = rt.llm.MessageHistory([rt.llm.UserMessage(rewritten.text)])
         return GuardrailDecision.transform_messages(
             messages=new_history, reason="rewritten by agent"
         )
@@ -145,12 +141,12 @@ async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
 
     guarded_llm._chat = wrapped  # type: ignore[method-assign]
 
-    Agent = rt.agent_node(
+    agent = rt.agent_node(
         name="guarded-transform", llm=guarded_llm, model_middleware=[rewrite]
     )
 
     with rt.Session():
-        await rt.call(Agent, user_input="the original question")
+        await rt.call(agent, user_input="the original question")
 
     assert any("sanitized question" in m for m in seen["messages"])
     assert not any("the original question" in m for m in seen["messages"])

--- a/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
@@ -1,0 +1,156 @@
+"""Integration tests: an async guardrail calling another agent via ``rt.call``.
+
+This is the scenario from issue #1466 -- the reason a guard needs to be able to be
+``async`` at all. A guard delegates its judgement to a second agent, which means the
+rail body has to ``await`` a full node invocation while the guarded agent's own model
+call is suspended inside the middleware chain.
+"""
+
+from __future__ import annotations
+
+import pytest
+import railtracks as rt
+from railtracks.built_nodes.llm.response import StringResponse
+from railtracks.guardrails import GuardrailBlockedError, GuardrailDecision
+from railtracks.guardrails.llm.decorators import input_guard, output_guard
+
+
+def _counting_chat(llm: rt.llm.ModelBase):
+    state = {"n": 0}
+    real = llm._chat
+
+    def wrapped(messages, **kwargs):  # type: ignore[no-untyped-def]
+        state["n"] += 1
+        return real(messages, **kwargs)
+
+    llm._chat = wrapped  # type: ignore[method-assign]
+    return state
+
+
+@pytest.mark.asyncio
+async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
+    """The judge says UNSAFE, so the guarded agent's own LLM is never reached."""
+    judge_llm = mock_llm(custom_response="UNSAFE")
+    Judge = rt.agent_node(name="judge", llm=judge_llm, system_message="judge the input")
+
+    seen = {}
+
+    @input_guard
+    async def llm_judge(event) -> GuardrailDecision:
+        verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
+        seen["verdict"] = verdict.text
+        if "UNSAFE" in verdict.text:
+            return GuardrailDecision.block(
+                reason="judge flagged input", user_facing_message="blocked"
+            )
+        return GuardrailDecision.allow()
+
+    guarded_llm = mock_llm(custom_response="should never be reached")
+    counts = _counting_chat(guarded_llm)
+    Agent = rt.agent_node(
+        name="guarded", llm=guarded_llm, model_middleware=[llm_judge]
+    )
+
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError) as exc:
+            await rt.call(Agent, user_input="something sketchy")
+
+    assert counts["n"] == 0
+    assert "UNSAFE" in seen["verdict"]
+    assert exc.value.reason == "judge flagged input"
+    assert exc.value.rail_name == "llm_judge"
+
+
+@pytest.mark.asyncio
+async def test_async_input_guard_allows_using_a_judge_agent(mock_llm):
+    """The judge says SAFE, so the guarded agent runs normally."""
+    Judge = rt.agent_node(
+        name="judge-ok", llm=mock_llm(custom_response="SAFE"), system_message="judge"
+    )
+
+    @input_guard
+    async def llm_judge(event) -> GuardrailDecision:
+        verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
+        if "UNSAFE" in verdict.text:
+            return GuardrailDecision.block(reason="flagged")
+        return GuardrailDecision.allow()
+
+    guarded_llm = mock_llm(custom_response="the real answer")
+    counts = _counting_chat(guarded_llm)
+    Agent = rt.agent_node(
+        name="guarded-ok", llm=guarded_llm, model_middleware=[llm_judge]
+    )
+
+    with rt.Session():
+        out = await rt.call(Agent, user_input="a normal question")
+
+    assert counts["n"] == 1
+    assert isinstance(out, StringResponse)
+    assert "the real answer" in out.text
+
+
+@pytest.mark.asyncio
+async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
+    """An async rail works on the output phase too."""
+    Judge = rt.agent_node(
+        name="judge-out", llm=mock_llm(custom_response="LEAK"), system_message="judge"
+    )
+
+    @output_guard
+    async def llm_judge(event) -> GuardrailDecision:
+        verdict = await rt.call(Judge, user_input=str(event.output_message.content))
+        if "LEAK" in verdict.text:
+            return GuardrailDecision.block(reason="judge flagged output")
+        return GuardrailDecision.allow()
+
+    Agent = rt.agent_node(
+        name="guarded-out",
+        llm=mock_llm(custom_response="here is your api key"),
+        model_middleware=[llm_judge],
+    )
+
+    with rt.Session():
+        with pytest.raises(GuardrailBlockedError) as exc:
+            await rt.call(Agent, user_input="tell me a secret")
+
+    assert exc.value.reason == "judge flagged output"
+
+
+@pytest.mark.asyncio
+async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
+    """An async rail can TRANSFORM using the result of a nested agent call."""
+    Rewriter = rt.agent_node(
+        name="rewriter",
+        llm=mock_llm(custom_response="sanitized question"),
+        system_message="rewrite",
+    )
+
+    @input_guard
+    async def rewrite(event) -> GuardrailDecision:
+        rewritten = await rt.call(Rewriter, user_input="anything")
+        new_history = rt.llm.MessageHistory(
+            [rt.llm.UserMessage(rewritten.text)]
+        )
+        return GuardrailDecision.transform_messages(
+            messages=new_history, reason="rewritten by agent"
+        )
+
+    seen = {}
+    guarded_llm = mock_llm(custom_response="ok")
+    real = guarded_llm._chat
+
+    def wrapped(messages, **kwargs):  # type: ignore[no-untyped-def]
+        seen["messages"] = [str(m.content) for m in messages]
+        return real(messages, **kwargs)
+
+    guarded_llm._chat = wrapped  # type: ignore[method-assign]
+
+    Agent = rt.agent_node(
+        name="guarded-transform", llm=guarded_llm, model_middleware=[rewrite]
+    )
+
+    with rt.Session():
+        await rt.call(Agent, user_input="the original question")
+
+    assert any("sanitized question" in m for m in seen["messages"])
+    assert not any("the original question" in m for m in seen["messages"])

--- a/packages/railtracks/tests/unit_tests/guardrails/test_async_guards.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_async_guards.py
@@ -1,0 +1,249 @@
+"""Tests for async (``async def``) guardrails.
+
+A guard's ``__call__`` may be sync or async; the rail evaluator awaits it before
+dispatching the decision. This is what lets a guard ``await rt.call(...)`` and
+delegate the judgement to another agent (issue #1466).
+"""
+
+from __future__ import annotations
+
+import pytest
+from railtracks.guardrails.core.decision import GuardrailAction, GuardrailDecision
+from railtracks.guardrails.core.event import LLMGuardrailEvent, LLMGuardrailPhase
+from railtracks.guardrails.llm.concrete import InputGuard, OutputGuard
+from railtracks.guardrails.llm.decorators import input_guard, output_guard
+from railtracks.llm import MessageHistory
+from railtracks.llm.message import AssistantMessage, UserMessage
+
+
+def _input_event(messages: MessageHistory) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(phase=LLMGuardrailPhase.INPUT, messages=messages)
+
+
+def _output_event(text: str) -> LLMGuardrailEvent:
+    return LLMGuardrailEvent(
+        phase=LLMGuardrailPhase.OUTPUT,
+        messages=MessageHistory(),
+        output_message=AssistantMessage(text),
+    )
+
+
+@pytest.fixture
+def history() -> MessageHistory:
+    return MessageHistory([UserMessage("hello")])
+
+
+class TestDecoratorBuildsAsyncGuard:
+    def test_async_fn_still_returns_a_guard_instance(self) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert isinstance(rail, InputGuard)
+        assert rail.name == "rail"
+
+    def test_async_output_fn_returns_output_guard(self) -> None:
+        @output_guard(name="async_out")
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert isinstance(rail, OutputGuard)
+        assert rail.name == "async_out"
+
+    def test_async_guard_reports_itself_as_async(self) -> None:
+        @input_guard
+        async def arail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        @input_guard
+        def srail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        assert arail._is_async() is True
+        assert srail._is_async() is False
+
+
+class TestAsyncRailDispatch:
+    """Each decision action dispatches identically for sync and async rails."""
+
+    async def test_allow(self, history) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow(reason="ok")
+
+        value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.ALLOW
+        assert value == history
+        assert len(traces) == 1
+        assert traces[0].action == "allow"
+
+    async def test_block(self, history) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.block(reason="nope", user_facing_message="u")
+
+        _value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.BLOCK
+        assert decision.reason == "nope"
+        assert traces[-1].action == "block"
+
+    async def test_transform(self, history) -> None:
+        replacement = MessageHistory([UserMessage("redacted")])
+
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.transform_messages(
+                messages=replacement, reason="redacted 1"
+            )
+
+        value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert value == replacement
+        assert decision.reason == "redacted 1"
+        assert traces[-1].action == "transform"
+
+    async def test_output_phase_async_rail(self) -> None:
+        @output_guard
+        async def rail(event) -> GuardrailDecision:
+            assert event.output_message is not None
+            return GuardrailDecision.block(reason="bad output")
+
+        event = _output_event("leaky")
+        _value, traces, decision = await rail.run(
+            event=event, value=event.output_message
+        )
+
+        assert decision.action == GuardrailAction.BLOCK
+        assert traces[-1].action == "block"
+
+
+class TestAsyncRailFailureModes:
+    async def test_raising_async_rail_fails_closed(self, history) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            raise RuntimeError("boom")
+
+        _value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.BLOCK
+        assert traces[-1].action == "error"
+        assert decision.meta is not None
+        assert decision.meta["exception_type"] == "RuntimeError"
+
+    async def test_raising_async_rail_fails_open(self, history) -> None:
+        @input_guard(fail_open=True)
+        async def rail(event) -> GuardrailDecision:
+            raise RuntimeError("boom")
+
+        value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision == GuardrailDecision.allow()
+        assert value == history
+        assert traces[-1].action == "error"
+
+    async def test_async_rail_returning_non_decision_is_caught(self, history) -> None:
+        """The awaited value is type-checked, so a bad return still fails closed."""
+
+        @input_guard
+        async def rail(event):
+            return "not a decision"
+
+        _value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.BLOCK
+        assert decision.meta is not None
+        assert decision.meta["exception_type"] == "TypeError"
+        assert "expected GuardrailDecision" in decision.meta["exception_message"]
+
+
+class TestSyncRailsUnaffected:
+    """Regression: the sync path must behave exactly as before."""
+
+    async def test_sync_rail_allows(self, history) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow(reason="ok")
+
+        value, traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.ALLOW
+        assert value == history
+        assert traces[0].action == "allow"
+
+    async def test_sync_rail_blocks(self, history) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.block(reason="nope")
+
+        _value, _traces, decision = await rail.run(
+            event=_input_event(history), value=history
+        )
+
+        assert decision.action == GuardrailAction.BLOCK
+
+
+class TestDecideAndAdecide:
+    def test_decide_on_async_guard_raises_pointing_at_adecide(self) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow()
+
+        with pytest.raises(TypeError, match="adecide"):
+            rail.decide("hello")
+
+    async def test_adecide_runs_an_async_guard(self) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            assert isinstance(event, LLMGuardrailEvent)
+            return GuardrailDecision.block(reason="flagged")
+
+        decision = await rail.adecide("hello")
+
+        assert decision.action == GuardrailAction.BLOCK
+        assert decision.reason == "flagged"
+
+    async def test_adecide_also_accepts_a_sync_guard(self) -> None:
+        @input_guard
+        def rail(event) -> GuardrailDecision:
+            return GuardrailDecision.allow(reason="fine")
+
+        decision = await rail.adecide("hello")
+
+        assert decision.action == GuardrailAction.ALLOW
+        assert decision.reason == "fine"
+
+    async def test_adecide_on_output_guard_uses_output_message(self) -> None:
+        @output_guard
+        async def rail(event) -> GuardrailDecision:
+            assert event.output_message.content == "the reply"
+            return GuardrailDecision.allow()
+
+        decision = await rail.adecide("the reply")
+
+        assert decision.action == GuardrailAction.ALLOW
+
+
+class TestDocstringPreserved:
+    def test_async_rail_docstring_carried_to_guard_class(self) -> None:
+        @input_guard
+        async def rail(event) -> GuardrailDecision:
+            """My async rail docstring."""
+            return GuardrailDecision.allow()
+
+        assert type(rail).__doc__ == "My async rail docstring."

--- a/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
@@ -55,7 +55,9 @@ def _output_event(messages: MessageHistory, output_message) -> LLMGuardrailEvent
 
 async def test_run_allow_returns_value_unchanged(sample_history):
     guard = FnInputGuard(lambda _e: GuardrailDecision.allow(reason="ok"))
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert value == sample_history
     assert blocked == GuardrailDecision.allow()
@@ -73,7 +75,9 @@ async def test_run_transform_updates_value(sample_history):
     guard = FnInputGuard(
         lambda _e: GuardrailDecision.transform_messages(messages=new_hist, reason="t1")
     )
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked.reason == "t1"
     assert value == new_hist
@@ -88,7 +92,9 @@ async def test_run_transform_missing_messages_fail_closed(sample_history):
             )
 
     guard = BadTransform(fail_open=False)
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked is not None
     assert blocked.action == GuardrailAction.BLOCK
@@ -104,7 +110,9 @@ async def test_run_transform_missing_messages_fail_open(sample_history):
             )
 
     guard = BadTransform(fail_open=True)
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked == GuardrailDecision.allow()  # fail_open lets the run continue
     assert value == sample_history  # unchanged: the failed transform never applied
@@ -122,7 +130,9 @@ async def test_run_block_stops_regardless_of_fail_open(sample_history):
             lambda _e: GuardrailDecision.block(reason="stop", user_facing_message="u"),
             fail_open=fail_open,
         )
-        value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+        value, traces, blocked = await guard.run(
+            event=_input_event(sample_history), value=sample_history
+        )
 
         assert blocked is not None, (
             f"fail_open={fail_open} should not override an explicit BLOCK"
@@ -142,7 +152,9 @@ async def test_run_rail_raises_fail_closed(sample_history):
         raise RuntimeError("rail error")
 
     guard = FnInputGuard(boom, fail_open=False)
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked is not None
     assert "raised exception" in blocked.reason.lower()
@@ -156,7 +168,9 @@ async def test_run_rail_raises_fail_open(sample_history):
         raise ValueError("x")
 
     guard = FnInputGuard(boom, fail_open=True)
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked == GuardrailDecision.allow()  # fail_open lets the run continue
     assert value == sample_history
@@ -168,7 +182,9 @@ async def test_run_wrong_return_type_fail_closed(sample_history):
         return "not a decision"
 
     guard = FnInputGuard(bad, fail_open=False)
-    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
 
     assert blocked is not None
     assert "raised exception" in blocked.reason.lower()
@@ -195,7 +211,9 @@ async def test_trace_rail_name_fallback_to_class(sample_history):
             return GuardrailDecision.allow()
 
     guard = UnnamedRail()
-    _value, traces, _blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    _value, traces, _blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
     assert traces[0].rail_name == "UnnamedRail"
 
 
@@ -205,7 +223,9 @@ async def test_trace_uses_rail_name_attr(sample_history):
             return GuardrailDecision.allow()
 
     guard = NamedRail(name="custom")
-    _value, traces, _blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
+    _value, traces, _blocked = await guard.run(
+        event=_input_event(sample_history), value=sample_history
+    )
     assert traces[0].rail_name == "custom"
 
 

--- a/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_base_llm_guardrail_run.py
@@ -53,9 +53,9 @@ def _output_event(messages: MessageHistory, output_message) -> LLMGuardrailEvent
 # ---------------------------------------------------------------------------
 
 
-def test_run_allow_returns_value_unchanged(sample_history):
+async def test_run_allow_returns_value_unchanged(sample_history):
     guard = FnInputGuard(lambda _e: GuardrailDecision.allow(reason="ok"))
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert value == sample_history
     assert blocked == GuardrailDecision.allow()
@@ -68,19 +68,19 @@ def test_run_allow_returns_value_unchanged(sample_history):
 # ---------------------------------------------------------------------------
 
 
-def test_run_transform_updates_value(sample_history):
+async def test_run_transform_updates_value(sample_history):
     new_hist = MessageHistory([UserMessage("two")])
     guard = FnInputGuard(
         lambda _e: GuardrailDecision.transform_messages(messages=new_hist, reason="t1")
     )
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked.reason == "t1"
     assert value == new_hist
     assert traces[-1].action == "transform"
 
 
-def test_run_transform_missing_messages_fail_closed(sample_history):
+async def test_run_transform_missing_messages_fail_closed(sample_history):
     class BadTransform(InputGuard):
         def __call__(self, _e: LLMGuardrailEvent) -> GuardrailDecision:
             return GuardrailDecision(
@@ -88,7 +88,7 @@ def test_run_transform_missing_messages_fail_closed(sample_history):
             )
 
     guard = BadTransform(fail_open=False)
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked is not None
     assert blocked.action == GuardrailAction.BLOCK
@@ -96,7 +96,7 @@ def test_run_transform_missing_messages_fail_closed(sample_history):
     assert traces[-1].action == "error"
 
 
-def test_run_transform_missing_messages_fail_open(sample_history):
+async def test_run_transform_missing_messages_fail_open(sample_history):
     class BadTransform(InputGuard):
         def __call__(self, _e: LLMGuardrailEvent) -> GuardrailDecision:
             return GuardrailDecision(
@@ -104,7 +104,7 @@ def test_run_transform_missing_messages_fail_open(sample_history):
             )
 
     guard = BadTransform(fail_open=True)
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked == GuardrailDecision.allow()  # fail_open lets the run continue
     assert value == sample_history  # unchanged: the failed transform never applied
@@ -116,13 +116,13 @@ def test_run_transform_missing_messages_fail_open(sample_history):
 # ---------------------------------------------------------------------------
 
 
-def test_run_block_stops_regardless_of_fail_open(sample_history):
+async def test_run_block_stops_regardless_of_fail_open(sample_history):
     for fail_open in (False, True):
         guard = FnInputGuard(
             lambda _e: GuardrailDecision.block(reason="stop", user_facing_message="u"),
             fail_open=fail_open,
         )
-        value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+        value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
         assert blocked is not None, f"fail_open={fail_open} should not override an explicit BLOCK"
         assert blocked.action == GuardrailAction.BLOCK
@@ -135,12 +135,12 @@ def test_run_block_stops_regardless_of_fail_open(sample_history):
 # ---------------------------------------------------------------------------
 
 
-def test_run_rail_raises_fail_closed(sample_history):
+async def test_run_rail_raises_fail_closed(sample_history):
     def boom(_e: LLMGuardrailEvent) -> GuardrailDecision:
         raise RuntimeError("rail error")
 
     guard = FnInputGuard(boom, fail_open=False)
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked is not None
     assert "raised exception" in blocked.reason.lower()
@@ -149,24 +149,24 @@ def test_run_rail_raises_fail_closed(sample_history):
     assert traces[0].meta.get("exception_type") == "RuntimeError"
 
 
-def test_run_rail_raises_fail_open(sample_history):
+async def test_run_rail_raises_fail_open(sample_history):
     def boom(_e: LLMGuardrailEvent) -> GuardrailDecision:
         raise ValueError("x")
 
     guard = FnInputGuard(boom, fail_open=True)
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked == GuardrailDecision.allow()  # fail_open lets the run continue
     assert value == sample_history
     assert traces[0].action == "error"
 
 
-def test_run_wrong_return_type_fail_closed(sample_history):
+async def test_run_wrong_return_type_fail_closed(sample_history):
     def bad(_e: LLMGuardrailEvent):
         return "not a decision"
 
     guard = FnInputGuard(bad, fail_open=False)
-    value, traces, blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    value, traces, blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
 
     assert blocked is not None
     assert "raised exception" in blocked.reason.lower()
@@ -187,23 +187,23 @@ def test_run_wrong_return_type_fail_closed(sample_history):
 # ---------------------------------------------------------------------------
 
 
-def test_trace_rail_name_fallback_to_class(sample_history):
+async def test_trace_rail_name_fallback_to_class(sample_history):
     class UnnamedRail(InputGuard):
         def __call__(self, _e: LLMGuardrailEvent) -> GuardrailDecision:
             return GuardrailDecision.allow()
 
     guard = UnnamedRail()
-    _value, traces, _blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    _value, traces, _blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
     assert traces[0].rail_name == "UnnamedRail"
 
 
-def test_trace_uses_rail_name_attr(sample_history):
+async def test_trace_uses_rail_name_attr(sample_history):
     class NamedRail(InputGuard):
         def __call__(self, _e: LLMGuardrailEvent) -> GuardrailDecision:
             return GuardrailDecision.allow()
 
     guard = NamedRail(name="custom")
-    _value, traces, _blocked = guard.run(event=_input_event(sample_history), value=sample_history)
+    _value, traces, _blocked = await guard.run(event=_input_event(sample_history), value=sample_history)
     assert traces[0].rail_name == "custom"
 
 
@@ -212,10 +212,10 @@ def test_trace_uses_rail_name_attr(sample_history):
 # ---------------------------------------------------------------------------
 
 
-def test_run_output_block(sample_history):
+async def test_run_output_block(sample_history):
     output_message = AssistantMessage("a")
     guard = FnOutputGuard(lambda _e: GuardrailDecision.block(reason="bad output"))
-    value, traces, blocked = guard.run(
+    value, traces, blocked = await guard.run(
         event=_output_event(sample_history, output_message), value=output_message
     )
 
@@ -223,13 +223,13 @@ def test_run_output_block(sample_history):
     assert traces[-1].action == "block"
 
 
-def test_run_output_transform(sample_history):
+async def test_run_output_transform(sample_history):
     output_message = AssistantMessage("a")
     new_message = AssistantMessage("b")
     guard = FnOutputGuard(
         lambda _e: GuardrailDecision.transform_output(output_message=new_message, reason="fix")
     )
-    value, traces, blocked = guard.run(
+    value, traces, blocked = await guard.run(
         event=_output_event(sample_history, output_message), value=output_message
     )
 

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guard_decorators.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guard_decorators.py
@@ -150,44 +150,44 @@ class TestRawInputCoercion:
 class TestRunIntegration:
     """Decorated guards run via .run() like hand-written subclasses."""
 
-    def test_run_allows(self) -> None:
+    async def test_run_allows(self) -> None:
         @input_guard
         def rail(event) -> GuardrailDecision:
             return GuardrailDecision.allow()
 
         event = _input_event(MessageHistory([UserMessage("hi")]))
-        value, traces, decision = rail.run(event=event, value=event.messages)
+        value, traces, decision = await rail.run(event=event, value=event.messages)
         assert decision.action == GuardrailAction.ALLOW
         assert len(traces) == 1
 
-    def test_run_stops_on_block(self) -> None:
+    async def test_run_stops_on_block(self) -> None:
         @input_guard
         def rail(event) -> GuardrailDecision:
             return GuardrailDecision.block(reason="blocked")
 
         event = _input_event(MessageHistory([UserMessage("hi")]))
-        _, _, decision = rail.run(event=event, value=event.messages)
+        _, _, decision = await rail.run(event=event, value=event.messages)
         assert decision is not None
         assert decision.action == GuardrailAction.BLOCK
 
 
 class TestFailOpen:
-    def test_fail_open_lets_request_continue_on_error(self) -> None:
+    async def test_fail_open_lets_request_continue_on_error(self) -> None:
         @input_guard(fail_open=True)
         def rail(event) -> GuardrailDecision:
             raise RuntimeError("boom")
 
         event = _input_event(MessageHistory([UserMessage("hi")]))
-        value, traces, decision = rail.run(event=event, value=event.messages)
+        value, traces, decision = await rail.run(event=event, value=event.messages)
         assert traces  # the exception was recorded
 
-    def test_fail_closed_blocks_on_error(self) -> None:
+    async def test_fail_closed_blocks_on_error(self) -> None:
         @input_guard
         def rail(event) -> GuardrailDecision:
             raise RuntimeError("boom")
 
         event = _input_event(MessageHistory([UserMessage("hi")]))
-        _, _, decision = rail.run(event=event, value=event.messages)
+        _, _, decision = await rail.run(event=event, value=event.messages)
         assert decision is not None
         assert decision.action == GuardrailAction.BLOCK
 

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
@@ -35,6 +35,28 @@ class FnOutputGuard(OutputGuard):
         return self._decision_fn(event)
 
 
+class AsyncFnInputGuard(InputGuard):
+    """Same as FnInputGuard, but with an ``async def __call__``."""
+
+    def __init__(self, fn, name: str | None = None):
+        super().__init__(name=name)
+        self._decision_fn = fn
+
+    async def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        return self._decision_fn(event)
+
+
+class AsyncFnOutputGuard(OutputGuard):
+    """Same as FnOutputGuard, but with an ``async def __call__``."""
+
+    def __init__(self, fn, name: str | None = None):
+        super().__init__(name=name)
+        self._decision_fn = fn
+
+    async def __call__(self, event: LLMGuardrailEvent) -> GuardrailDecision:
+        return self._decision_fn(event)
+
+
 def _make_response(text: str = "hi") -> Response:
     return Response(message=AssistantMessage(text), message_info=MessageInfo(model_name="m"))
 
@@ -178,3 +200,82 @@ async def test_output_guard_skips_intermediate_tool_call_turns():
 
     assert guard_fired["n"] == 0  # tool-requesting turns are intermediate: never guarded
     assert result is tool_call_response  # passed through untouched, tool calls intact
+
+
+# ---------------------------------------------------------------------------
+# Async guards wire up identically
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_input_guard_transform_rewrites_history_before_call():
+    seen = {}
+    new_history = MessageHistory([UserMessage("redacted")])
+
+    async def fake_call(message_history, schema, tools):
+        seen["message_history"] = message_history
+        return _make_response("ok")
+
+    guard = AsyncFnInputGuard(
+        lambda _e: GuardrailDecision.transform_messages(messages=new_history, reason="t")
+    )
+
+    await guard.wrap(fake_call)(MessageHistory([UserMessage("hi")]), None, None)
+
+    assert seen["message_history"] == new_history
+
+
+@pytest.mark.asyncio
+async def test_async_input_guard_block_raises_and_never_calls_onward():
+    call_count = {"n": 0}
+
+    async def fake_call(message_history, schema, tools):
+        call_count["n"] += 1
+        return _make_response("should not happen")
+
+    guard = AsyncFnInputGuard(
+        lambda _e: GuardrailDecision.block(reason="nope", user_facing_message="blocked")
+    )
+
+    with pytest.raises(GuardrailBlockedError) as exc:
+        await guard.wrap(fake_call)(MessageHistory([UserMessage("hi")]), None, None)
+
+    assert call_count["n"] == 0
+    assert exc.value.reason == "nope"
+
+
+@pytest.mark.asyncio
+async def test_async_output_guard_blocks_the_final_reply():
+    async def fake_call(message_history, schema, tools):
+        return _make_response("leaky")
+
+    guard = AsyncFnOutputGuard(lambda _e: GuardrailDecision.block(reason="bad output"))
+
+    with pytest.raises(GuardrailBlockedError) as exc:
+        await guard.wrap(fake_call)(MessageHistory([UserMessage("q")]), None, None)
+
+    assert exc.value.reason == "bad output"
+
+
+@pytest.mark.asyncio
+async def test_async_output_guard_skips_intermediate_tool_calls():
+    """An async rail is still exempt from intermediate tool-call turns."""
+    fired = {"n": 0}
+
+    def decision(_e):
+        fired["n"] += 1
+        return GuardrailDecision.block(reason="should never fire")
+
+    async def fake_call(message_history, schema, tools):
+        return Response(
+            message=AssistantMessage(
+                [ToolCall(name="t", identifier="tc_1", arguments={})]
+            ),
+            message_info=MessageInfo(model_name="m"),
+        )
+
+    guard = AsyncFnOutputGuard(decision)
+    result = await guard.wrap(fake_call)(MessageHistory([UserMessage("q")]), None, None)
+
+    assert fired["n"] == 0
+    assert len(result.message.tool_calls) == 1

--- a/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
+++ b/packages/railtracks/tests/unit_tests/guardrails/test_guard_middleware_wiring.py
@@ -225,7 +225,9 @@ async def test_async_input_guard_transform_rewrites_history_before_call():
         return _make_response("ok")
 
     guard = AsyncFnInputGuard(
-        lambda _e: GuardrailDecision.transform_messages(messages=new_history, reason="t")
+        lambda _e: GuardrailDecision.transform_messages(
+            messages=new_history, reason="t"
+        )
     )
 
     await guard.wrap(fake_call)(MessageHistory([UserMessage("hi")]), None, None)

--- a/packages/railtracks/tests/unit_tests/test_pending_changes.py
+++ b/packages/railtracks/tests/unit_tests/test_pending_changes.py
@@ -160,6 +160,27 @@ def test_removed_names_are_not_advertised_but_stay_discoverable():
         assert name in dir(rt.guardrails)
 
 
+@pytest.mark.parametrize("name", SURVIVING_GUARDRAIL_NAMES)
+def test_surviving_names_are_importable_from_rt_guardrails(name):
+    """These are unchanged in 1.5.0, so `from railtracks.guardrails import X` must work.
+
+    InputGuard/OutputGuard regressed here once: the docs told users to subclass them
+    and import them from `rt.guardrails`, but they were only reachable from
+    `rt.guardrails.llm.concrete`, so the documented snippet raised ImportError.
+    """
+    module = importlib.import_module("railtracks.guardrails")
+
+    assert hasattr(module, name), f"railtracks.guardrails is missing {name}"
+    assert name in module.__all__
+    assert name in dir(module)
+
+
+@pytest.mark.parametrize("name", SURVIVING_GUARDRAIL_NAMES)
+def test_surviving_names_do_not_warn(name):
+    """Unchanged names must never warn, or users will over-migrate."""
+    assert_silent(lambda: getattr(rt.guardrails, name))
+
+
 
 
 

--- a/packages/railtracks/tests/unit_tests/test_pending_changes.py
+++ b/packages/railtracks/tests/unit_tests/test_pending_changes.py
@@ -184,10 +184,6 @@ def test_surviving_names_do_not_warn(name):
     assert_silent(lambda: getattr(rt.guardrails, name))
 
 
-
-
-
-
 def test_rt_interactive_warns():
     with pytest.warns(FutureWarning, match="rt.interactive is removed"):
         rt.interactive


### PR DESCRIPTION
## Summary

Guardrails could only be authored as synchronous functions, so a rail could never `await rt.call(...)` and delegate its decision to another agent. The eval path (`BaseLLMGuardrail.run` → `_eval_one_rail` → `self(event)`) was synchronous while sitting between async middleware layers.

This makes the eval path async and accepts sync-or-async guards, following the `unpack_async_sync` pattern already used by `verifier` and `before_llm`/`after_llm`. Every existing synchronous guard, including all six prebuilt rails, keeps working untouched. Adds `adecide()` as the async counterpart to `decide()`, which now raises a clear `TypeError` on an async guard instead of handing back an un-awaited coroutine.

Closes #1495.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Example
```python
class SafetyReport(BaseModel):
    safe_request: bool
    reason: str

Judge = rt.agent_node(
    name="safety-judge",
    llm=rt.llm.OpenAILLM("gpt-4o"),
    output_schema=SafetyReport,
    system_message="You decide whether a user request is safe to answer.",
)

@rt.input_guard(name="llm_judge")
async def llm_judge(event: LLMGuardrailEvent) -> GuardrailDecision:
    verdict = await rt.call(Judge, user_input=str(event.messages[-1].content))
    if not verdict.structured.safe_request:
        return GuardrailDecision.block(
            reason=f"The judge flagged this request: {verdict.structured.reason}",
            user_facing_message="I can't help with that.",
        )
    return GuardrailDecision.allow()
```

## Notes
1. Subclassing works the same way: define `async def __call__(self, event)`.

2. Cost characteristic, documented but not fixed here. Guards are model middleware, so a rail fires once per model round-trip, not once per agent call. OutputGuard skips intermediate tool-call turns; InputGuard has no equivalent. **This will be handled in another PR** (RE: https://github.com/RailtownAI/railtracks/issues/1496). 

3. Fixed a doc and interface misalignment: Re-exported `InputGuard` and `OutputGuard` classes at `rt.guardrails` level to match the docs and make the interface easier (previously users had to import from `rt.guardrails.llm.concrete`
