### PR TITLE
feat(middleware): rename before/after hooks to pre/post with deprecation shims

### DIFF
--- a/docs/documentation/agent_design/middleware/custom.md
+++ b/docs/documentation/agent_design/middleware/custom.md
@@ -5,15 +5,15 @@ The middleware system is designed to support the custom creation of middleware t
 | Decorator | Scope | Runs
 |---|---|---|
 | `rt.wrap_node` | Node | Wraps the whole node call. You decide if/how many times the inner call runs |
-| `rt.after_node` | Node | Once, after the node completes successfully (skipped if it raises) | 
+| `rt.post_node` | Node | Once, after the node completes successfully (skipped if it raises) | 
 | `rt.wrap_llm` | Model | Wraps the whole model call. You decide if/how many times the inner call runs ||
-| `rt.before_llm` | Model | Once, before each model call, to transform the inputs |
-| `rt.after_llm` | Model | Once, after each successful model call |
+| `rt.pre_llm` | Model | Once, before each model call, to transform the inputs |
+| `rt.post_llm` | Model | Once, after each successful model call |
 
-`wrap_node` and `wrap_llm` are the general-purpose forms. Every other decorator is a thin convenience built on top of one of them (`after_node` and `after_llm` only get to run the inner call once and act on its result; `before_llm` only gets to transform the inputs before the inner call runs). 
+`wrap_node` and `wrap_llm` are the general-purpose forms. Every other decorator is a thin convenience built on top of one of them (`post_node` and `post_llm` only get to run the inner call once and act on its result; `pre_llm` only gets to transform the inputs before the inner call runs). 
 
 !!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
-    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `post_node`, `pre_llm`, and `post_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 ## Node middleware
 
@@ -22,7 +22,7 @@ The middleware system is designed to support the custom creation of middleware t
 ```
 
 ```python
---8<-- "docs/scripts/middleware.py:after_node_demo"
+--8<-- "docs/scripts/middleware.py:post_node_demo"
 ```
 
 The same middleware attaches to a `function_node` exactly the same way, via `middleware=`:

--- a/docs/documentation/agent_design/middleware/overview.md
+++ b/docs/documentation/agent_design/middleware/overview.md
@@ -24,12 +24,12 @@ Most middleware will wrap an entire node or function call, including `rt.functio
 | Decorator | Runs |
 |---|---|
 | `rt.wrap_node` | Wraps the whole node call; you decide if/how many times the inner call runs 
-| `rt.after_node` | Once, after the node completes successfully (skipped if the node raises)
+| `rt.post_node` | Once, after the node completes successfully (skipped if the node raises)
 
-`rt.wrap_node` is the general-purpose form. The retry example above is built on it. `rt.after_node` is a narrower convenience for the common "do something with the result and pass it through" case:
+`rt.wrap_node` is the general-purpose form. The retry example above is built on it. `rt.post_node` is a narrower convenience for the common "do something with the result and pass it through" case:
 
 ```python
---8<-- "docs/scripts/middleware.py:after_node_demo"
+--8<-- "docs/scripts/middleware.py:post_node_demo"
 ```
 
 The same middleware attaches to a `function_node` exactly the same way, via `middleware=`:
@@ -43,8 +43,8 @@ Sometimes you want your middleware to wrap around the model call itself, rather 
 
 | Decorator | Runs |
 |---|---|
-| `rt.before_llm` | Once, before each model call, to transform the inputs |
-| `rt.after_llm` | Once, after each successful model call|
+| `rt.pre_llm` | Once, before each model call, to transform the inputs |
+| `rt.post_llm` | Once, after each successful model call|
 | `rt.wrap_llm` | Wraps the whole model call. |
 
 ```python
@@ -52,7 +52,7 @@ Sometimes you want your middleware to wrap around the model call itself, rather 
 ```
 
 !!! note "`wrap_node` / `wrap_llm` functions must be `async def`"
-    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `after_node`, `before_llm`, and `after_llm` are more forgiving: they accept either a plain `def` or an `async def`.
+    `wrap_node` and `wrap_llm` re-invoke the inner call directly, so the function you decorate must be defined with `async def`. A plain `def` raises `TypeError` immediately for `wrap_node`, or fails with a confusing "can't be used in 'await' expression" error at call time for `wrap_llm`. `post_node`, `pre_llm`, and `post_llm` are more forgiving: they accept either a plain `def` or an `async def`.
 
 !!! note "Guardrails are Model Middleware"
     Built-in guardrails (PII redaction, length limits, blocked text, ...) are implemented as model middleware under the hood. See [Guardrails](../middleware/guardrails/overview.md).

--- a/docs/scripts/middleware.py
+++ b/docs/scripts/middleware.py
@@ -31,8 +31,8 @@ async def timed(call, *args, **kwargs):
 # --8<-- [end: wrappers_timed]
 
 
-# --8<-- [start: after_node_demo]
-@rt.after_node
+# --8<-- [start: post_node_demo]
+@rt.post_node
 def log_result(result):
     print("node finished:", result)
     return result
@@ -43,17 +43,17 @@ async def log_result_async(call, *args, **kwargs):
     result = await call(*args, **kwargs)
     print("node finished:", result)
     return result
-# --8<-- [end: after_node_demo]
+# --8<-- [end: post_node_demo]
 
 
 # --8<-- [start: model_middleware_demo]
-@rt.before_llm
+@rt.pre_llm
 def print_message(message_history: rt.llm.MessageHistory, schema, tools):
     print(message_history)
     return message_history, schema, tools
 
 
-@rt.after_llm
+@rt.post_llm
 def print_response(response: rt.llm.Response):
     print(response.message)
     return response

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -49,8 +49,11 @@ __all__ = [
     "NodeMessageHistory",
     "enable_logging",
     "wrap_node",
+    "post_node",
     "after_node",
     "couple",
+    "pre_llm",
+    "post_llm",
     "before_llm",
     "after_llm",
     "wrap_llm",
@@ -77,12 +80,18 @@ from . import (
     retrieval,
 )
 from ._session import Session, session
-from .built_nodes.llm.middleware import after_llm, before_llm, wrap_llm
+from .built_nodes.llm.middleware import (
+    after_llm,
+    before_llm,
+    post_llm,
+    pre_llm,
+    wrap_llm,
+)
 from .context.central import session_id, set_config
 from .guardrails import input_guard, output_guard
 from .interaction import astream, broadcast, call, call_batch, couple
 from .llm.context_injection_utils import escape_braces
-from .middleware import after_node, wrap_node
+from .middleware import after_node, post_node, wrap_node
 from .nodes.manifest import ToolManifest
 from .orchestration.connection import FlowConnection, NodeMessageHistory
 from .orchestration.flow import Flow

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/__init__.py
@@ -1,4 +1,6 @@
 __all__ = [
+    "pre_llm",
+    "post_llm",
     "before_llm",
     "after_llm",
     "wrap_llm",
@@ -6,4 +8,6 @@ __all__ = [
 
 from .after_llm import after_llm
 from .before_llm import before_llm
+from .post_llm import post_llm
+from .pre_llm import pre_llm
 from .wrap_llm import wrap_llm

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -35,7 +35,6 @@ def after_llm(
         change="is renamed",
         instead="rt.post_llm",
         detail="The function itself is unchanged.",
-        stacklevel=2,
     )
     if fn is None:
         return post_llm(name=name)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/after_llm.py
@@ -1,22 +1,12 @@
-import functools
-from typing import Awaitable, Callable, overload
+from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any, Awaitable, Callable, overload
 
-from railtracks.built_nodes._types import LLM_CALL
-from railtracks.events.middleware import (
-    MiddlewareModelOutputFailureEvent,
-    MiddlewareModelOutputInvocationEvent,
-    MiddlewareModelOutputResponseEvent,
-)
-from railtracks.events.send import emit
-from railtracks.llm.history import MessageHistory
 from railtracks.llm.middleware import ModelMiddleware
 from railtracks.llm.response import Response
-from railtracks.llm.tools.tool import Tool
-from railtracks.utils.unpack import unpack_async_sync
+from railtracks.utils.deprecation import warn_pending_change
 
-from .wrap_llm import wrap_llm
+from .post_llm import post_llm
 
 
 @overload
@@ -38,54 +28,15 @@ def after_llm(
     /,
     *,
     name: str | None = None,
-) -> (
-    ModelMiddleware
-    | Callable[[Callable[[Response], Response | Awaitable[Response]]], ModelMiddleware]
-):
-    """
-    A special decorator to create a middleware that runs after every successful call to the model.
-
-    Example usage:
-    ```python
-    @after_llm
-    async def my_middleware(response):
-        # do something with the response
-        return response
-    ```
-    """
-
-    def decorator(fn):
-        @wrap_llm(name=name)
-        @functools.wraps(fn)
-        async def wrapper(
-            llm_call: LLM_CALL,
-            message_history: MessageHistory,
-            schema: type[BaseModel] | None,
-            tools: list[Tool] | None,
-        ):
-            response = await llm_call(message_history, schema, tools)
-
-            invocation_event = MiddlewareModelOutputInvocationEvent(
-                response=response,
-            )
-            await emit(invocation_event)
-
-            try:
-                response = await unpack_async_sync(fn(response))
-            except Exception as e:
-                failure_event = MiddlewareModelOutputFailureEvent.from_exception(e)
-                await emit(failure_event)
-                raise e
-
-            response_event = MiddlewareModelOutputResponseEvent(
-                response=response,
-            )
-            await emit(response_event)
-
-            return response
-
-        return wrapper
-
+) -> Any:
+    """Deprecated: Use ``rt.post_llm`` instead."""
+    warn_pending_change(
+        "rt.after_llm",
+        change="is renamed",
+        instead="rt.post_llm",
+        detail="The function itself is unchanged.",
+        stacklevel=2,
+    )
     if fn is None:
-        return decorator
-    return decorator(fn)
+        return post_llm(name=name)
+    return post_llm(fn, name=name)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
@@ -1,20 +1,15 @@
-import functools
-from typing import Awaitable, Callable, overload
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, overload
 
 from pydantic import BaseModel
 
-from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
-from railtracks.events.middleware import (
-    MiddlewareModelInputInvocationEvent,
-    MiddlewareModelInputResponseEvent,
-)
-from railtracks.events.send import emit
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.middleware import ModelMiddleware
 from railtracks.llm.tools.tool import Tool
-from railtracks.utils.unpack import unpack_async_sync
+from railtracks.utils.deprecation import warn_pending_change
 
-from ..._types import LLM_CALL
+from .pre_llm import pre_llm
 
 
 @overload
@@ -57,64 +52,15 @@ def before_llm(
     /,
     *,
     name: str | None = None,
-) -> (
-    ModelMiddleware
-    | Callable[
-        [
-            Callable[
-                [MessageHistory, type[BaseModel] | None, list[Tool] | None],
-                tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
-                | Awaitable[
-                    tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
-                ],
-            ]
-        ],
-        ModelMiddleware,
-    ]
-):
-    """
-    A special decorator to create a middleware that maps the inputs to a new input before every call to a model
-
-    Example usage:
-    ```python
-    @before_llm
-    async def my_middleware(message_history, schema, tools):
-        # do something with the inputs
-        return message_history, schema, tools
-    ```
-    """
-
-    def decorator(fn):
-        @wrap_llm(name=name)
-        @functools.wraps(fn)
-        async def wrapper(
-            llm_call: LLM_CALL,
-            message_history: MessageHistory,
-            schema: type[BaseModel] | None,
-            tools: list[Tool] | None,
-        ):
-            invocation_event = MiddlewareModelInputInvocationEvent(
-                message_history=message_history,
-                schema=schema,
-                tools=tools,
-            )
-            await emit(invocation_event)
-
-            message_history, schema, tools = await unpack_async_sync(
-                fn(message_history, schema, tools)
-            )
-
-            response_event = MiddlewareModelInputResponseEvent(
-                message_history=message_history,
-                schema=schema,
-                tools=tools,
-            )
-            await emit(response_event)
-
-            return await llm_call(message_history, schema, tools)
-
-        return wrapper
-
+) -> Any:
+    """Deprecated: Use ``rt.pre_llm`` instead."""
+    warn_pending_change(
+        "rt.before_llm",
+        change="is renamed",
+        instead="rt.pre_llm",
+        detail="The function itself is unchanged.",
+        stacklevel=2,
+    )
     if fn is None:
-        return decorator
-    return decorator(fn)
+        return pre_llm(name=name)
+    return pre_llm(fn, name=name)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/before_llm.py
@@ -59,7 +59,6 @@ def before_llm(
         change="is renamed",
         instead="rt.pre_llm",
         detail="The function itself is unchanged.",
-        stacklevel=2,
     )
     if fn is None:
         return pre_llm(name=name)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/post_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/post_llm.py
@@ -1,0 +1,91 @@
+import functools
+from typing import Awaitable, Callable, overload
+
+from pydantic import BaseModel
+
+from railtracks.built_nodes._types import LLM_CALL
+from railtracks.events.middleware import (
+    MiddlewareModelOutputFailureEvent,
+    MiddlewareModelOutputInvocationEvent,
+    MiddlewareModelOutputResponseEvent,
+)
+from railtracks.events.send import emit
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.middleware import ModelMiddleware
+from railtracks.llm.response import Response
+from railtracks.llm.tools.tool import Tool
+from railtracks.utils.unpack import unpack_async_sync
+
+from .wrap_llm import wrap_llm
+
+
+@overload
+def post_llm(
+    fn: Callable[[Response], Response | Awaitable[Response]], /
+) -> ModelMiddleware: ...
+
+
+@overload
+def post_llm(
+    *, name: str | None = None
+) -> Callable[
+    [Callable[[Response], Response | Awaitable[Response]]], ModelMiddleware
+]: ...
+
+
+def post_llm(
+    fn: Callable[[Response], Response | Awaitable[Response]] | None = None,
+    /,
+    *,
+    name: str | None = None,
+) -> (
+    ModelMiddleware
+    | Callable[[Callable[[Response], Response | Awaitable[Response]]], ModelMiddleware]
+):
+    """
+    A special decorator to create a middleware that runs after every successful call to the model.
+
+    Example usage:
+    ```python
+    @post_llm
+    async def my_middleware(response):
+        # do something with the response
+        return response
+    ```
+    """
+
+    def decorator(fn):
+        @wrap_llm(name=name)
+        @functools.wraps(fn)
+        async def wrapper(
+            llm_call: LLM_CALL,
+            message_history: MessageHistory,
+            schema: type[BaseModel] | None,
+            tools: list[Tool] | None,
+        ):
+            response = await llm_call(message_history, schema, tools)
+
+            invocation_event = MiddlewareModelOutputInvocationEvent(
+                response=response,
+            )
+            await emit(invocation_event)
+
+            try:
+                response = await unpack_async_sync(fn(response))
+            except Exception as e:
+                failure_event = MiddlewareModelOutputFailureEvent.from_exception(e)
+                await emit(failure_event)
+                raise e
+
+            response_event = MiddlewareModelOutputResponseEvent(
+                response=response,
+            )
+            await emit(response_event)
+
+            return response
+
+        return wrapper
+
+    if fn is None:
+        return decorator
+    return decorator(fn)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/middleware/pre_llm.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/middleware/pre_llm.py
@@ -1,0 +1,120 @@
+import functools
+from typing import Awaitable, Callable, overload
+
+from pydantic import BaseModel
+
+from railtracks.built_nodes.llm.middleware.wrap_llm import wrap_llm
+from railtracks.events.middleware import (
+    MiddlewareModelInputInvocationEvent,
+    MiddlewareModelInputResponseEvent,
+)
+from railtracks.events.send import emit
+from railtracks.llm.history import MessageHistory
+from railtracks.llm.middleware import ModelMiddleware
+from railtracks.llm.tools.tool import Tool
+from railtracks.utils.unpack import unpack_async_sync
+
+from ..._types import LLM_CALL
+
+
+@overload
+def pre_llm(
+    fn: Callable[
+        [MessageHistory, type[BaseModel] | None, list[Tool] | None],
+        tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+        | Awaitable[tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]],
+    ],
+    /,
+    *,
+    name: str | None = None,
+) -> ModelMiddleware: ...
+
+
+@overload
+def pre_llm(
+    *, name: str | None = None
+) -> Callable[
+    [
+        Callable[
+            [MessageHistory, type[BaseModel] | None, list[Tool] | None],
+            tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+            | Awaitable[
+                tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+            ],
+        ]
+    ],
+    ModelMiddleware,
+]: ...
+
+
+def pre_llm(
+    fn: Callable[
+        [MessageHistory, type[BaseModel] | None, list[Tool] | None],
+        tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+        | Awaitable[tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]],
+    ]
+    | None = None,
+    /,
+    *,
+    name: str | None = None,
+) -> (
+    ModelMiddleware
+    | Callable[
+        [
+            Callable[
+                [MessageHistory, type[BaseModel] | None, list[Tool] | None],
+                tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+                | Awaitable[
+                    tuple[MessageHistory, type[BaseModel] | None, list[Tool] | None]
+                ],
+            ]
+        ],
+        ModelMiddleware,
+    ]
+):
+    """
+    A special decorator to create a middleware that maps the inputs to a new input before every call to a model
+
+    Example usage:
+    ```python
+    @pre_llm
+    async def my_middleware(message_history, schema, tools):
+        # do something with the inputs
+        return message_history, schema, tools
+    ```
+    """
+
+    def decorator(fn):
+        @wrap_llm(name=name)
+        @functools.wraps(fn)
+        async def wrapper(
+            llm_call: LLM_CALL,
+            message_history: MessageHistory,
+            schema: type[BaseModel] | None,
+            tools: list[Tool] | None,
+        ):
+            invocation_event = MiddlewareModelInputInvocationEvent(
+                message_history=message_history,
+                schema=schema,
+                tools=tools,
+            )
+            await emit(invocation_event)
+
+            message_history, schema, tools = await unpack_async_sync(
+                fn(message_history, schema, tools)
+            )
+
+            response_event = MiddlewareModelInputResponseEvent(
+                message_history=message_history,
+                schema=schema,
+                tools=tools,
+            )
+            await emit(response_event)
+
+            return await llm_call(message_history, schema, tools)
+
+        return wrapper
+
+    if fn is None:
+        return decorator
+    return decorator(fn)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/model_invoker.py
@@ -127,7 +127,7 @@ class ModelInvoker:
     round-trip (i.e. inside the tool-calling loop). The core callable takes
     ``(messages, schema, tools)`` and returns a :class:`Response`. Middleware wraps
     symmetrically (an earlier list entry is outer: it runs first going in and last
-    coming out), so a ``@before_llm``/``@wrap_llm`` layer earlier in the list
+    coming out), so a ``@pre_llm``/``@wrap_llm`` layer earlier in the list
     sees/transforms the request before one placed later, and sees the final
     ``Response`` after it on the way back out.
 

--- a/packages/railtracks/src/railtracks/cli/skills/middleware.md
+++ b/packages/railtracks/src/railtracks/cli/skills/middleware.md
@@ -8,12 +8,12 @@ The user wants to add middleware to a railtracks node/agent: $ARGUMENTS
 |---|---|---|---|
 | `rt.wrap_node` | `async fn(call, *args, **kwargs) -> result` | `middleware=` or `model_middleware=` | Yes — you control the try/except |
 | `rt.wrap_llm` | `async fn(llm_call, message_history, schema, tools) -> Response` | `model_middleware=` only | Yes |
-| `rt.before_llm` | `fn(message_history, schema, tools) -> (message_history, schema, tools)` (sync or async) | `model_middleware=` only | N/A (runs before the call) |
-| `rt.after_llm` | `fn(response) -> response` (sync or async) | `model_middleware=` only | No — skipped on exception |
-| `rt.after_node` | `fn(result) -> result` (sync or async) | `middleware=` or `model_middleware=` | No — skipped on exception |
+| `rt.pre_llm` | `fn(message_history, schema, tools) -> (message_history, schema, tools)` (sync or async) | `model_middleware=` only | N/A (runs before the call) |
+| `rt.post_llm` | `fn(response) -> response` (sync or async) | `model_middleware=` only | No — skipped on exception |
+| `rt.post_node` | `fn(result) -> result` (sync or async) | `middleware=` or `model_middleware=` | No — skipped on exception |
 
-- All five accept optional keyword-only `name=` and work bare or called: `@rt.before_llm`, `@rt.after_node(name="print_after")`.
-- `wrap_node`/`wrap_llm` require `async def` (`TypeError` otherwise). `before_llm`/`after_llm`/`after_node` accept sync or async.
+- All five accept optional keyword-only `name=` and work bare or called: `@rt.pre_llm`, `@rt.post_node(name="print_after")`.
+- `wrap_node`/`wrap_llm` require `async def` (`TypeError` otherwise). `pre_llm`/`post_llm`/`post_node` accept sync or async.
 - `middleware=` wraps the whole node call (an agent's full tool-calling loop, including every tool node it invokes). `model_middleware=` wraps one raw LLM call inside that loop.
 - Attach at creation — `rt.agent_node(..., middleware=[...], model_middleware=[...])` — or after the fact without mutating the original — `rt.couple(node, middleware=[...], model_middleware=[...])`.
 - List order = wrapping order: `middleware=[A, B, C]` → `A` wraps `B` wraps `C` wraps the node. `rt.couple`-ing more onto an already-middlewared node adds the new ones innermost; existing middleware stays outermost.
@@ -23,7 +23,7 @@ The user wants to add middleware to a railtracks node/agent: $ARGUMENTS
 ## Best practices
 
 ### 1. Exception handling & retries
-- `before_llm`, `after_llm`, `after_node` **only run on success** — an exception skips them entirely. If you need to react to failure (cleanup, translation, fallback), use `wrap_node`/`wrap_llm` and put your own `try`/`except` around `await call(...)`.
+- `pre_llm`, `post_llm`, `post_node` **only run on success** — an exception skips them entirely. If you need to react to failure (cleanup, translation, fallback), use `wrap_node`/`wrap_llm` and put your own `try`/`except` around `await call(...)`.
 - **Where you put a retry changes what it re-executes:**
   - `model_middleware=` retry only re-issues the raw LLM call — safe by default, no side effects beyond the model provider request.
   - `middleware=` retry on an agent re-runs the **entire node**, including every tool call that already succeeded in that attempt. Only retry at this slot if the tools involved are safe to re-run (idempotent, or guarded by an idempotency key) — otherwise a transient failure after a non-idempotent tool call (e.g. "send email", "charge card") causes it to fire twice.
@@ -38,7 +38,7 @@ The user wants to add middleware to a railtracks node/agent: $ARGUMENTS
 
 ### 3. Ordering & composition
 - Two different things happen depending on middleware shape — know which one you're ordering:
-  - **Input-transforming middleware** (`before_llm`-style: mutates `message_history`/`schema`/`tools` before calling onward) — earlier entries in the list run first and hand their result to later entries. Put transformations before validations: `model_middleware=[ContextInjection(), my_guard]` so the guard sees the filled-in prompt, not the raw template.
+  - **Input-transforming middleware** (`pre_llm`-style: mutates `message_history`/`schema`/`tools` before calling onward) — earlier entries in the list run first and hand their result to later entries. Put transformations before validations: `model_middleware=[ContextInjection(), my_guard]` so the guard sees the filled-in prompt, not the raw template.
   - **Span-wrapping middleware** (retry, timing, logging that brackets a whole call) — the outermost entry sees the aggregate outcome; the innermost is what actually gets re-invoked on each attempt. `middleware=[Retry(3), log_after]` → the log fires once per retry attempt (it's inside the retry). `middleware=[log_after, Retry(3)]` → the log fires once, for the final outcome only (it's outside the retry). Pick based on whether you want per-attempt or per-call visibility.
 - When `rt.couple`-ing middleware onto a node that already has some, the new list is innermost — it can't run "before" existing outer middleware like auth checks.
 
@@ -76,7 +76,7 @@ def block_secrets(event: rt.guardrails.LLMGuardrailEvent) -> rt.guardrails.Guard
     return rt.guardrails.GuardrailDecision.allow()
 
 # Not a policy decision -> plain middleware
-@rt.before_llm
+@rt.pre_llm
 def log_prompt(message_history, schema, tools):
     print(message_history)
     return message_history, schema, tools
@@ -86,7 +86,7 @@ def log_prompt(message_history, schema, tools):
 ```python
 import railtracks as rt
 
-@rt.after_node(name="print_after")
+@rt.post_node(name="print_after")
 async def log_result(result):
     print("Finished:", result)
     return result
@@ -114,5 +114,5 @@ Adjusted = rt.couple(
 - Don't retry at `middleware=` on an agent with non-idempotent tools — it re-runs every tool call in that attempt, not just the failed step.
 - Don't hand-roll a content allow/block check as plain middleware — use `input_guard`/`output_guard` so it shows up in `GuardrailTrace` like the rest of your rails.
 - Don't write a plain `def` for `wrap_node`/`wrap_llm` — it must be `async def`.
-- Don't expect `after_llm`/`after_node` to run on failure — they're success-only; use `wrap_llm`/`wrap_node` if you need failure-aware logic.
+- Don't expect `post_llm`/`post_node` to run on failure — they're success-only; use `wrap_llm`/`wrap_node` if you need failure-aware logic.
 - Don't assume `name=` changes what shows up in railtracks' own traces — it doesn't (yet), outside of guardrails.

--- a/packages/railtracks/src/railtracks/cli/viz_api/models.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/models.py
@@ -113,13 +113,13 @@ class MiddlewareKind(str, Enum):
     ``parent_middleware_type_id`` — see :func:`queries._middleware_kind_case`.
 
     The derivation is a precedence ladder rather than a switch, and that is
-    load-bearing: ``@before_llm`` and ``@after_llm`` are both built on
+    load-bearing: ``@pre_llm`` and ``@post_llm`` are both built on
     ``@wrap_llm``, so each emits its own specialised pair *and* the generic
     ``middleware.model.invocation`` / ``.response``. Measured on one agent run
     with every decorator stacked, ``middleware.model.invocation`` fires four
-    times — once each for the ``@before_llm``, the ``@after_llm``, the
+    times — once each for the ``@pre_llm``, the ``@post_llm``, the
     ``@wrap_llm`` and the framework's own ``_llm_observe``. Equality tests would
-    call a ``@before_llm`` a plain model wrapper; only most-specific-wins is
+    call a ``@pre_llm`` a plain model wrapper; only most-specific-wins is
     right.
 
     ``NODE_WRAPPER`` and ``LLM_WRAPPER`` are the same decorator shape in the two
@@ -137,9 +137,9 @@ class MiddlewareKind(str, Enum):
     ============================ ==========================================
     ``INPUT_GUARD``              ``@input_guard`` / ``InputGuard`` subclass
     ``OUTPUT_GUARD``             ``@output_guard`` / ``OutputGuard`` subclass
-    ``REQUEST_TRANSFORM``        ``@before_llm``
-    ``RESPONSE_TRANSFORM``       ``@after_llm``
-    ``RESULT_HOOK``              ``@after_node``
+    ``REQUEST_TRANSFORM``        ``@pre_llm``
+    ``RESPONSE_TRANSFORM``       ``@post_llm``
+    ``RESULT_HOOK``              ``@post_node``
     ``LLM_WRAPPER``              ``@wrap_llm`` (``model_middleware=``)
     ``NODE_WRAPPER``             ``@wrap_node`` (``middleware=``)
     ============================ ==========================================

--- a/packages/railtracks/src/railtracks/cli/viz_api/queries/middleware.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/queries/middleware.py
@@ -53,13 +53,13 @@ _INTERNAL_MIDDLEWARE_NAMES = ("_observe_middleware", "_llm_observe")
 #: Kind per ``middleware_type_id``, as a precedence ladder over the *specialised*
 #: event types a middleware emits.
 #:
-#: Most-specific-wins is load-bearing, not defensive. ``@before_llm`` and
-#: ``@after_llm`` are both built on ``@wrap_llm``, so each emits its own
+#: Most-specific-wins is load-bearing, not defensive. ``@pre_llm`` and
+#: ``@post_llm`` are both built on ``@wrap_llm``, so each emits its own
 #: specialised pair *and* the generic ``middleware.model.invocation`` /
 #: ``.response``. Measured on one agent run with every decorator stacked,
 #: ``middleware.model.invocation`` fires four times — once each for the
-#: ``@before_llm``, the ``@after_llm``, the ``@wrap_llm`` and ``_llm_observe``.
-#: Rewriting these ``LIKE``s as equality tests would label a ``@before_llm`` a
+#: ``@pre_llm``, the ``@post_llm``, the ``@wrap_llm`` and ``_llm_observe``.
+#: Rewriting these ``LIKE``s as equality tests would label a ``@pre_llm`` a
 #: plain model wrapper.
 #:
 #: The final band fallback catches an LLM-band middleware that emits no
@@ -74,7 +74,7 @@ _INTERNAL_MIDDLEWARE_NAMES = ("_observe_middleware", "_llm_observe")
 #: as ``llm_wrapper``.
 #:
 #: The consequence is worth stating plainly rather than discovering: a
-#: ``@before_llm`` is reported as a request transform **only when the framework
+#: ``@pre_llm`` is reported as a request transform **only when the framework
 #: emits the specialised pair for it**, and where it does not, the honest answer
 #: from the stream is "something wrapped the LLM call". The ladder is not guessing
 #: past what was recorded, and the ``.input.%`` / ``.output.%`` rungs are kept

--- a/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
+++ b/packages/railtracks/src/railtracks/guardrails/llm/decorators.py
@@ -1,6 +1,6 @@
 """Decorators for authoring guardrails from a plain function.
 
-Mirror the ``@before_llm`` / ``@after_llm`` middleware decorators: wrap a function
+Mirror the ``@pre_llm`` / ``@post_llm`` middleware decorators: wrap a function
 that maps an event to a :class:`GuardrailDecision` and get back a ready-to-use
 :class:`InputGuard` / :class:`OutputGuard` instance.
 

--- a/packages/railtracks/src/railtracks/middleware/__init__.py
+++ b/packages/railtracks/src/railtracks/middleware/__init__.py
@@ -3,12 +3,14 @@ from railtracks.middleware.core import (
     Middleware,
     wrap_node,
 )
+from railtracks.middleware.post import post_node
 from railtracks.middleware.verdict import Verdict, VerifierRejectedError
 
 __all__ = [
+    "post_node",
+    "after_node",
     "Middleware",
     "wrap_node",
-    "after_node",
     "Verdict",
     "VerifierRejectedError",
 ]

--- a/packages/railtracks/src/railtracks/middleware/after.py
+++ b/packages/railtracks/src/railtracks/middleware/after.py
@@ -1,14 +1,11 @@
-import functools
-from typing import Awaitable, Callable, TypeVar, overload
+from __future__ import annotations
 
-from railtracks.events.middleware import (
-    MiddlewareOutputInvocationEvent,
-    MiddlewareOutputResponseEvent,
-)
-from railtracks.events.send import emit
-from railtracks.utils.unpack import unpack_async_sync
+from typing import Any, Awaitable, Callable, TypeVar, overload
 
-from .core import Middleware, wrap_node
+from railtracks.utils.deprecation import warn_pending_change
+
+from .core import Middleware
+from .post import post_node
 
 _R = TypeVar("_R")
 
@@ -32,41 +29,15 @@ def after_node(
     /,
     *,
     name: str | None = None,
-) -> (
-    Middleware[..., _R]
-    | Callable[
-        [Callable[[_R], Awaitable[_R]] | Callable[[_R], _R]], Middleware[..., _R]
-    ]
-):
-    """
-    Special decorator to create a middleware that runs after the node completes. The wrapped function will run and then your after function will be called upon succesful completion of the function.
-
-    NOTE: This middleware will not run the node raises an exception.
-    """
-
+) -> Any:
+    """Deprecated: Use ``rt.post_node`` instead."""
+    warn_pending_change(
+        "rt.after_node",
+        change="is renamed",
+        instead="rt.post_node",
+        detail="The function itself is unchanged.",
+        stacklevel=2,
+    )
     if fn is None:
-        return lambda f: wrap_node(_wrapper(f), name=name)
-
-    return wrap_node(_wrapper(fn), name=name)
-
-
-def _wrapper(func: Callable[[_R], Awaitable[_R]] | Callable[[_R], _R], /):
-    @functools.wraps(func)
-    async def wrapper(call: Callable[..., Awaitable[_R]], *args, **kwargs):
-        result = await call(*args, **kwargs)
-        input_event = MiddlewareOutputInvocationEvent(
-            response=result,
-        )
-        await emit(input_event)
-        post_after_result = func(result)
-
-        result = await unpack_async_sync(post_after_result)
-
-        output_event = MiddlewareOutputResponseEvent(
-            response=result,
-        )
-        await emit(output_event)
-
-        return result
-
-    return wrapper
+        return post_node(name=name)
+    return post_node(fn, name=name)

--- a/packages/railtracks/src/railtracks/middleware/after.py
+++ b/packages/railtracks/src/railtracks/middleware/after.py
@@ -36,7 +36,6 @@ def after_node(
         change="is renamed",
         instead="rt.post_node",
         detail="The function itself is unchanged.",
-        stacklevel=2,
     )
     if fn is None:
         return post_node(name=name)

--- a/packages/railtracks/src/railtracks/middleware/post.py
+++ b/packages/railtracks/src/railtracks/middleware/post.py
@@ -1,0 +1,72 @@
+import functools
+from typing import Awaitable, Callable, TypeVar, overload
+
+from railtracks.events.middleware import (
+    MiddlewareOutputInvocationEvent,
+    MiddlewareOutputResponseEvent,
+)
+from railtracks.events.send import emit
+from railtracks.utils.unpack import unpack_async_sync
+
+from .core import Middleware, wrap_node
+
+_R = TypeVar("_R")
+
+
+@overload
+def post_node(
+    fn: Callable[[_R], Awaitable[_R]], /, *, name: str | None = None
+) -> Middleware[..., _R]: ...
+
+
+@overload
+def post_node(
+    *, name: str | None = None
+) -> Callable[
+    [Callable[[_R], Awaitable[_R]] | Callable[[_R], _R]], Middleware[..., _R]
+]: ...
+
+
+def post_node(
+    fn: Callable[[_R], Awaitable[_R]] | Callable[[_R], _R] | None = None,
+    /,
+    *,
+    name: str | None = None,
+) -> (
+    Middleware[..., _R]
+    | Callable[
+        [Callable[[_R], Awaitable[_R]] | Callable[[_R], _R]], Middleware[..., _R]
+    ]
+):
+    """
+    Special decorator to create a middleware that runs after the node completes. The wrapped function will run and then your post function will be called upon successful completion of the function.
+
+    NOTE: This middleware will not run if the node raises an exception.
+    """
+
+    if fn is None:
+        return lambda f: wrap_node(_wrapper(f), name=name)
+
+    return wrap_node(_wrapper(fn), name=name)
+
+
+def _wrapper(func: Callable[[_R], Awaitable[_R]] | Callable[[_R], _R], /):
+    @functools.wraps(func)
+    async def wrapper(call: Callable[..., Awaitable[_R]], *args, **kwargs):
+        result = await call(*args, **kwargs)
+        input_event = MiddlewareOutputInvocationEvent(
+            response=result,
+        )
+        await emit(input_event)
+        post_after_result = func(result)
+
+        result = await unpack_async_sync(post_after_result)
+
+        output_event = MiddlewareOutputResponseEvent(
+            response=result,
+        )
+        await emit(output_event)
+
+        return result
+
+    return wrapper

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-from railtracks.built_nodes.llm.middleware import before_llm
+from railtracks.built_nodes.llm.middleware import pre_llm
 from railtracks.guardrails.core import (
     GuardrailBlockedError,
     GuardrailDecision,
@@ -163,7 +163,7 @@ async def test_output_guards_fire_in_reverse_list_order(mock_llm):
 async def test_guard_and_plain_middleware_interleave_by_position(mock_llm):
     trace = []
 
-    @before_llm
+    @pre_llm
     async def plain_tracer(message_history, schema, tools):
         trace.append("plain")
         return message_history, schema, tools

--- a/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
@@ -6,7 +6,7 @@ import pytest
 import railtracks as rt
 from jsonschema import validate
 from pydantic import BaseModel, Field
-from railtracks.built_nodes.llm.middleware import before_llm
+from railtracks.built_nodes.llm.middleware import pre_llm
 from railtracks.exceptions.errors import LLMError
 from railtracks.guardrails.core import (
     GuardrailBlockedError,
@@ -678,7 +678,7 @@ class TestGuardrailsEndToEnd:
                 trace.append("output")
                 return GuardrailDecision.allow()
 
-        @before_llm
+        @pre_llm
         async def plain_tracer(message_history, schema, tools):
             trace.append("plain")
             return message_history, schema, tools

--- a/packages/railtracks/tests/integration_tests/middlewares/test_streaming_guardrail_interaction.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_streaming_guardrail_interaction.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import pytest
 import railtracks as rt
-from railtracks.built_nodes.llm.middleware import before_llm
+from railtracks.built_nodes.llm.middleware import pre_llm
 from railtracks.guardrails.core import (
     GuardrailBlockedError,
     GuardrailDecision,
@@ -118,7 +118,7 @@ async def test_output_guard_and_plain_middleware_both_fire_while_streaming(mock_
     after-hook runs, no matter which nests inside the other."""
     trace = []
 
-    @before_llm
+    @pre_llm
     async def plain_tracer(message_history, schema, tools):
         trace.append("plain")
         return message_history, schema, tools

--- a/packages/railtracks/tests/unit_tests/built_nodes/llm/test_middleware_decorators.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/llm/test_middleware_decorators.py
@@ -1,9 +1,7 @@
-"""Unit tests for wrap_llm/before_llm/after_llm's `name` handling.
+"""Unit tests for wrap_llm/pre_llm/post_llm's `name` handling.
 
-The bare decorator forms (@wrap_llm, @before_llm, @after_llm) are already exercised
-elsewhere (e.g. test_guardrail_ordering.py uses a bare @before_llm), but the
-parametrized form -- @wrap_llm(name=...), @before_llm(name=...), @after_llm(name=...)
--- had zero direct test coverage before this file.
+The bare decorator forms (@wrap_llm, @pre_llm, @post_llm) are exercised
+as well as the parametrized form -- @wrap_llm(name=...), @pre_llm(name=...), @post_llm(name=...).
 
 The bare-form `.name` tests below are regression tests for a bug where, with no
 explicit name, `.name` fell back to the decorator's internal inner-closure name
@@ -13,7 +11,7 @@ explicit name, `.name` fell back to the decorator's internal inner-closure name
 from __future__ import annotations
 
 import pytest
-from railtracks.built_nodes.llm.middleware import after_llm, before_llm, wrap_llm
+from railtracks.built_nodes.llm.middleware import post_llm, pre_llm, wrap_llm
 from railtracks.llm.history import MessageHistory
 from railtracks.llm.message import AssistantMessage, UserMessage
 from railtracks.llm.response import MessageInfo, Response
@@ -48,13 +46,13 @@ async def test_wrap_llm_parametrized_sets_name_and_still_runs():
 
 
 @pytest.mark.asyncio
-async def test_before_llm_parametrized_sets_name_and_transforms_request():
-    @before_llm(name="custom-before")
+async def test_pre_llm_parametrized_sets_name_and_transforms_request():
+    @pre_llm(name="custom-pre")
     async def middleware(message_history, schema, tools):
         new_history = MessageHistory([*message_history, UserMessage("appended")])
         return new_history, schema, tools
 
-    assert middleware.name == "custom-before"
+    assert middleware.name == "custom-pre"
 
     seen = {}
 
@@ -69,15 +67,15 @@ async def test_before_llm_parametrized_sets_name_and_transforms_request():
 
 
 @pytest.mark.asyncio
-async def test_after_llm_parametrized_sets_name_and_transforms_response():
-    @after_llm(name="custom-after")
+async def test_post_llm_parametrized_sets_name_and_transforms_response():
+    @post_llm(name="custom-post")
     async def middleware(response):
         return Response(
             message=AssistantMessage(content=response.text.upper()),
             message_info=response.message_info,
         )
 
-    assert middleware.name == "custom-after"
+    assert middleware.name == "custom-post"
 
     async def core(message_history, schema, tools):
         return _response("hi")
@@ -101,17 +99,17 @@ def test_wrap_llm_bare_defaults_name_to_original_function():
     assert my_wrap_middleware.name == "my_wrap_middleware"
 
 
-def test_before_llm_bare_defaults_name_to_original_function():
-    @before_llm
-    async def my_before_middleware(message_history, schema, tools):
+def test_pre_llm_bare_defaults_name_to_original_function():
+    @pre_llm
+    async def my_pre_middleware(message_history, schema, tools):
         return message_history, schema, tools
 
-    assert my_before_middleware.name == "my_before_middleware"
+    assert my_pre_middleware.name == "my_pre_middleware"
 
 
-def test_after_llm_bare_defaults_name_to_original_function():
-    @after_llm
-    async def my_after_middleware(response):
+def test_post_llm_bare_defaults_name_to_original_function():
+    @post_llm
+    async def my_post_middleware(response):
         return response
 
-    assert my_after_middleware.name == "my_after_middleware"
+    assert my_post_middleware.name == "my_post_middleware"

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -9,7 +9,7 @@ from railtracks.built_nodes._node_builder import (
     safe_create_node,
 )
 from railtracks.built_nodes.function.node_builder import FunctionNodeBuilder
-from railtracks.built_nodes.llm.middleware import after_llm
+from railtracks.built_nodes.llm.middleware import post_llm
 from railtracks.built_nodes.llm.node_builder import LLMNodeBuilder
 from railtracks.exceptions.errors import NodeCreationError
 from railtracks.guardrails.core import GuardrailDecision
@@ -565,7 +565,7 @@ def test_nodebuilder_llm_guardrail_vs_user_middleware_order_is_list_position(
                 reason="always redact",
             )
 
-    @after_llm
+    @post_llm
     def overwrite_after_guardrail(response):
         return Response(
             message=AssistantMessage("overwritten by user middleware"),

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -122,7 +122,7 @@ def test_after_does_not_run_when_call_raises():
         fn_called["value"] = True
         return result
 
-    @rt.function_node(middleware=[rt.after_node(mark)])
+    @rt.function_node(middleware=[rt.post_node(mark)])
     def boom() -> int:
         raise ValueError("nope")
 
@@ -136,7 +136,7 @@ def test_after_does_not_run_when_call_raises():
 
 
 def test_after_replaces_return_value_on_success():
-    @rt.function_node(middleware=[rt.after_node(lambda result: result * 10)])
+    @rt.function_node(middleware=[rt.post_node(lambda result: result * 10)])
     def five() -> int:
         return 5
 

--- a/packages/railtracks/tests/unit_tests/test_pending_changes.py
+++ b/packages/railtracks/tests/unit_tests/test_pending_changes.py
@@ -237,3 +237,89 @@ def test_node_subclassing_is_silent():
         return MyNode
 
     assert_silent(define_subclass)
+
+
+# ---------------------------------------------------------------------------------------
+# before_llm / after_llm / after_node -> pre_llm / post_llm / post_node
+# ---------------------------------------------------------------------------------------
+
+
+def test_before_llm_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.before_llm is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.before_llm
+        def hook(history, schema, tools):
+            return history, schema, tools
+
+
+def test_before_llm_parameterized_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.before_llm is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.before_llm(name="custom")
+        def hook(history, schema, tools):
+            return history, schema, tools
+
+
+def test_after_llm_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.after_llm is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.after_llm
+        def hook(response):
+            return response
+
+
+def test_after_llm_parameterized_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.after_llm is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.after_llm(name="custom")
+        def hook(response):
+            return response
+
+
+def test_after_node_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.after_node is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.after_node
+        def hook(result):
+            return result
+
+
+def test_after_node_parameterized_warns():
+    with pytest.warns(
+        FutureWarning, match="rt.after_node is renamed in railtracks 1.5.0"
+    ):
+
+        @rt.after_node(name="custom")
+        def hook(result):
+            return result
+
+
+def test_pre_llm_forward_is_silent():
+    assert_silent(
+        lambda: rt.pre_llm(lambda history, schema, tools: (history, schema, tools))
+    )
+    assert_silent(
+        lambda: rt.pre_llm(name="custom")(
+            lambda history, schema, tools: (history, schema, tools)
+        )
+    )
+
+
+def test_post_llm_forward_is_silent():
+    assert_silent(lambda: rt.post_llm(lambda response: response))
+    assert_silent(lambda: rt.post_llm(name="custom")(lambda response: response))
+
+
+def test_post_node_forward_is_silent():
+    assert_silent(lambda: rt.post_node(lambda result: result))
+    assert_silent(lambda: rt.post_node(name="custom")(lambda result: result))

--- a/packages/railtracks/tests/unit_tests/test_pending_changes.py
+++ b/packages/railtracks/tests/unit_tests/test_pending_changes.py
@@ -247,61 +247,90 @@ def test_node_subclassing_is_silent():
 def test_before_llm_warns():
     with pytest.warns(
         FutureWarning, match="rt.before_llm is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.before_llm
         def hook(history, schema, tools):
             return history, schema, tools
 
+    assert record[0].filename == __file__
+
 
 def test_before_llm_parameterized_warns():
     with pytest.warns(
         FutureWarning, match="rt.before_llm is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.before_llm(name="custom")
         def hook(history, schema, tools):
             return history, schema, tools
 
+    assert record[0].filename == __file__
+
 
 def test_after_llm_warns():
     with pytest.warns(
         FutureWarning, match="rt.after_llm is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.after_llm
         def hook(response):
             return response
 
+    assert record[0].filename == __file__
+
 
 def test_after_llm_parameterized_warns():
     with pytest.warns(
         FutureWarning, match="rt.after_llm is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.after_llm(name="custom")
         def hook(response):
             return response
 
+    assert record[0].filename == __file__
+
 
 def test_after_node_warns():
     with pytest.warns(
         FutureWarning, match="rt.after_node is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.after_node
         def hook(result):
             return result
 
+    assert record[0].filename == __file__
+
 
 def test_after_node_parameterized_warns():
     with pytest.warns(
         FutureWarning, match="rt.after_node is renamed in railtracks 1.5.0"
-    ):
+    ) as record:
 
         @rt.after_node(name="custom")
         def hook(result):
             return result
+
+    assert record[0].filename == __file__
+
+
+def test_multiple_deprecated_calls_emit_distinct_warnings():
+    with pytest.warns(FutureWarning) as record:
+
+        @rt.before_llm
+        def hook1(h, s, t):
+            return h, s, t
+
+        @rt.before_llm
+        def hook2(h, s, t):
+            return h, s, t
+
+    assert len(record) == 2
+    assert record[0].lineno != record[1].lineno
+    assert record[0].filename == __file__
+    assert record[1].filename == __file__
 
 
 def test_pre_llm_forward_is_silent():


### PR DESCRIPTION
> **Note:** This PR replaces #1511, which was accidentally closed while I was syncing my fork with upstream `main`. The requested review changes have been incorporated here.

## Summary

Renames the middleware hook primitives to use the consistent `pre_*` / `post_*` naming convention:

- `before_llm` → `pre_llm`
- `after_llm` → `post_llm`
- `after_node` → `post_node`

The existing names remain available as deprecated shims for backward compatibility and emit a `FutureWarning` pointing users to the new names.

Closes #1510.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

The new `pre_llm`, `post_llm`, and `post_node` APIs are re-exported from the relevant public modules.

Deprecated `before_llm`, `after_llm`, and `after_node` continue to work through lightweight delegation shims, allowing existing users to migrate without an immediate breaking change.

Internal framework usage has been migrated to the new names so normal framework execution does not emit deprecation warnings.

Added/updated tests cover the new APIs, deprecated API warnings, and parameterized decorator forms.