### PR TITLE
duplicated warnings removed

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,19 +1,5 @@
 {% extends "base.html" %}
 
-{#
-  Announcement bar, rendered above the header on every page. This is how the 1.5.0
-  upgrade guide is surfaced -- it is deliberately NOT a nav entry, so it stays visible
-  without taking a slot in the top-level navigation.
-
-  Remove this block once 1.5.0 has shipped and the guide no longer needs promoting.
-#}
-{% block announce %}
-  <a href="{{ 'documentation/upgrading/1_5_0/' | url }}">
-    Railtracks 1.5.0 is coming with breaking changes, see what changes and how to prepare
-    &nbsp;&rarr;
-  </a>
-{% endblock %}
-
 {% block extrahead %}
 {{ super() }}
 <!-- Google tag (gtag.js) -->

--- a/packages/railtracks/src/railtracks/utils/config.py
+++ b/packages/railtracks/src/railtracks/utils/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from typing import Any, Callable, Coroutine
 
 
@@ -30,18 +29,11 @@ class ExecutorConfig:
             timeout (float | None): The maximum number of seconds to wait for a response to your top level request. Pass None (or omit) to disable the timeout entirely.
             end_on_error (bool): If true, the executor will stop execution when an exception is encountered.
             broadcast_callback (Callable or Coroutine): A function or coroutine that receives items published with `rt.broadcast`.
-            save_state (bool | None): Deprecated. If passed, emits a DeprecationWarning. `RAILTRACKS_DISABLE_EVENTS=True` skips the write regardless. Otherwise, explicit value wins; when unset, defaults to True (save).
+            save_state (bool | None): Deprecated at the user-facing API layer (see Flow). `RAILTRACKS_DISABLE_EVENTS=True` skips the write regardless. Otherwise, explicit value wins; when unset, defaults to True (save).
         """
         self.timeout = timeout
         self.end_on_error = end_on_error
         self.subscriber = broadcast_callback
-        if save_state is not None:
-            warnings.warn(
-                "The save_state parameter is being deprecated. Use the "
-                "RAILTRACKS_DISABLE_EVENTS env var instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         # During test runs, disable save_state by default unless
         # RAILTRACKS_ALLOW_PERSISTENCE is set (see `save_state` property).
         self._user_save_state = save_state
@@ -74,7 +66,7 @@ class ExecutorConfig:
         """
         If any of the parameters are provided (not None), it will create a new update the current instance with the new values and return a deep copied reference to it.
         """
-        new = ExecutorConfig(
+        return ExecutorConfig(
             timeout=timeout,
             end_on_error=end_on_error
             if end_on_error is not None
@@ -82,14 +74,11 @@ class ExecutorConfig:
             broadcast_callback=subscriber
             if subscriber is not None
             else self.subscriber,
-            save_state=save_state,
+            save_state=save_state if save_state is not None else self._user_save_state,
             payload_callback=payload_callback
             if payload_callback is not None
             else self.payload_callback,
         )
-        if save_state is None:
-            new._user_save_state = self._user_save_state
-        return new
 
     def __repr__(self):
         return (

--- a/packages/railtracks/tests/unit_tests/test_session.py
+++ b/packages/railtracks/tests/unit_tests/test_session.py
@@ -239,26 +239,28 @@ def test_session_implicit_default_save_state_is_true_and_no_warning(
     assert save_state_warnings == []
 
 
-def test_session_explicit_save_state_true_emits_deprecation_warning(monkeypatch):
-    """Passing save_state at all is deprecated. Without the env var, explicit
-    True still resolves to True."""
+def test_session_explicit_save_state_true(monkeypatch, recwarn):
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(
-        DeprecationWarning, match="save_state parameter is being deprecated"
-    ):
-        r = Session(save_state=True)
+    r = Session(save_state=True)
     assert r.executor_config.save_state is True
+    assert not [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning) and "save_state" in str(w.message)
+    ]
 
 
-def test_session_explicit_save_state_false_emits_deprecation_warning(monkeypatch):
+def test_session_explicit_save_state_false(monkeypatch, recwarn):
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.delenv("RAILTRACKS_DISABLE_EVENTS", raising=False)
-    with pytest.warns(
-        DeprecationWarning, match="save_state parameter is being deprecated"
-    ):
-        r = Session(save_state=False)
+    r = Session(save_state=False)
     assert r.executor_config.save_state is False
+    assert not [
+        w
+        for w in recwarn.list
+        if issubclass(w.category, DeprecationWarning) and "save_state" in str(w.message)
+    ]
 
 
 def test_env_var_wins_over_explicit_save_state_true(monkeypatch):
@@ -266,10 +268,7 @@ def test_env_var_wins_over_explicit_save_state_true(monkeypatch):
     env var is the ops-level kill switch and takes precedence."""
     monkeypatch.setenv("RAILTRACKS_ALLOW_PERSISTENCE", "1")
     monkeypatch.setenv("RAILTRACKS_DISABLE_EVENTS", "True")
-    with pytest.warns(
-        DeprecationWarning, match="save_state parameter is being deprecated"
-    ):
-        r = Session(save_state=True)
+    r = Session(save_state=True)
     assert r.executor_config.save_state is False
 
 

--- a/packages/railtracks/tests/unit_tests/utils/test_config.py
+++ b/packages/railtracks/tests/unit_tests/utils/test_config.py
@@ -111,14 +111,8 @@ def test_precedence_overwritten_timeout_float_enables(base_config):
     assert updated_config.timeout == 42.0
 
 
-def test_save_state_explicit_emits_deprecation_warning():
-    with pytest.warns(
-        DeprecationWarning, match="save_state parameter is being deprecated"
-    ):
-        ExecutorConfig(save_state=False)
-
-
-def test_save_state_unset_emits_no_deprecation_warning(recwarn):
+def test_save_state_emits_no_deprecation_warning(recwarn):
+    ExecutorConfig(save_state=False)
     ExecutorConfig()
     assert not [
         w


### PR DESCRIPTION
## Summary

Closes #1504 and removes duplicated deprecation warnings. Verified locally that everything runs as expected. @CoronRing if you could please verify with docker as well.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

