### PR TITLE
1516 directory install for claude code

### DIFF
--- a/docs/documentation/getting_started/ai_setup.md
+++ b/docs/documentation/getting_started/ai_setup.md
@@ -33,7 +33,7 @@ pip install 'railtracks[visual]'
 
 === "Claude Code"
 
-    Installs a skill file at `.claude/skills/agent-builder/SKILL.md`. Claude Code automatically picks up skills in this directory and applies them when you ask it to build an agent.
+    Installs a skill directory at `.claude/skills/agent-builder/`. Claude Code automatically picks up skills in this directory and applies them when you ask it to build an agent.
 
     ```bash
     railtracks add claude:agent-builder
@@ -44,8 +44,14 @@ pip install 'railtracks[visual]'
         .claude/
         └── skills/
             └── agent-builder/
-                └── SKILL.md   ← railtracks agent-building knowledge
+                ├── SKILL.md   ← railtracks agent-building knowledge
+                └── ...        ← any supporting files the skill ships
         ```
+
+    !!! note "Supporting files"
+        A skill can ship more than `SKILL.md`; `references/`, `scripts/`, and so on. The whole
+        directory is copied, with its sub-paths intact. Claude Code loads a supporting file only
+        when `SKILL.md` links it, on demand, so nothing extra enters the context until it is needed.
 
 === "GitHub Copilot"
 
@@ -118,6 +124,11 @@ Skills are bundled **inside the railtracks package**, no internet connection req
 
 !!! warning "Existing files"
     For Claude Code and Cursor, if the target file already exists you'll be prompted to confirm before overwriting. Pass `--force` to skip the prompt.
+
+!!! note "Re-installing after an upgrade"
+    Installing copies what the version you have ships. It does not yet remove a supporting file that
+    an *older* railtracks shipped and the current one dropped; delete the skill directory first if
+    you want a clean slate.
 
 ## Example: Building Your First Agent
 

--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -41,11 +41,13 @@ from .constants import (
 )
 from .io import (
     _print_update_available,
+    confirm_overwrite,
     print_error,
     print_status,
     print_success,
     print_warning,
 )
+from .skill_install import CLAUDE, install_skill_directory
 from .skills_registry import Skill, discover_skills
 
 # ---------------------------------------------------------------------------
@@ -284,46 +286,21 @@ def _strip_skill_arguments(content: str) -> str:
     return "\n".join(kept)
 
 
-def _confirm_overwrite(file_path: Path) -> bool:
-    """Prompt the user to confirm overwriting an existing file. Returns True to proceed."""
-    try:
-        answer = (
-            input(f"[{cli_name}] '{file_path}' already exists. Overwrite? [y/N] ")
-            .strip()
-            .lower()
-        )
-    except (EOFError, KeyboardInterrupt):
-        print()
-        return False
-    return answer in ("y", "yes")
+def _add_claude(skill: Skill, force: bool) -> list[Path]:
+    """Install a skill for Claude Code as a skill directory, and report what it wrote.
 
-
-def _add_claude(skill: Skill, force: bool) -> None:
-    """Install skill for Claude Code as a SKILL.md file."""
-    target = Path(".claude") / "skills" / skill.name / "SKILL.md"
-    if target.exists() and not force:
-        if not _confirm_overwrite(target):
-            print_status("Aborted.")
-            sys.exit(0)
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    hint = (
-        f'argument-hint: "{skill.argument_hint}"\n'
-        if skill.argument_hint is not None
-        else ""
-    )
-    frontmatter = (
-        f"---\nname: {skill.name}\ndescription: {skill.description}\n{hint}---\n\n"
-    )
-    target.write_text(frontmatter + skill.body, encoding="utf-8")
-    print_success(f"Installed '{skill.name}' for Claude Code -> {target}")
+    Thin by design: everything here that another assistant would also need lives in
+    `skill_install`, parameterised by root path and projection, so the remaining
+    handlers become the same two values rather than the same function again.
+    """
+    return install_skill_directory(skill, CLAUDE, force)
 
 
 def _add_codex(skill: Skill, force: bool) -> None:
     """Install a skill for Codex as a repository-scoped SKILL.md file."""
     target = Path(".agents") / "skills" / skill.name / "SKILL.md"
     if target.exists() and not force:
-        if not _confirm_overwrite(target):
+        if not confirm_overwrite(target):
             print_status("Aborted.")
             sys.exit(0)
 
@@ -373,7 +350,7 @@ def _add_cursor(skill: Skill, force: bool) -> None:
     """Install skill for Cursor as a .mdc rules file."""
     target = Path(".cursor") / "rules" / f"{skill.name}.mdc"
     if target.exists() and not force:
-        if not _confirm_overwrite(target):
+        if not confirm_overwrite(target):
             print_status("Aborted.")
             sys.exit(0)
 
@@ -393,8 +370,11 @@ _TOOL_HANDLERS = {
 }
 
 
-def add_skill(spec: str, force: bool = False) -> None:
-    """Parse <tool>:<skill-name> and install the skill for the given AI coding tool."""
+def add_skill(spec: str, force: bool = False) -> list[Path] | None:
+    """Parse <tool>:<skill-name> and install the skill for the given AI coding tool.
+
+    Returns the files the handler wrote, for handlers that report them.
+    """
     if ":" not in spec:
         print_error(
             f"Invalid format '{spec}'. Expected '<tool>:<skill>', e.g. 'claude:agent-builder'."
@@ -418,7 +398,7 @@ def add_skill(spec: str, force: bool = False) -> None:
         )
         sys.exit(1)
 
-    _TOOL_HANDLERS[tool](SKILL_REGISTRY[skill_name], force)
+    return _TOOL_HANDLERS[tool](SKILL_REGISTRY[skill_name], force)
 
 
 def list_skills() -> None:

--- a/packages/railtracks/src/railtracks/cli/io.py
+++ b/packages/railtracks/src/railtracks/cli/io.py
@@ -1,4 +1,6 @@
-"""CLI stdout helpers (stdlib + colorama only)."""
+"""CLI terminal I/O helpers (stdlib + colorama only)."""
+
+from pathlib import Path
 
 from colorama import Fore, Style
 
@@ -26,3 +28,17 @@ def _print_update_available() -> None:
         f"{Fore.YELLOW}[{cli_name}] A newer UI is available! "
         f"Run 'railtracks update' to upgrade.{Style.RESET_ALL}"
     )
+
+
+def confirm_overwrite(path: Path) -> bool:
+    """Prompt the user before overwriting `path`. Returns True to proceed."""
+    try:
+        answer = (
+            input(f"[{cli_name}] '{path}' already exists. Overwrite? [y/N] ")
+            .strip()
+            .lower()
+        )
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return False
+    return answer in ("y", "yes")

--- a/packages/railtracks/src/railtracks/cli/skill_install.py
+++ b/packages/railtracks/src/railtracks/cli/skill_install.py
@@ -1,0 +1,200 @@
+"""Installing a discovered skill directory into an assistant's native layout.
+
+Every assistant that supports skill *directories* takes the same install: copy
+``SKILL.md`` plus its supporting files to ``<root>/<name>/``, with the skill's
+frontmatter projected into the keys that assistant actually consumes. Only two
+things differ per target, so those two are the parameters and
+`install_skill_directory` is the shared body:
+
+* **the root path** — ``.claude/skills``, ``.agents/skills``, ``.github/skills``,
+  ``.cursor/skills``. Each assistant gets its own native path even where the paths
+  cross-read, so that one ``railtracks add`` maps to exactly one directory on disk.
+* **the projection** — how the skill's metadata and body become the file the target
+  reads. Both halves live here rather than in a handler: the frontmatter half
+  because targets consume different key sets, and the body half because
+  ``$ARGUMENTS`` is substituted only by Claude Code and must be resolved away for
+  everyone else. A handler that copies ``skill.body`` straight to disk reintroduces
+  that bug for its target.
+
+Claude Code is the first target through here. The remaining three wait on the
+install manifest, which owns removing the legacy installs they are migrating from.
+
+**Not handled here: stale files.** Re-installing copies over what we ship now, but
+a supporting file that a *previous* version shipped and this one dropped stays on
+disk. Knowing what we wrote last time is the manifest's job, not the copy's.
+
+**Authoring constraint for skills that ship supporting files:** Claude Code reads a
+supporting file only when ``SKILL.md`` links it, while Copilot auto-discovers the
+whole directory. A skill written for auto-discovery therefore silently
+under-delivers on Claude Code, so every supporting file must be linked from the
+body by explicit relative path. That is the strict case, and it is free for every
+other target.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+import yaml
+
+from .io import confirm_overwrite, print_status, print_success, print_warning
+from .skills_registry import SKILL_FILE, Skill
+
+
+@dataclass(frozen=True)
+class InstallTarget:
+    """One assistant's directory install: where it reads, and what it reads.
+
+    Attributes:
+        label: The assistant's display name, for CLI output.
+        root: Directory holding one sub-directory per installed skill, relative to
+            the project the user is running in.
+        frontmatter: Renders the skill's metadata into the target's frontmatter
+            block, `---` delimiters and trailing blank line included.
+        body: Renders the Markdown body the target receives. Only Claude Code
+            passes it through unchanged; see the module docstring.
+    """
+
+    label: str
+    root: Path
+    frontmatter: Callable[[Skill], str]
+    body: Callable[[Skill], str]
+
+
+def render_frontmatter(
+    ordered: Sequence[tuple[str, Any]],
+    extra: Mapping[str, Any] | None = None,
+    *,
+    skill_name: str = "",
+) -> str:
+    """Render a frontmatter block from projected keys plus a target's `tools:` block.
+
+    `ordered` carries the keys every install of this target emits, in the order it
+    emits them, and is rendered verbatim — a value of None omits its key entirely,
+    which is how an absent `argument-hint` avoids shipping the literal "None".
+    `extra` is the target's own `tools.<assistant>` block: rendered through YAML
+    rather than by hand, because its values are whatever the skill author wrote and
+    unknown keys have to survive unchanged. Leaf collections stay in flow style, so a
+    hand-written `allowed-tools: [Read, Edit]` comes back out the way it went in.
+    """
+    lines = [f"{key}: {value}\n" for key, value in ordered if value is not None]
+
+    emitted = {key for key, value in ordered if value is not None}
+    passthrough = {}
+    for key, value in (extra or {}).items():
+        # A duplicate key would be silently resolved by whichever YAML parser reads
+        # the result, so the projected key wins and the collision is reported.
+        if key in emitted:
+            print_warning(
+                f"skill '{skill_name}': '{key}' in the tools block is ignored; "
+                f"the skill's own '{key}' is used instead."
+            )
+            continue
+        passthrough[key] = value
+
+    rendered_extra = (
+        yaml.safe_dump(
+            passthrough, default_flow_style=None, sort_keys=False, allow_unicode=True
+        )
+        if passthrough
+        else ""
+    )
+    return "---\n" + "".join(lines) + rendered_extra + "---\n\n"
+
+
+def _quote(value: str) -> str:
+    """Emit a string as a double-quoted YAML scalar."""
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def claude_frontmatter(skill: Skill) -> str:
+    """Project a skill into the frontmatter Claude Code consumes.
+
+    `name` and `description` are Claude-native keys already, so this is close to a
+    verbatim copy — which is the point of building the reference handler here.
+    `argument-hint` is Claude-only (no other target has the field or a documented
+    substitution), and `tools.claude` carries the rest: `allowed-tools`, `paths`,
+    `disable-model-invocation`, and anything a later Claude version adds.
+    """
+    return render_frontmatter(
+        (
+            ("name", skill.name),
+            ("description", skill.description),
+            (
+                "argument-hint",
+                _quote(skill.argument_hint)
+                if skill.argument_hint is not None
+                else None,
+            ),
+        ),
+        skill.tools.get("claude"),
+        skill_name=skill.name,
+    )
+
+
+CLAUDE = InstallTarget(
+    label="Claude Code",
+    root=Path(".claude") / "skills",
+    # Claude Code is the one target that substitutes $ARGUMENTS, so it is the one
+    # target whose body ships as authored.
+    body=lambda skill: skill.body,
+    frontmatter=claude_frontmatter,
+)
+
+
+def _planned_files(skill: Skill, destination: Path) -> list[tuple[Path, Path | None]]:
+    """Every file this install writes, as (destination, source or None for SKILL.md)."""
+    planned: list[tuple[Path, Path | None]] = [(destination / SKILL_FILE, None)]
+    planned += [
+        (destination / relative, skill.directory / relative)
+        for relative in skill.supporting_files
+    ]
+    return planned
+
+
+def install_skill_directory(
+    skill: Skill, target: InstallTarget, force: bool = False
+) -> list[Path]:
+    """Install `skill` for `target` and return the files written, in write order.
+
+    The file list is returned rather than only printed because it is exactly what an
+    install manifest needs to record, and re-deriving it later would mean a second
+    implementation of this function's layout decisions.
+
+    Prompts before overwriting anything already on disk unless `force` is set, and
+    exits without writing if the user declines.
+    """
+    destination = target.root / skill.name
+    planned = _planned_files(skill, destination)
+
+    clashes = [path for path, _ in planned if path.exists()]
+    if clashes and not force:
+        # One clash reads better named directly; several read better as the
+        # directory they share.
+        if not confirm_overwrite(clashes[0] if len(clashes) == 1 else destination):
+            print_status("Aborted.")
+            sys.exit(0)
+
+    written: list[Path] = []
+    for path, source in planned:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if source is None:
+            path.write_text(
+                target.frontmatter(skill) + target.body(skill), encoding="utf-8"
+            )
+        else:
+            shutil.copy2(source, path)
+        written.append(path)
+
+    extras = len(written) - 1
+    suffix = (
+        f" (+{extras} supporting file{'' if extras == 1 else 's'})" if extras else ""
+    )
+    print_success(
+        f"Installed '{skill.name}' for {target.label} -> {written[0]}{suffix}"
+    )
+    return written

--- a/packages/railtracks/tests/unit_tests/cli/test_cli.py
+++ b/packages/railtracks/tests/unit_tests/cli/test_cli.py
@@ -15,10 +15,13 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import yaml
 from fastapi.testclient import TestClient
 from railtracks.cli import (
     SKILLS,
     SUPPORTED_TOOLS,
+    _add_claude,
+    _strip_skill_arguments,
     _visual_dependencies_available,
     add_skill,
     check_for_ui_update,
@@ -38,6 +41,8 @@ from railtracks.cli.io import (
     print_success,
     print_warning,
 )
+from railtracks.cli.skill_install import CLAUDE, InstallTarget, install_skill_directory
+from railtracks.cli.skills_registry import load_skill
 from railtracks.cli.viz_server import app
 
 
@@ -419,6 +424,285 @@ class TestSkillInstallers(unittest.TestCase):
 
         content = Path(".claude/skills/agent-builder/SKILL.md").read_text(encoding="utf-8")
         self.assertIn("$ARGUMENTS", content)
+
+
+def _write_skill(root, name, frontmatter, body="# Heading\n\nBody text.\n", files=None):
+    """Create a synthetic skill directory and return the loaded `Skill`.
+
+    Bundled skills deliberately ship no supporting files and no `tools:` block —
+    `test_skills_registry` asserts both, as the canary for when content work starts —
+    so the directory install can only be exercised against fixtures until then.
+    """
+    directory = Path(root) / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "SKILL.md").write_text(
+        f"---\n{frontmatter}---\n\n{body}", encoding="utf-8"
+    )
+    for relative, content in (files or {}).items():
+        path = directory / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return load_skill(directory)
+
+
+class TestClaudeDirectoryInstall(unittest.TestCase):
+    """`railtracks add claude:<skill>` copies a skill directory, not a flat file."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def _installed(self, name="fixture-skill"):
+        return Path(f".claude/skills/{name}/SKILL.md").read_text(encoding="utf-8")
+
+    def test_supporting_files_keep_their_relative_subpaths(self):
+        """A `references/` tree is what the directory install exists to carry."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={
+                "references/api.md": "# Generated API\n",
+                "references/nested/data.json": '{"k": 1}\n',
+                "scripts/demo.py": "print('hi')\n",
+            },
+        )
+
+        _add_claude(skill, force=False)
+
+        root = Path(".claude/skills/fixture-skill")
+        self.assertEqual(
+            (root / "references/api.md").read_text(encoding="utf-8"),
+            "# Generated API\n",
+        )
+        self.assertEqual(
+            (root / "references/nested/data.json").read_text(encoding="utf-8"),
+            '{"k": 1}\n',
+        )
+        self.assertEqual(
+            (root / "scripts/demo.py").read_text(encoding="utf-8"), "print('hi')\n"
+        )
+
+    def test_skill_without_supporting_files_is_unchanged(self):
+        """The flat-file output this replaced must survive byte for byte."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            'name: fixture-skill\ndescription: A fixture.\nargument-hint: "[what to do]"\n',
+        )
+
+        _add_claude(skill, force=False)
+
+        self.assertEqual(
+            self._installed(),
+            "---\nname: fixture-skill\ndescription: A fixture.\n"
+            'argument-hint: "[what to do]"\n---\n\n# Heading\n\nBody text.\n',
+        )
+
+    def test_absent_argument_hint_omits_the_key(self):
+        """An optional key with no value must not ship as the literal "None"."""
+        skill = _write_skill(
+            self.source, "fixture-skill", "name: fixture-skill\ndescription: A fixture.\n"
+        )
+
+        _add_claude(skill, force=False)
+
+        content = self._installed()
+        self.assertNotIn("argument-hint", content)
+        self.assertNotIn("None", content)
+
+    def test_tools_claude_block_is_merged_into_the_frontmatter(self):
+        """Including keys this version has never heard of — they are forward support."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  claude:\n"
+            "    allowed-tools: [Read, Edit]\n"
+            "    disable-model-invocation: true\n"
+            "    some-future-key: yes-please\n",
+        )
+
+        _add_claude(skill, force=False)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["allowed-tools"], ["Read", "Edit"])
+        self.assertIs(frontmatter["disable-model-invocation"], True)
+        self.assertEqual(frontmatter["some-future-key"], "yes-please")
+        self.assertEqual(frontmatter["name"], "fixture-skill")
+
+    def test_other_assistants_tool_blocks_are_not_emitted(self):
+        """`tools.cursor` is Cursor's projection to make, not Claude's."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  cursor:\n"
+            "    globs: '**/*.py'\n",
+        )
+
+        _add_claude(skill, force=False)
+
+        self.assertNotIn("globs", self._installed())
+
+    def test_skill_keys_win_over_a_colliding_tools_key(self):
+        """A duplicate frontmatter key is resolved silently by the reader; warn instead."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  claude:\n"
+            "    description: Sneaky override.\n",
+        )
+
+        with patch("railtracks.cli.skill_install.print_warning") as mock_warning:
+            _add_claude(skill, force=False)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["description"], "A fixture.")
+        mock_warning.assert_called_once()
+
+    def test_force_overwrites_an_existing_directory_without_prompting(self):
+        """`--force` covers the directory case, not just the single file."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Second\n"},
+        )
+        target = Path(".claude/skills/fixture-skill/references")
+        target.mkdir(parents=True)
+        (target / "api.md").write_text("# First\n", encoding="utf-8")
+
+        with patch("builtins.input", side_effect=AssertionError("prompted anyway")):
+            _add_claude(skill, force=True)
+
+        self.assertEqual((target / "api.md").read_text(encoding="utf-8"), "# Second\n")
+
+    def test_declining_the_prompt_writes_nothing(self):
+        """A refused overwrite must leave every file it would have touched alone."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Second\n"},
+        )
+        target = Path(".claude/skills/fixture-skill/references")
+        target.mkdir(parents=True)
+        (target / "api.md").write_text("# First\n", encoding="utf-8")
+
+        with patch("builtins.input", return_value="n"):
+            with self.assertRaises(SystemExit):
+                _add_claude(skill, force=False)
+
+        self.assertEqual((target / "api.md").read_text(encoding="utf-8"), "# First\n")
+        self.assertFalse(Path(".claude/skills/fixture-skill/SKILL.md").exists())
+
+    def test_returns_every_file_it_wrote(self):
+        """The install manifest's input; deriving it a second time would drift."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Generated\n", "scripts/demo.py": "x = 1\n"},
+        )
+
+        written = _add_claude(skill, force=False)
+
+        self.assertEqual(
+            written,
+            [
+                Path(".claude/skills/fixture-skill/SKILL.md"),
+                Path(".claude/skills/fixture-skill/references/api.md"),
+                Path(".claude/skills/fixture-skill/scripts/demo.py"),
+            ],
+        )
+        self.assertTrue(all(path.is_file() for path in written))
+
+    def test_add_skill_reports_the_files_written(self):
+        """The list has to survive the CLI entry point, not just the handler."""
+        written = add_skill("claude:agent-builder")
+
+        self.assertEqual(
+            written, [Path(".claude/skills/agent-builder/SKILL.md")]
+        )
+
+    def test_a_dropped_supporting_file_is_left_behind(self):
+        """Known gap, deliberately not fixed here: stale removal is the manifest's job.
+
+        Delete this test when the install manifest lands; until then it pins the
+        behaviour so nobody mistakes a plain copy for a sync.
+        """
+        first = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/gone.md": "# Shipped once\n"},
+        )
+        _add_claude(first, force=True)
+        (first.directory / "references/gone.md").unlink()
+
+        _add_claude(load_skill(first.directory), force=True)
+
+        self.assertTrue(Path(".claude/skills/fixture-skill/references/gone.md").exists())
+
+
+class TestInstallTargetParameters(unittest.TestCase):
+    """The two parameters are the deliverable: a target root, and a projection."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def test_claude_target_writes_to_its_native_path(self):
+        """Each assistant gets its own root, never a path it merely also reads."""
+        self.assertEqual(CLAUDE.root, Path(".claude") / "skills")
+
+    def test_another_target_needs_only_a_root_and_a_projection(self):
+        """Stand up a second target with no new code; that is what makes it reusable."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            body="Use $ARGUMENTS here.\n",
+            files={"references/api.md": "# Generated\n"},
+        )
+        elsewhere = InstallTarget(
+            label="Some Assistant",
+            root=Path(".somewhere") / "skills",
+            frontmatter=lambda s: f"---\nname: {s.name}\n---\n\n",
+            body=lambda s: _strip_skill_arguments(s.body),
+        )
+
+        written = install_skill_directory(skill, elsewhere)
+
+        self.assertEqual(
+            written,
+            [
+                Path(".somewhere/skills/fixture-skill/SKILL.md"),
+                Path(".somewhere/skills/fixture-skill/references/api.md"),
+            ],
+        )
+        content = written[0].read_text(encoding="utf-8")
+        self.assertEqual(content, "---\nname: fixture-skill\n---\n\nUse the request here.")
+        self.assertFalse(Path(".claude").exists())
 
 
 class TestListSkills(unittest.TestCase):

--- a/packages/railtracks/tests/unit_tests/cli/test_skills_registry.py
+++ b/packages/railtracks/tests/unit_tests/cli/test_skills_registry.py
@@ -65,6 +65,27 @@ class TestBundledSkills:
         """No handler reads `tools:` yet, so nothing bundled should author it."""
         assert discover_skills()[name].tools == {}
 
+    @pytest.mark.parametrize("name", BUNDLED_SKILLS)
+    def test_supporting_files_are_linked_from_the_body(self, name):
+        """Claude Code reads a supporting file only when `SKILL.md` links it.
+
+        Copilot auto-discovers the whole directory instead, so a skill authored for
+        auto-discovery silently under-delivers on Claude Code. Explicit relative
+        links are the house style: strict for Claude, free for everyone else.
+        Vacuous while nothing bundled ships extras, load-bearing the moment one does.
+        """
+        skill = discover_skills()[name]
+
+        unlinked = [
+            relative
+            for relative in skill.supporting_files
+            if relative.as_posix() not in skill.body
+        ]
+        assert not unlinked, (
+            f"skill '{name}': {unlinked} ship in the directory but nothing in "
+            f"SKILL.md links them, so Claude Code will never read them."
+        )
+
 
 class TestLegacySkillsMapping:
     """`SKILLS` must expose the same keys and values the hardcoded dict did."""


### PR DESCRIPTION
## Summary

Teaches the `claude` install handler to copy a skill *directory*: `SKILL.md` plus its supporting files, with relative sub-paths intact. `discover_skills()` has exposed `Skill.supporting_files` and `Skill.tools` since #1479 and nothing consumed either; this
consumes both.

The copy itself lives in a new `cli/skill_install.py`, parameterized by the only two
things that differ per assistant; **the target root path and the frontmatter projection**. Frontmatter is
projected from the skill's own `SKILL.md` (`name`, `description`, `argument-hint` when present) and
the `tools.claude` block is merged in, unknown keys passing through unchanged as forward support for
a Claude version we have not shipped for.

Closes #1516.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes
