### PR TITLE
prevent mkdocs serve infinite reload from stale pdoc output

### DIFF
--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -17,6 +17,7 @@ if [ ! -d "packages/railtracks/src/railtracks" ]; then
     exit 1
 fi
 
+rm -rf docs/api_reference
 mkdir -p docs/api_reference
 
 echo "Running pdoc to generate API documentation..."

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -26,6 +27,11 @@ def _api_reference_is_fresh(src_dir: Path, output_dir: Path) -> bool:
 
 
 def _generate_api_reference(repo_root: Path, output_dir: Path) -> None:
+    # Wipe the output dir so HTML for removed modules doesn't linger. Orphaned files
+    # pin the freshness check's `min(mtime)` to an old date and cause every build to
+    # regenerate, which triggers `mkdocs serve`'s watcher into an infinite reload loop.
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
     subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Summary

Stops `mkdocs serve` from reloading in an infinite loop caused by stale pdoc output.

`docs/api_reference/` accumulated HTML files whose source modules were later deleted. Those orphans pinned the freshness check's `min(mtime)` to an old date, so every build re-ran pdoc, mkdocs' watcher saw the churn, and reloaded — forever.

Fix: wipe `docs/api_reference/` before pdoc runs, both in the mkdocs hook and in `scripts/generate_api_docs.sh` (used by CI).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

CI unaffected: `release_docs.yaml` runs `generate_api_docs.sh` (now self-cleaning) before `mkdocs gh-deploy`, so the hook's freshness gate skips pdoc on the deploy build.