### PR TITLE
Opt in stacktrace

### DIFF
--- a/docs/observability/tracking/error_handling.md
+++ b/docs/observability/tracking/error_handling.md
@@ -48,13 +48,7 @@ All internal errors include helpful debugging notes and formatted error messages
     If you need the full history in a log line for debugging, render it explicitly at the call site:
 
     ```python
-    from railtracks.exceptions import LLMError
-
-    try:
-        ...
-    except LLMError as err:
-        logger.error("LLM call failed: %s", err.format_verbose())
-        # or route err.message_history wherever your data-handling policy allows
+    --8<-- "docs/scripts/error_handling.py:msg_hist"
     ```
 
 ## Error Handling Patterns

--- a/docs/observability/tracking/error_handling.md
+++ b/docs/observability/tracking/error_handling.md
@@ -40,6 +40,23 @@ All internal errors include helpful debugging notes and formatted error messages
     --8<-- "docs/scripts/error_handling.py:fatal_error"
     ```
 
+### Inspecting LLMError message history
+
+`LLMError` carries the input `MessageHistory` on `err.message_history` so you can inspect it programmatically. `str(err)` and `repr(err)` never embed that history. The exception text shows only a redacted summary like `"N message(s) redacted"`. This keeps conversation contents (which may include PII, credentials, or customer data) out of anything that captures the exception string, such as `logger.exception(...)` or a crash reporter.
+
+!!! danger "Full Message History"
+    If you need the full history in a log line for debugging, render it explicitly at the call site:
+
+    ```python
+    from railtracks.exceptions import LLMError
+
+    try:
+        ...
+    except LLMError as err:
+        logger.error("LLM call failed: %s", err.format_verbose())
+        # or route err.message_history wherever your data-handling policy allows
+    ```
+
 ## Error Handling Patterns
 
 ???+ example "Basic Error Handling"

--- a/docs/observability/tracking/logging.md
+++ b/docs/observability/tracking/logging.md
@@ -49,20 +49,6 @@ Loggers use dotted names (often from `__name__`), e.g. `RT.railtracks._session`.
 
 File output from `log_file` / `RT_LOG_FILE` still records the **full** dotted `name` on each record; only the console formatter applies `name_style`.
 
-### LLM error verbosity
-
-When an LLM call fails, `LLMError` carries the input `MessageHistory` on `err.message_history` so you can inspect it programmatically. By default, `str(err)` and `repr(err)` **do not** embed that history and only a redacted summary (`"N message(s) redacted"`) appears in the exception text. This keeps conversation contents (which may include PII, credentials, or customer data) out of anything that captures the exception string, such as `logger.exception(...)` or a crash reporter.
-
-For local debugging, opt in with `verbose_llm_errors=True`:
-
-```python
-import railtracks as rt
-
-rt.enable_logging(level="DEBUG", verbose_llm_errors=True)
-```
-
-With the flag on, the full history is rendered into the exception string as before. Leave it off in production; if you need the history in a controlled way, read `err.message_history` directly in your `except` block and route it wherever your data-handling policy allows.
-
 ### Logging Levels
 
 Railtracks supports six logging levels aligned with the standard Python logging framework:

--- a/docs/observability/tracking/logging.md
+++ b/docs/observability/tracking/logging.md
@@ -49,6 +49,20 @@ Loggers use dotted names (often from `__name__`), e.g. `RT.railtracks._session`.
 
 File output from `log_file` / `RT_LOG_FILE` still records the **full** dotted `name` on each record; only the console formatter applies `name_style`.
 
+### LLM error verbosity
+
+When an LLM call fails, `LLMError` carries the input `MessageHistory` on `err.message_history` so you can inspect it programmatically. By default, `str(err)` and `repr(err)` **do not** embed that history and only a redacted summary (`"N message(s) redacted"`) appears in the exception text. This keeps conversation contents (which may include PII, credentials, or customer data) out of anything that captures the exception string, such as `logger.exception(...)` or a crash reporter.
+
+For local debugging, opt in with `verbose_llm_errors=True`:
+
+```python
+import railtracks as rt
+
+rt.enable_logging(level="DEBUG", verbose_llm_errors=True)
+```
+
+With the flag on, the full history is rendered into the exception string as before. Leave it off in production; if you need the history in a controlled way, read `err.message_history` directly in your `except` block and route it wherever your data-handling policy allows.
+
 ### Logging Levels
 
 Railtracks supports six logging levels aligned with the standard Python logging framework:

--- a/docs/scripts/error_handling.py
+++ b/docs/scripts/error_handling.py
@@ -126,5 +126,14 @@ async def call_with_fallback(primary_node, fallback_node, user_input):
         raise
 # --8<-- [end: fallback]
 
+# --8<-- [start: msg_hist]
+from railtracks.exceptions import LLMError
+
+try:
+    ...
+except LLMError as err:
+    logger.error("LLM call failed: %s", err.format_verbose())
+    # or route err.message_history wherever your data-handling policy allows
+# --8<-- [end: msg_hist]
 
 

--- a/packages/railtracks/src/railtracks/exceptions/errors.py
+++ b/packages/railtracks/src/railtracks/exceptions/errors.py
@@ -76,32 +76,35 @@ class LLMError(RTError):
         if not self.message_history:
             return self._color(base, self.RED)
 
-        # Lazy import to keep the exceptions module free of a hard logging dep.
-        from railtracks.utils.logging.config import verbose_llm_errors
-
         try:
             count = len(self.message_history)
         except TypeError:
             count = None
 
-        if verbose_llm_errors():
-            mh_str = str(self.message_history)
-            indented_mh = "\n".join("    " + line for line in mh_str.splitlines())
-            detail = self._color("Message History:\n", self.BOLD_GREEN) + self._color(
-                indented_mh, self.GREEN
-            )
-        else:
-            summary = (
-                f"{count} message(s) redacted; "
-                "enable via rt.enable_logging(verbose_llm_errors=True)"
-                if count is not None
-                else "message history redacted; "
-                "enable via rt.enable_logging(verbose_llm_errors=True)"
-            )
-            detail = self._color("Message History: ", self.BOLD_GREEN) + self._color(
-                summary, self.GREEN
-            )
+        summary = (
+            f"{count} message(s) redacted; "
+            "call err.format_verbose() to render or read err.message_history"
+            if count is not None
+            else "message history redacted; "
+            "call err.format_verbose() to render or read err.message_history"
+        )
+        detail = self._color("Message History: ", self.BOLD_GREEN) + self._color(
+            summary, self.GREEN
+        )
+        notes_str = "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
+        return f"\n{self._color(base, self.RED)}{notes_str}"
 
+    def format_verbose(self) -> str:
+        """Render the exception with the full input ``MessageHistory`` embedded."""
+        base = super().__str__()
+        if not self.message_history:
+            return self._color(base, self.RED)
+
+        mh_str = str(self.message_history)
+        indented_mh = "\n".join("    " + line for line in mh_str.splitlines())
+        detail = self._color("Message History:\n", self.BOLD_GREEN) + self._color(
+            indented_mh, self.GREEN
+        )
         notes_str = "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
         return f"\n{self._color(base, self.RED)}{notes_str}"
 

--- a/packages/railtracks/src/railtracks/exceptions/errors.py
+++ b/packages/railtracks/src/railtracks/exceptions/errors.py
@@ -73,24 +73,39 @@ class LLMError(RTError):
 
     def __str__(self):
         base = super().__str__()
-        details = []
-        if self.message_history:
+        if not self.message_history:
+            return self._color(base, self.RED)
+
+        # Lazy import to keep the exceptions module free of a hard logging dep.
+        from railtracks.utils.logging.config import verbose_llm_errors
+
+        try:
+            count = len(self.message_history)
+        except TypeError:
+            count = None
+
+        if verbose_llm_errors():
             mh_str = str(self.message_history)
-            indented_mh = "\n".join(
-                "    " + line for line in mh_str.splitlines()
-            )  # 2 indents (2-spaces) per indent
-            details.append(
-                self._color("Message History:\n", self.BOLD_GREEN)
-                + self._color(indented_mh, self.GREEN)
+            indented_mh = "\n".join("    " + line for line in mh_str.splitlines())
+            detail = self._color(
+                "Message History:\n", self.BOLD_GREEN
+            ) + self._color(indented_mh, self.GREEN)
+        else:
+            summary = (
+                f"{count} message(s) redacted; "
+                "enable via rt.enable_logging(verbose_llm_errors=True)"
+                if count is not None
+                else "message history redacted; "
+                "enable via rt.enable_logging(verbose_llm_errors=True)"
             )
-        if details:
-            notes_str = (
-                "\n"
-                + self._color("Details:\n", self.BOLD_GREEN)
-                + "\n".join(f"  {d}" for d in details)
+            detail = self._color("Message History: ", self.BOLD_GREEN) + self._color(
+                summary, self.GREEN
             )
-            return f"\n{self._color(base, self.RED)}{notes_str}"
-        return self._color(base, self.RED)
+
+        notes_str = (
+            "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
+        )
+        return f"\n{self._color(base, self.RED)}{notes_str}"
 
 
 class GlobalTimeOutError(RTError):

--- a/packages/railtracks/src/railtracks/exceptions/errors.py
+++ b/packages/railtracks/src/railtracks/exceptions/errors.py
@@ -87,9 +87,9 @@ class LLMError(RTError):
         if verbose_llm_errors():
             mh_str = str(self.message_history)
             indented_mh = "\n".join("    " + line for line in mh_str.splitlines())
-            detail = self._color(
-                "Message History:\n", self.BOLD_GREEN
-            ) + self._color(indented_mh, self.GREEN)
+            detail = self._color("Message History:\n", self.BOLD_GREEN) + self._color(
+                indented_mh, self.GREEN
+            )
         else:
             summary = (
                 f"{count} message(s) redacted; "
@@ -102,9 +102,7 @@ class LLMError(RTError):
                 summary, self.GREEN
             )
 
-        notes_str = (
-            "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
-        )
+        notes_str = "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
         return f"\n{self._color(base, self.RED)}{notes_str}"
 
 

--- a/packages/railtracks/src/railtracks/llm/models/_model_exception_base.py
+++ b/packages/railtracks/src/railtracks/llm/models/_model_exception_base.py
@@ -20,24 +20,40 @@ class ModelError(RTLLMError):
 
     def __str__(self):
         base = super().__str__()
-        details = []
-        if self.message_history:
-            mh_str = str(self.message_history)
-            indented_mh = "\n".join(
-                "    " + line for line in mh_str.splitlines()
-            )  # 2 indents (2-spaces) per indent
-            details.append(
-                self._color("Message History:\n", self.BOLD_GREEN)
-                + self._color(indented_mh, self.GREEN)
-            )
-        if details:
-            notes_str = (
-                "\n"
-                + self._color("Details:\n", self.BOLD_GREEN)
-                + "\n".join(f"  {d}" for d in details)
-            )
-            return f"\n{self._color(base, self.RED)}{notes_str}"
-        return self._color(base, self.RED)
+        if not self.message_history:
+            return self._color(base, self.RED)
+
+        try:
+            count = len(self.message_history)
+        except TypeError:
+            count = None
+
+        summary = (
+            f"{count} message(s) redacted; "
+            "call err.format_verbose() to render or read err.message_history"
+            if count is not None
+            else "message history redacted; "
+            "call err.format_verbose() to render or read err.message_history"
+        )
+        detail = self._color("Message History: ", self.BOLD_GREEN) + self._color(
+            summary, self.GREEN
+        )
+        notes_str = "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
+        return f"\n{self._color(base, self.RED)}{notes_str}"
+
+    def format_verbose(self) -> str:
+        """Render the exception with the full input ``MessageHistory`` embedded."""
+        base = super().__str__()
+        if not self.message_history:
+            return self._color(base, self.RED)
+
+        mh_str = str(self.message_history)
+        indented_mh = "\n".join("    " + line for line in mh_str.splitlines())
+        detail = self._color("Message History:\n", self.BOLD_GREEN) + self._color(
+            indented_mh, self.GREEN
+        )
+        notes_str = "\n" + self._color("Details:\n", self.BOLD_GREEN) + f"  {detail}"
+        return f"\n{self._color(base, self.RED)}{notes_str}"
 
 
 class ModelNotFoundError(RTLLMError):

--- a/packages/railtracks/src/railtracks/utils/logging/config.py
+++ b/packages/railtracks/src/railtracks/utils/logging/config.py
@@ -47,20 +47,6 @@ _module_logging_file: ContextVar[str | os.PathLike | None] = ContextVar(
     "module_logging_file", default=None
 )
 
-_verbose_llm_errors: ContextVar[bool] = ContextVar("verbose_llm_errors", default=False)
-
-
-def verbose_llm_errors() -> bool:
-    """Whether ``LLMError.__str__`` should embed the full message history.
-
-    Off by default so exception strings and log output don't disclose LLM
-    conversation contents (which may contain PII, credentials, or other
-    sensitive data). Turn on via ``enable_logging(verbose_llm_errors=True)``
-    when debugging.
-    """
-    return _verbose_llm_errors.get()
-
-
 # Initialize colorama
 init(autoreset=True)
 
@@ -282,7 +268,6 @@ def initialize_module_logging(
     log_file: str | os.PathLike | None = None,
     *,
     name_style: LoggerNameDisplay = "short",
-    verbose_llm_errors: bool = False,
 ) -> None:
     """
     Initialize module-level logging (internal). Use enable_logging() for the public API.
@@ -308,7 +293,6 @@ def initialize_module_logging(
 
     _module_logging_level.set(env_level_int)
     _module_logging_file.set(env_log_file)
-    _verbose_llm_errors.set(verbose_llm_errors)
 
     logger = logging.getLogger(rt_logger_name)
     logger.setLevel(env_level_str)
@@ -341,7 +325,6 @@ def enable_logging(
     log_file: str | os.PathLike | None = None,
     *,
     name_style: LoggerNameDisplay = "short",
-    verbose_llm_errors: bool = False,
 ) -> None:
     """
     Opt-in helper to enable Railtracks logging. Call this explicitly from your
@@ -358,14 +341,9 @@ def enable_logging(
         name_style: Console column for logger name: ``full`` (dotted name) or
             ``short`` (``RT.<Label>``: last segment with leading non-letters stripped,
             then capitalized). Default ``short``.
-        verbose_llm_errors: When True, ``str(LLMError)`` embeds the full input
-            MessageHistory. Off by default because that content may include PII,
-            credentials, or other sensitive data and would otherwise flow into
-            any log or crash-reporter that captures the exception string.
     """
     initialize_module_logging(
         level=level,
         log_file=log_file,
         name_style=name_style,
-        verbose_llm_errors=verbose_llm_errors,
     )

--- a/packages/railtracks/src/railtracks/utils/logging/config.py
+++ b/packages/railtracks/src/railtracks/utils/logging/config.py
@@ -47,6 +47,21 @@ _module_logging_file: ContextVar[str | os.PathLike | None] = ContextVar(
     "module_logging_file", default=None
 )
 
+_verbose_llm_errors: ContextVar[bool] = ContextVar(
+    "verbose_llm_errors", default=False
+)
+
+
+def verbose_llm_errors() -> bool:
+    """Whether ``LLMError.__str__`` should embed the full message history.
+
+    Off by default so exception strings and log output don't disclose LLM
+    conversation contents (which may contain PII, credentials, or other
+    sensitive data). Turn on via ``enable_logging(verbose_llm_errors=True)``
+    when debugging.
+    """
+    return _verbose_llm_errors.get()
+
 # Initialize colorama
 init(autoreset=True)
 
@@ -268,6 +283,7 @@ def initialize_module_logging(
     log_file: str | os.PathLike | None = None,
     *,
     name_style: LoggerNameDisplay = "short",
+    verbose_llm_errors: bool = False,
 ) -> None:
     """
     Initialize module-level logging (internal). Use enable_logging() for the public API.
@@ -293,6 +309,7 @@ def initialize_module_logging(
 
     _module_logging_level.set(env_level_int)
     _module_logging_file.set(env_log_file)
+    _verbose_llm_errors.set(verbose_llm_errors)
 
     logger = logging.getLogger(rt_logger_name)
     logger.setLevel(env_level_str)
@@ -325,6 +342,7 @@ def enable_logging(
     log_file: str | os.PathLike | None = None,
     *,
     name_style: LoggerNameDisplay = "short",
+    verbose_llm_errors: bool = False,
 ) -> None:
     """
     Opt-in helper to enable Railtracks logging. Call this explicitly from your
@@ -341,5 +359,14 @@ def enable_logging(
         name_style: Console column for logger name: ``full`` (dotted name) or
             ``short`` (``RT.<Label>``: last segment with leading non-letters stripped,
             then capitalized). Default ``short``.
+        verbose_llm_errors: When True, ``str(LLMError)`` embeds the full input
+            MessageHistory. Off by default because that content may include PII,
+            credentials, or other sensitive data and would otherwise flow into
+            any log or crash-reporter that captures the exception string.
     """
-    initialize_module_logging(level=level, log_file=log_file, name_style=name_style)
+    initialize_module_logging(
+        level=level,
+        log_file=log_file,
+        name_style=name_style,
+        verbose_llm_errors=verbose_llm_errors,
+    )

--- a/packages/railtracks/src/railtracks/utils/logging/config.py
+++ b/packages/railtracks/src/railtracks/utils/logging/config.py
@@ -47,9 +47,7 @@ _module_logging_file: ContextVar[str | os.PathLike | None] = ContextVar(
     "module_logging_file", default=None
 )
 
-_verbose_llm_errors: ContextVar[bool] = ContextVar(
-    "verbose_llm_errors", default=False
-)
+_verbose_llm_errors: ContextVar[bool] = ContextVar("verbose_llm_errors", default=False)
 
 
 def verbose_llm_errors() -> bool:
@@ -61,6 +59,7 @@ def verbose_llm_errors() -> bool:
     when debugging.
     """
     return _verbose_llm_errors.get()
+
 
 # Initialize colorama
 init(autoreset=True)

--- a/packages/railtracks/tests/unit_tests/llm/models/test_model_exceptions.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_model_exceptions.py
@@ -1,0 +1,46 @@
+import pytest
+from railtracks.llm.models._model_exception_base import ModelError
+
+
+@pytest.fixture
+def fake_message_history():
+    class Fake:
+        def __str__(self):
+            return "FakeHistory\nLine2"
+
+        def __len__(self):
+            return 2
+
+    return Fake()
+
+
+def test_modelerror_basic():
+    err = ModelError("api failed")
+    s = str(err)
+    assert "Failure reason" in s
+    assert "api failed" in s
+
+
+def test_modelerror_redacts_history_by_default(fake_message_history):
+    err = ModelError("timeout!", message_history=fake_message_history)
+    s = str(err)
+    assert "timeout!" in s
+    assert "Message History" in s
+    assert "2 message(s) redacted" in s
+    assert "FakeHistory" not in s
+    assert "Line2" not in s
+    assert err.message_history is fake_message_history
+
+
+def test_modelerror_format_verbose_includes_history(fake_message_history):
+    err = ModelError("timeout!", message_history=fake_message_history)
+    s = err.format_verbose()
+    assert "timeout!" in s
+    assert "Message History:" in s
+    assert "FakeHistory" in s
+    assert "Line2" in s
+
+
+def test_modelerror_format_verbose_without_history():
+    err = ModelError("api failed")
+    assert err.format_verbose() == str(err)

--- a/packages/railtracks/tests/unit_tests/test_exceptions.py
+++ b/packages/railtracks/tests/unit_tests/test_exceptions.py
@@ -8,7 +8,6 @@ from railtracks.exceptions.errors import (
     NodeCreationError,
     NodeInvocationError,
 )
-from railtracks.utils.logging.config import _verbose_llm_errors
 
 # NOTE: This file contains very basic tests to ensure that the exception classes are working as expected.
 
@@ -83,15 +82,6 @@ def fake_message_history():
     return Fake()
 
 
-@pytest.fixture
-def verbose_llm_errors_on():
-    token = _verbose_llm_errors.set(True)
-    try:
-        yield
-    finally:
-        _verbose_llm_errors.reset(token)
-
-
 def test_llmerror_basic():
     err = LLMError("api failed")
     s = str(err)
@@ -111,15 +101,18 @@ def test_llmerror_redacts_history_by_default(fake_message_history):
     assert err.message_history is fake_message_history
 
 
-def test_llmerror_includes_history_when_enabled(
-    fake_message_history, verbose_llm_errors_on
-):
+def test_llmerror_format_verbose_includes_history(fake_message_history):
     err = LLMError("timeout!", message_history=fake_message_history)
-    s = str(err)
+    s = err.format_verbose()
     assert "timeout!" in s
     assert "Message History:" in s
     assert "FakeHistory" in s
     assert "Line2" in s
+
+
+def test_llmerror_format_verbose_without_history():
+    err = LLMError("api failed")
+    assert err.format_verbose() == str(err)
 
 
 # =========== END LLMError tests ===================

--- a/packages/railtracks/tests/unit_tests/test_exceptions.py
+++ b/packages/railtracks/tests/unit_tests/test_exceptions.py
@@ -8,6 +8,7 @@ from railtracks.exceptions.errors import (
     NodeCreationError,
     NodeInvocationError,
 )
+from railtracks.utils.logging.config import _verbose_llm_errors
 
 # NOTE: This file contains very basic tests to ensure that the exception classes are working as expected.
 
@@ -76,7 +77,19 @@ def fake_message_history():
         def __str__(self):
             return "FakeHistory\nLine2"
 
+        def __len__(self):
+            return 2
+
     return Fake()
+
+
+@pytest.fixture
+def verbose_llm_errors_on():
+    token = _verbose_llm_errors.set(True)
+    try:
+        yield
+    finally:
+        _verbose_llm_errors.reset(token)
 
 
 def test_llmerror_basic():
@@ -86,7 +99,21 @@ def test_llmerror_basic():
     assert "api failed" in s
 
 
-def test_llmerror_with_history(fake_message_history):
+def test_llmerror_redacts_history_by_default(fake_message_history):
+    err = LLMError("timeout!", message_history=fake_message_history)
+    s = str(err)
+    assert "timeout!" in s
+    assert "Message History" in s
+    assert "2 message(s) redacted" in s
+    assert "FakeHistory" not in s
+    assert "Line2" not in s
+    # Attribute is preserved for opt-in access
+    assert err.message_history is fake_message_history
+
+
+def test_llmerror_includes_history_when_enabled(
+    fake_message_history, verbose_llm_errors_on
+):
     err = LLMError("timeout!", message_history=fake_message_history)
     s = str(err)
     assert "timeout!" in s


### PR DESCRIPTION
## Summary

`LLMError.__str__` used to render the full input `MessageHistory` into the exception text, so any `logger.exception(...)`, `str(err)`, `repr(err)` contained the message history.

Default now emits a redacted summary (`"N message(s) redacted"`). The `message_history` attribute is still there for structured callers. When a specific log line genuinely needs the full render, call `err.format_verbose()` at that site:

```python
except LLMError as err:
    logger.error("LLM call failed: %s", err.format_verbose())
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [ ] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

No global toggle. The choice to render the history is made at the call site that logs it, which keeps `str(err)` predictable regardless of process state.

Docs: new `### Inspecting LLMError message history` subsection in `error_handling.md`
