### PR TITLE
Refactor skill installation for Codex, Copilot, and Cursor; migrate t…

### DIFF
--- a/packages/railtracks/src/railtracks/cli/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/__init__.py
@@ -33,7 +33,15 @@ from colorama import Fore, Style
 
 from railtracks.paths import resolve_railtracks_home
 
-from ._skillkit import CLAUDE, Skill, discover_skills, install_skill_directory
+from ._skillkit import (
+    CLAUDE,
+    CODEX,
+    COPILOT,
+    CURSOR,
+    Skill,
+    discover_skills,
+    install_skill_directory,
+)
 from .constants import (
     DEFAULT_PORT,
     cli_directory,
@@ -42,7 +50,6 @@ from .constants import (
 )
 from .io import (
     _print_update_available,
-    confirm_overwrite,
     print_error,
     print_status,
     print_success,
@@ -249,42 +256,6 @@ def update_railtracks():
 # ---------------------------------------------------------------------------
 
 
-def _strip_skill_arguments(content: str) -> str:
-    """Resolve the `$ARGUMENTS` placeholder for targets that never substitute it.
-
-    Claude Code is the only target with an argument-hint field and documented
-    `$ARGUMENTS` substitution, so it is the only one that gets the placeholder. Codex
-    and Cursor document no substitution, and Copilot reads `copilot-instructions.md` as
-    always-on repository context, so for all three the placeholder would ship to the
-    model literally.
-    """
-    kept: list[str] = []
-    drop_next_blank = False
-    for line in content.splitlines():
-        if drop_next_blank and not line.strip():
-            drop_next_blank = False
-            continue
-        drop_next_blank = False
-
-        if "$ARGUMENTS" not in line:
-            kept.append(line)
-            continue
-
-        # A whole line that only exists to introduce the argument is dropped, along
-        # with the blank line it would otherwise leave behind; an inline mention is
-        # reworded in place.
-        if line.rstrip().endswith(": $ARGUMENTS"):
-            drop_next_blank = bool(kept) and not kept[-1].strip()
-            continue
-
-        kept.append(
-            line.replace("`$ARGUMENTS`", "the request").replace(
-                "$ARGUMENTS", "the request"
-            )
-        )
-    return "\n".join(kept)
-
-
 def _add_claude(skill: Skill, force: bool) -> list[Path]:
     """Install a skill for Claude Code as a skill directory, and report what it wrote.
 
@@ -295,70 +266,19 @@ def _add_claude(skill: Skill, force: bool) -> list[Path]:
     return install_skill_directory(skill, CLAUDE, force)
 
 
-def _add_codex(skill: Skill, force: bool) -> None:
-    """Install a skill for Codex as a repository-scoped SKILL.md file."""
-    target = Path(".agents") / "skills" / skill.name / "SKILL.md"
-    if target.exists() and not force:
-        if not confirm_overwrite(target):
-            print_status("Aborted.")
-            sys.exit(0)
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    frontmatter = f"---\nname: {skill.name}\ndescription: {skill.description}\n---\n\n"
-    target.write_text(
-        frontmatter + _strip_skill_arguments(skill.body), encoding="utf-8"
-    )
-    print_success(f"Installed '{skill.name}' for Codex -> {target}")
+def _add_codex(skill: Skill, force: bool) -> list[Path]:
+    """Install a skill for Codex as a skill directory under .agents/skills."""
+    return install_skill_directory(skill, CODEX, force)
 
 
-def _add_copilot(skill: Skill, force: bool) -> None:
-    """Install skill for GitHub Copilot by appending to copilot-instructions.md."""
-    target = Path(".github") / "copilot-instructions.md"
-    start_marker = f"<!-- railtracks:{skill.name}:start -->"
-    end_marker = f"<!-- railtracks:{skill.name}:end -->"
-
-    if target.exists():
-        existing = target.read_text(encoding="utf-8")
-        if start_marker in existing:
-            print_warning(
-                f"Skill '{skill.name}' is already present in {target}. "
-                "Remove the existing section and re-run to update it, or use --force."
-            )
-            if not force:
-                sys.exit(0)
-            start_idx = existing.index(start_marker)
-            end_idx = existing.index(end_marker) + len(end_marker)
-            existing = existing[:start_idx] + existing[end_idx:]
-    else:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        existing = ""
-
-    # Rewrite rather than append, so regenerating a skill in place is byte-identical
-    # to installing it fresh and repeated --force runs don't accumulate blank lines.
-    preamble = existing.rstrip()
-    section = (
-        f"{start_marker}\n{_strip_skill_arguments(skill.body).strip()}\n{end_marker}\n"
-    )
-    target.write_text(
-        f"{preamble}\n\n{section}" if preamble else section, encoding="utf-8"
-    )
-    print_success(f"Installed '{skill.name}' for GitHub Copilot -> {target}")
+def _add_copilot(skill: Skill, force: bool) -> list[Path]:
+    """Install a skill for GitHub Copilot as a skill directory under .github/skills."""
+    return install_skill_directory(skill, COPILOT, force)
 
 
-def _add_cursor(skill: Skill, force: bool) -> None:
-    """Install skill for Cursor as a .mdc rules file."""
-    target = Path(".cursor") / "rules" / f"{skill.name}.mdc"
-    if target.exists() and not force:
-        if not confirm_overwrite(target):
-            print_status("Aborted.")
-            sys.exit(0)
-
-    target.parent.mkdir(parents=True, exist_ok=True)
-    frontmatter = f"---\ndescription: {skill.description}\nalwaysApply: false\n---\n\n"
-    target.write_text(
-        frontmatter + _strip_skill_arguments(skill.body), encoding="utf-8"
-    )
-    print_success(f"Installed '{skill.name}' for Cursor -> {target}")
+def _add_cursor(skill: Skill, force: bool) -> list[Path]:
+    """Install a skill for Cursor as a skill directory under .cursor/skills."""
+    return install_skill_directory(skill, CURSOR, force)
 
 
 _TOOL_HANDLERS = {

--- a/packages/railtracks/src/railtracks/cli/_skillkit/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/__init__.py
@@ -2,12 +2,18 @@
 
 * `registry` — the on-disk skill format, and the discovery that reads it.
 * `manifest` — the record an install leaves in a skill directory.
-* `install` — the directory copy itself, parameterised per assistant.
+* `install` — the workflow that copies a skill directory, prunes stale files, and
+  writes a manifest. Provider-agnostic; the specifics come from `providers`.
+* `providers/` — one `InstallTarget` per supported assistant.
 
 Private to the CLI; the names re-exported below are the surface it uses.
 """
 
-from .install import CLAUDE, InstallTarget, install_skill_directory
+from .install import (
+    InstallTarget,
+    install_skill_directory,
+    strip_skill_arguments,
+)
 from .manifest import (
     MANIFEST_FILE,
     InstallRecord,
@@ -15,6 +21,7 @@ from .manifest import (
     package_version,
     read_record,
 )
+from .providers import CLAUDE, CODEX, COPILOT, CURSOR
 from .registry import (
     Skill,
     SkillFormatError,
@@ -25,6 +32,9 @@ from .registry import (
 
 __all__ = [
     "CLAUDE",
+    "CODEX",
+    "COPILOT",
+    "CURSOR",
     "InstallRecord",
     "InstallTarget",
     "MANIFEST_FILE",
@@ -37,4 +47,5 @@ __all__ = [
     "load_skill",
     "package_version",
     "read_record",
+    "strip_skill_arguments",
 ]

--- a/packages/railtracks/src/railtracks/cli/_skillkit/install.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/install.py
@@ -1,9 +1,10 @@
 """Installing a skill directory into an assistant's native layout.
 
 An `InstallTarget` supplies the two things that differ per assistant — the root path
-it reads skills from, and the projection that renders `SKILL.md` for it.
-`install_skill_directory` does the rest: copy the directory, drop what a previous
-install left and this one does not ship, and record the result for the next one.
+it reads skills from, and the projection that renders `SKILL.md` for it. Concrete
+targets live in `providers/`, one file per assistant; adding another one is a copy of
+one of those files. This module owns the workflow: copy the directory, drop what a
+previous install left and this one does not ship, and record the result.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ import yaml
 
 from ..io import confirm_overwrite, print_status, print_success, print_warning
 from .manifest import (
+    find_legacy_installs,
     is_ours_unmodified,
     prune,
     read_record,
@@ -27,6 +29,42 @@ from .manifest import (
     write_record,
 )
 from .registry import SKILL_FILE, Skill
+
+
+def strip_skill_arguments(content: str) -> str:
+    """Resolve the `$ARGUMENTS` placeholder for targets that never substitute it.
+
+    Claude Code is the only target with an argument-hint field and documented
+    `$ARGUMENTS` substitution, so it is the only one that gets the placeholder. For
+    every other target the placeholder would ship to the model literally, so we drop
+    a whole line whose sole purpose is to introduce the argument and reword an
+    inline mention as "the request".
+
+    Lives on the projection so a handler cannot skip it.
+    """
+    kept: list[str] = []
+    drop_next_blank = False
+    for line in content.splitlines():
+        if drop_next_blank and not line.strip():
+            drop_next_blank = False
+            continue
+        drop_next_blank = False
+
+        if "$ARGUMENTS" not in line:
+            kept.append(line)
+            continue
+
+        # Drop the whole intro line (and its trailing blank); reword inline mentions in place.
+        if line.rstrip().endswith(": $ARGUMENTS"):
+            drop_next_blank = bool(kept) and not kept[-1].strip()
+            continue
+
+        kept.append(
+            line.replace("`$ARGUMENTS`", "the request").replace(
+                "$ARGUMENTS", "the request"
+            )
+        )
+    return "\n".join(kept)
 
 
 @dataclass(frozen=True)
@@ -77,51 +115,15 @@ def render_frontmatter(
             continue
         passthrough[key] = value
 
+    # Force block style: a one-key flow map after block-style lines is ambiguous YAML.
     rendered_extra = (
         yaml.safe_dump(
-            passthrough, default_flow_style=None, sort_keys=False, allow_unicode=True
+            passthrough, default_flow_style=False, sort_keys=False, allow_unicode=True
         )
         if passthrough
         else ""
     )
     return "---\n" + "".join(lines) + rendered_extra + "---\n\n"
-
-
-def _quote(value: str) -> str:
-    """Emit a string as a double-quoted YAML scalar."""
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
-
-
-def claude_frontmatter(skill: Skill) -> str:
-    """Project a skill into the frontmatter Claude Code consumes.
-
-    `name` and `description` map across directly, `argument-hint` is emitted when the
-    skill has one, and `tools.claude` supplies everything else.
-    """
-    return render_frontmatter(
-        (
-            ("name", skill.name),
-            ("description", skill.description),
-            (
-                "argument-hint",
-                _quote(skill.argument_hint)
-                if skill.argument_hint is not None
-                else None,
-            ),
-        ),
-        skill.tools.get("claude"),
-        skill_name=skill.name,
-    )
-
-
-CLAUDE = InstallTarget(
-    key="claude",
-    label="Claude Code",
-    root=Path(".claude") / "skills",
-    # Claude Code substitutes $ARGUMENTS itself, so its body ships as authored.
-    body=lambda skill: skill.body,
-    frontmatter=claude_frontmatter,
-)
 
 
 def _planned_files(skill: Skill, destination: Path) -> list[tuple[Path, Path | None]]:
@@ -148,6 +150,10 @@ def install_skill_directory(
     destination = target.root / skill.name
     planned = _planned_files(skill, destination)
     previous = read_record(destination)
+
+    # Report legacy Copilot/Cursor installs the new handler will not touch.
+    for legacy in find_legacy_installs(skill.name):
+        print_warning(legacy.advice())
 
     skew = version_skew(previous)
     if skew:

--- a/packages/railtracks/src/railtracks/cli/_skillkit/providers/__init__.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/providers/__init__.py
@@ -1,0 +1,14 @@
+"""One `InstallTarget` per supported assistant.
+
+Each provider file owns everything specific to its assistant — the root path, the
+frontmatter projection, and any quirks (Cursor's `globs` → `paths` alias,
+Claude's argument-hint substitution). Adding another assistant is a copy of one
+of these files plus a re-export line below; `install.py` does not change.
+"""
+
+from .claude import CLAUDE
+from .codex import CODEX
+from .copilot import COPILOT
+from .cursor import CURSOR
+
+__all__ = ["CLAUDE", "CODEX", "COPILOT", "CURSOR"]

--- a/packages/railtracks/src/railtracks/cli/_skillkit/providers/claude.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/providers/claude.py
@@ -1,0 +1,56 @@
+"""The Claude Code install target.
+
+Native path: `.claude/skills/<name>/`. Consumes `name`, `description`,
+`argument-hint`, plus whatever the skill puts under `tools.claude`:
+`allowed-tools`, `disallowed-tools`, `paths`, `disable-model-invocation`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..install import InstallTarget, render_frontmatter
+from ..registry import Skill
+
+
+def _quote(value: str) -> str:
+    """Emit a string as a double-quoted YAML scalar.
+
+    `argument-hint` is the only field that reaches SKILL.md pre-quoted — its value
+    can contain brackets and colons and we want it to survive a round-trip through
+    the reader unchanged. Every other field is either a bare identifier or a nested
+    structure `yaml.safe_dump` renders correctly on its own.
+    """
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _frontmatter(skill: Skill) -> str:
+    """Project a skill into the frontmatter Claude Code consumes.
+
+    `name` and `description` map across directly; `argument-hint` is emitted when
+    the skill has one; `tools.claude` supplies everything else.
+    """
+    return render_frontmatter(
+        (
+            ("name", skill.name),
+            ("description", skill.description),
+            (
+                "argument-hint",
+                _quote(skill.argument_hint)
+                if skill.argument_hint is not None
+                else None,
+            ),
+        ),
+        skill.tools.get("claude"),
+        skill_name=skill.name,
+    )
+
+
+CLAUDE = InstallTarget(
+    key="claude",
+    label="Claude Code",
+    root=Path(".claude") / "skills",
+    # Claude Code substitutes $ARGUMENTS itself, so its body ships as authored.
+    body=lambda skill: skill.body,
+    frontmatter=_frontmatter,
+)

--- a/packages/railtracks/src/railtracks/cli/_skillkit/providers/codex.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/providers/codex.py
@@ -1,0 +1,38 @@
+"""The Codex install target.
+
+Native path: `.agents/skills/<name>/`. Codex reads only `name` and `description`
+from `SKILL.md`. An `agents/openai.yaml` sidecar would carry invocation policy
+and MCP dependencies, but nothing about it belongs in the frontmatter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..install import InstallTarget, render_frontmatter, strip_skill_arguments
+from ..registry import Skill
+
+
+def _frontmatter(skill: Skill) -> str:
+    """Project a skill into the frontmatter Codex consumes.
+
+    `tools.codex` is passed through so a forward-added key survives, though no
+    key is defined for it today.
+    """
+    return render_frontmatter(
+        (
+            ("name", skill.name),
+            ("description", skill.description),
+        ),
+        skill.tools.get("codex"),
+        skill_name=skill.name,
+    )
+
+
+CODEX = InstallTarget(
+    key="codex",
+    label="Codex",
+    root=Path(".agents") / "skills",
+    body=lambda skill: strip_skill_arguments(skill.body),
+    frontmatter=_frontmatter,
+)

--- a/packages/railtracks/src/railtracks/cli/_skillkit/providers/copilot.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/providers/copilot.py
@@ -1,0 +1,39 @@
+"""The GitHub Copilot install target.
+
+Native path: `.github/skills/<name>/`. Copilot reads `name` and `description`,
+and consumes `allowed-tools` and `license` from `tools.copilot`. The old
+marker-block in `.github/copilot-instructions.md` is not written any more;
+`find_legacy_installs` reports it if it is still on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..install import InstallTarget, render_frontmatter, strip_skill_arguments
+from ..registry import Skill
+
+
+def _frontmatter(skill: Skill) -> str:
+    """Project a skill into the frontmatter Copilot consumes.
+
+    `argument-hint` is Claude-only and stays a top-level key on the source; it
+    never reaches this projection.
+    """
+    return render_frontmatter(
+        (
+            ("name", skill.name),
+            ("description", skill.description),
+        ),
+        skill.tools.get("copilot"),
+        skill_name=skill.name,
+    )
+
+
+COPILOT = InstallTarget(
+    key="copilot",
+    label="GitHub Copilot",
+    root=Path(".github") / "skills",
+    body=lambda skill: strip_skill_arguments(skill.body),
+    frontmatter=_frontmatter,
+)

--- a/packages/railtracks/src/railtracks/cli/_skillkit/providers/cursor.py
+++ b/packages/railtracks/src/railtracks/cli/_skillkit/providers/cursor.py
@@ -1,0 +1,47 @@
+"""The Cursor install target.
+
+Native path: `.cursor/skills/<name>/`. Cursor reads `name` (which must equal the
+folder name), `description`, plus `paths` and `disable-model-invocation` from
+`tools.cursor`. The old `.cursor/rules/<name>.mdc` is not written any more;
+`find_legacy_installs` reports it if it is still on disk.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..install import InstallTarget, render_frontmatter, strip_skill_arguments
+from ..registry import Skill
+
+
+def _frontmatter(skill: Skill) -> str:
+    """Project a skill into the frontmatter Cursor consumes.
+
+    Legacy `globs` is normalised to `paths` — Cursor documents the rename, so no
+    author should have to touch a skill they already wrote. `registry.load_skill`
+    enforces `name == directory.name` on the source, and we install into
+    `<root>/<skill.name>/`, so emitting `skill.name` here preserves the invariant.
+    """
+    tools = skill.tools.get("cursor")
+    if tools is not None and "globs" in tools and "paths" not in tools:
+        # A shallow copy — the source is read-only via MappingProxyType.
+        tools = {
+            ("paths" if key == "globs" else key): value for key, value in tools.items()
+        }
+    return render_frontmatter(
+        (
+            ("name", skill.name),
+            ("description", skill.description),
+        ),
+        tools,
+        skill_name=skill.name,
+    )
+
+
+CURSOR = InstallTarget(
+    key="cursor",
+    label="Cursor",
+    root=Path(".cursor") / "skills",
+    body=lambda skill: strip_skill_arguments(skill.body),
+    frontmatter=_frontmatter,
+)

--- a/packages/railtracks/tests/unit_tests/cli/skillkit/test_install.py
+++ b/packages/railtracks/tests/unit_tests/cli/skillkit/test_install.py
@@ -12,20 +12,21 @@ from unittest.mock import patch
 import yaml
 from railtracks.cli import (
     _add_claude,
-    _strip_skill_arguments,
     add_skill,
 )
-from railtracks.cli._skillkit.install import (
+from railtracks.cli._skillkit import (
     CLAUDE,
+    CODEX,
+    COPILOT,
+    CURSOR,
+    MANIFEST_FILE,
     InstallTarget,
     install_skill_directory,
-)
-from railtracks.cli._skillkit.manifest import (
-    MANIFEST_FILE,
+    load_skill,
     package_version,
     read_record,
+    strip_skill_arguments,
 )
-from railtracks.cli._skillkit.registry import load_skill
 
 
 def _write_skill(root, name, frontmatter, body="# Heading\n\nBody text.\n", files=None):
@@ -408,6 +409,396 @@ class TestSkillSync(unittest.TestCase):
         self.assertEqual(written, [Path(".claude/skills/agent-builder/SKILL.md")])
 
 
+class TestCodexDirectoryInstall(unittest.TestCase):
+    """`railtracks add codex:<skill>` writes a skill directory under .agents/skills."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def _installed(self, name="fixture-skill"):
+        return Path(f".agents/skills/{name}/SKILL.md").read_text(encoding="utf-8")
+
+    def test_codex_target_writes_to_its_native_path(self):
+        """§3.1 / D8: Codex's native path is `.agents/skills/`."""
+        self.assertEqual(CODEX.root, Path(".agents") / "skills")
+
+    def test_argument_placeholder_is_stripped(self):
+        """Codex documents no substitution, so `$ARGUMENTS` never survives (D9)."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            body="Do the thing: $ARGUMENTS\n\nMore body.\n",
+        )
+
+        install_skill_directory(skill, CODEX)
+
+        self.assertNotIn("$ARGUMENTS", self._installed())
+
+    def test_argument_hint_is_dropped_from_the_frontmatter(self):
+        """`argument-hint` is Claude-only; §3.5 keeps it off every other target."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            'name: fixture-skill\ndescription: A fixture.\nargument-hint: "[what]"\n',
+        )
+
+        install_skill_directory(skill, CODEX)
+
+        self.assertNotIn("argument-hint", self._installed())
+
+    def test_supporting_files_ride_along(self):
+        """The whole point of the migration: `references/` travels with the skill."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Generated\n"},
+        )
+
+        install_skill_directory(skill, CODEX)
+
+        self.assertEqual(
+            Path(".agents/skills/fixture-skill/references/api.md").read_text(
+                encoding="utf-8"
+            ),
+            "# Generated\n",
+        )
+
+    def test_install_writes_a_manifest_beside_the_skill(self):
+        """Codex now participates in sync semantics — the record makes it so."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+        )
+
+        install_skill_directory(skill, CODEX)
+
+        record = read_record(Path(".agents/skills/fixture-skill"))
+        self.assertEqual(record.target, "codex")
+        self.assertEqual([f.path for f in record.files], ["SKILL.md"])
+
+
+class TestCopilotDirectoryInstall(unittest.TestCase):
+    """`railtracks add copilot:<skill>` writes a skill directory under .github/skills."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def _installed(self, name="fixture-skill"):
+        return Path(f".github/skills/{name}/SKILL.md").read_text(encoding="utf-8")
+
+    def test_copilot_target_writes_to_its_native_path(self):
+        """§3.1 / D8: Copilot's native path is `.github/skills/`, not `.claude/skills`."""
+        self.assertEqual(COPILOT.root, Path(".github") / "skills")
+
+    def test_argument_placeholder_is_stripped(self):
+        """Copilot documents no substitution, so `$ARGUMENTS` never survives (D9)."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            body="Do the thing: $ARGUMENTS\n\nMore body.\n",
+        )
+
+        install_skill_directory(skill, COPILOT)
+
+        self.assertNotIn("$ARGUMENTS", self._installed())
+
+    def test_argument_hint_is_dropped_from_the_frontmatter(self):
+        """`argument-hint` is Claude-only; §3.5 keeps it off every other target."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            'name: fixture-skill\ndescription: A fixture.\nargument-hint: "[what]"\n',
+        )
+
+        install_skill_directory(skill, COPILOT)
+
+        self.assertNotIn("argument-hint", self._installed())
+
+    def test_tools_copilot_block_is_merged_into_the_frontmatter(self):
+        """`allowed-tools` and `license` from `tools.copilot` reach the target (§3.5)."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  copilot:\n"
+            "    license: MIT\n"
+            "    allowed-tools: [Read, Edit]\n",
+        )
+
+        install_skill_directory(skill, COPILOT)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["license"], "MIT")
+        self.assertEqual(frontmatter["allowed-tools"], ["Read", "Edit"])
+
+    def test_other_assistants_tool_blocks_are_not_emitted(self):
+        """`tools.claude` is Claude's projection to make, not Copilot's."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  claude:\n"
+            "    allowed-tools: [Read]\n",
+        )
+
+        install_skill_directory(skill, COPILOT)
+
+        content = self._installed()
+        self.assertNotIn("Read", content)
+        self.assertNotIn("allowed-tools", content)
+
+    def test_supporting_files_ride_along(self):
+        """The whole point of D8's directory install: `references/` travels with it."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Generated\n"},
+        )
+
+        install_skill_directory(skill, COPILOT)
+
+        self.assertEqual(
+            Path(".github/skills/fixture-skill/references/api.md").read_text(
+                encoding="utf-8"
+            ),
+            "# Generated\n",
+        )
+
+
+class TestCursorDirectoryInstall(unittest.TestCase):
+    """`railtracks add cursor:<skill>` writes a skill directory under .cursor/skills."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def _installed(self, name="fixture-skill"):
+        return Path(f".cursor/skills/{name}/SKILL.md").read_text(encoding="utf-8")
+
+    def test_cursor_target_writes_to_its_native_path(self):
+        """§3.1 / D8: Cursor's native path is `.cursor/skills/`, not `.cursor/rules`."""
+        self.assertEqual(CURSOR.root, Path(".cursor") / "skills")
+
+    def test_argument_placeholder_is_stripped(self):
+        """Cursor documents no substitution, so `$ARGUMENTS` never survives (D9)."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            body="Do this: $ARGUMENTS\n\nMore body.\n",
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        self.assertNotIn("$ARGUMENTS", self._installed())
+
+    def test_frontmatter_name_equals_the_folder_name(self):
+        """§3.1 requires `name == folder name`; the projection must preserve it."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["name"], "fixture-skill")
+        # And the folder path derives from it, so the invariant is a real one.
+        self.assertTrue(Path(".cursor/skills/fixture-skill").is_dir())
+
+    def test_tools_cursor_block_is_merged_into_the_frontmatter(self):
+        """`paths` and `disable-model-invocation` from `tools.cursor` reach it (§3.5)."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  cursor:\n"
+            "    paths: '**/*.py'\n"
+            "    disable-model-invocation: true\n",
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["paths"], "**/*.py")
+        self.assertIs(frontmatter["disable-model-invocation"], True)
+
+    def test_legacy_globs_is_normalised_to_paths(self):
+        """§3.5: Cursor's docs renamed `globs` to `paths`; existing skills need no edit."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  cursor:\n"
+            "    globs: '**/*.py'\n",
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["paths"], "**/*.py")
+        self.assertNotIn("globs", frontmatter)
+
+    def test_paths_wins_when_both_are_authored(self):
+        """A skill written for the new key should not have it silently overwritten."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n"
+            "tools:\n"
+            "  cursor:\n"
+            "    paths: '**/*.ts'\n"
+            "    globs: '**/*.py'\n",
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        frontmatter = yaml.safe_load(self._installed().split("---\n")[1])
+        self.assertEqual(frontmatter["paths"], "**/*.ts")
+
+    def test_supporting_files_ride_along(self):
+        """The whole point of D8's directory install: `references/` travels with it."""
+        skill = _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+            files={"references/api.md": "# Generated\n"},
+        )
+
+        install_skill_directory(skill, CURSOR)
+
+        self.assertEqual(
+            Path(".cursor/skills/fixture-skill/references/api.md").read_text(
+                encoding="utf-8"
+            ),
+            "# Generated\n",
+        )
+
+
+class TestLegacyDetectionWiredIntoInstall(unittest.TestCase):
+    """§4.4: `find_legacy_installs` reaches the user's terminal through the CLI.
+
+    Tested in isolation on the manifest; here it has to surface through the install
+    itself, so the handler cannot silently grow a private "is this ours?" answer.
+    """
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.source = Path(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree(self.source)
+
+    def _fixture(self):
+        return _write_skill(
+            self.source,
+            "fixture-skill",
+            "name: fixture-skill\ndescription: A fixture.\n",
+        )
+
+    def _install_legacy_copilot_region(self):
+        instructions = Path(".github/copilot-instructions.md")
+        instructions.parent.mkdir(parents=True, exist_ok=True)
+        instructions.write_text(
+            "<!-- railtracks:fixture-skill:start -->\nold body\n"
+            "<!-- railtracks:fixture-skill:end -->\n",
+            encoding="utf-8",
+        )
+
+    def _install_legacy_cursor_file(self):
+        rule = Path(".cursor/rules/fixture-skill.mdc")
+        rule.parent.mkdir(parents=True, exist_ok=True)
+        rule.write_text(
+            "---\ndescription: x\nalwaysApply: false\n---\n\nold body\n",
+            encoding="utf-8",
+        )
+
+    def test_a_legacy_copilot_region_is_reported_on_a_copilot_install(self):
+        """The migration path: user re-runs `add copilot:x`, learns the old block is stale."""
+        self._install_legacy_copilot_region()
+
+        with patch("railtracks.cli._skillkit.install.print_warning") as mock_warning:
+            install_skill_directory(self._fixture(), COPILOT, force=True)
+
+        reported = " ".join(str(c.args[0]) for c in mock_warning.call_args_list if c.args)
+        self.assertIn("copilot-instructions.md", reported)
+        self.assertIn("legacy", reported)
+
+    def test_a_legacy_cursor_mdc_is_reported_on_a_cursor_install(self):
+        """The migration path: user re-runs `add cursor:x`, learns the old .mdc is stale."""
+        self._install_legacy_cursor_file()
+
+        with patch("railtracks.cli._skillkit.install.print_warning") as mock_warning:
+            install_skill_directory(self._fixture(), CURSOR, force=True)
+
+        reported = " ".join(str(c.args[0]) for c in mock_warning.call_args_list if c.args)
+        self.assertIn("fixture-skill.mdc", reported)
+        self.assertIn("legacy", reported)
+
+    def test_the_legacy_install_is_reported_but_not_removed(self):
+        """D12: the manifest recognises legacy installs; it never deletes them."""
+        self._install_legacy_copilot_region()
+        self._install_legacy_cursor_file()
+        before_copilot = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
+        before_cursor = Path(".cursor/rules/fixture-skill.mdc").read_text(encoding="utf-8")
+
+        with patch("railtracks.cli._skillkit.install.print_warning"):
+            install_skill_directory(self._fixture(), COPILOT, force=True)
+
+        self.assertEqual(
+            Path(".github/copilot-instructions.md").read_text(encoding="utf-8"),
+            before_copilot,
+        )
+        self.assertEqual(
+            Path(".cursor/rules/fixture-skill.mdc").read_text(encoding="utf-8"),
+            before_cursor,
+        )
+
+    def test_a_clean_repo_reports_no_legacy_installs(self):
+        """No legacy content on disk, no legacy warnings — the common case is silent."""
+        with patch("railtracks.cli._skillkit.install.print_warning") as mock_warning:
+            install_skill_directory(self._fixture(), COPILOT, force=True)
+
+        self.assertEqual(mock_warning.call_count, 0)
+
+
 class TestInstallTargetParameters(unittest.TestCase):
     """The two parameters are the deliverable: a target root, and a projection."""
 
@@ -440,7 +831,7 @@ class TestInstallTargetParameters(unittest.TestCase):
             label="Some Assistant",
             root=Path(".somewhere") / "skills",
             frontmatter=lambda s: f"---\nname: {s.name}\n---\n\n",
-            body=lambda s: _strip_skill_arguments(s.body),
+            body=lambda s: strip_skill_arguments(s.body),
         )
 
         written = install_skill_directory(skill, elsewhere)

--- a/packages/railtracks/tests/unit_tests/cli/test_cli.py
+++ b/packages/railtracks/tests/unit_tests/cli/test_cli.py
@@ -355,19 +355,26 @@ class TestSkillInstallers(unittest.TestCase):
         )
         self.assertNotIn("$ARGUMENTS", content)
 
-    def test_cursor_installs_rules_file(self):
-        """Cursor skills are written as .mdc rules with valid metadata."""
+    def test_cursor_installs_skill_directory(self):
+        """Cursor skills ship as `.cursor/skills/<name>/SKILL.md`, not the legacy .mdc."""
         add_skill("cursor:agent-builder")
 
-        target = Path(".cursor/rules/agent-builder.mdc")
+        target = Path(".cursor/skills/agent-builder/SKILL.md")
         self.assertTrue(target.is_file())
         content = target.read_text(encoding="utf-8")
-        self.assertTrue(content.startswith("---\ndescription: "))
-        self.assertIn("alwaysApply: false", content)
+        self.assertTrue(content.startswith("---\nname: agent-builder\n"))
+        self.assertIn("description:", content)
         self.assertIn("# Build a Railtracks Agent", content)
 
+    def test_cursor_does_not_write_the_legacy_mdc(self):
+        """D10: no legacy writes. The old .mdc path must not be touched."""
+        add_skill("cursor:agent-builder")
+
+        self.assertFalse(Path(".cursor/rules/agent-builder.mdc").exists())
+        self.assertFalse(Path(".cursor/rules").exists())
+
     def test_cursor_does_not_use_other_tool_directories(self):
-        """Cursor installation must use its own rules discovery path."""
+        """Cursor installation must use its own skills discovery path."""
         add_skill("cursor:agent-builder")
 
         self.assertFalse(Path(".claude").exists())
@@ -378,40 +385,36 @@ class TestSkillInstallers(unittest.TestCase):
         """Cursor has no argument-hint field and no substitution, so $ARGUMENTS goes."""
         add_skill("cursor:agent-builder")
 
-        content = Path(".cursor/rules/agent-builder.mdc").read_text(encoding="utf-8")
+        content = Path(".cursor/skills/agent-builder/SKILL.md").read_text(
+            encoding="utf-8"
+        )
         self.assertNotIn("$ARGUMENTS", content)
+
+    def test_copilot_installs_skill_directory(self):
+        """Copilot skills ship as `.github/skills/<name>/SKILL.md` — no marker block."""
+        add_skill("copilot:agent-builder")
+
+        target = Path(".github/skills/agent-builder/SKILL.md")
+        self.assertTrue(target.is_file())
+        content = target.read_text(encoding="utf-8")
+        self.assertTrue(content.startswith("---\nname: agent-builder\n"))
+        self.assertIn("description:", content)
+        self.assertIn("# Build a Railtracks Agent", content)
+
+    def test_copilot_does_not_write_the_legacy_marker_block(self):
+        """D10: no legacy writes. copilot-instructions.md must not be touched."""
+        add_skill("copilot:agent-builder")
+
+        self.assertFalse(Path(".github/copilot-instructions.md").exists())
 
     def test_copilot_resolves_argument_placeholder(self):
-        """Copilot instructions are always-on context, so $ARGUMENTS never survives."""
+        """Copilot's directory install ships no argument-hint field, so $ARGUMENTS goes."""
         add_skill("copilot:agent-builder")
 
-        content = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
+        content = Path(".github/skills/agent-builder/SKILL.md").read_text(
+            encoding="utf-8"
+        )
         self.assertNotIn("$ARGUMENTS", content)
-        self.assertIn("<!-- railtracks:agent-builder:start -->", content)
-        self.assertIn("<!-- railtracks:agent-builder:end -->", content)
-
-    def test_copilot_reinstall_is_idempotent(self):
-        """Regenerating a skill in place must not duplicate it or add blank lines."""
-        add_skill("copilot:agent-builder")
-        first = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
-
-        add_skill("copilot:agent-builder", force=True)
-        second = Path(".github/copilot-instructions.md").read_text(encoding="utf-8")
-
-        self.assertEqual(first, second)
-
-    def test_copilot_preserves_surrounding_content(self):
-        """Hand-maintained sections around the markers must survive a regeneration."""
-        target = Path(".github/copilot-instructions.md")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text("# Hand written preamble\n", encoding="utf-8")
-
-        add_skill("copilot:agent-builder")
-        add_skill("copilot:agent-builder", force=True)
-
-        content = target.read_text(encoding="utf-8")
-        self.assertTrue(content.startswith("# Hand written preamble\n"))
-        self.assertEqual(content.count("<!-- railtracks:agent-builder:start -->"), 1)
 
     def test_claude_keeps_argument_placeholder(self):
         """Claude Code substitutes $ARGUMENTS at invocation, so it must be preserved."""


### PR DESCRIPTION
## Summary

Closes #1535.

Adds directory-install handlers for Copilot (`.github/skills/<name>/`) and Cursor (`.cursor/skills/<name>/`), migrates Codex to the same shared flow, and wires `find_legacy_installs` into `install_skill_directory` so a stale `copilot-instructions.md` marker block or `.cursor/rules/<name>.mdc` is reported (never removed) before every install runs. Provider-specific code (root path + frontmatter projection) is split into one file per assistant under `_skillkit/providers/` so adding a fifth assistant is a new file plus one re-export line; `install.py` becomes provider-agnostic.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

- User-visible path change: Copilot skills now install to `.github/skills/<name>/` (was `.github/copilot-instructions.md`); Cursor skills install to `.cursor/skills/<name>/` (was `.cursor/rules/<name>.mdc`). The old paths are no longer written; if they exist from a prior install they surface as a warning and stay put for the user to remove by hand.
- Codex path is unchanged (`.agents/skills/<name>/SKILL.md`); the migration adds supporting-file copy and manifest tracking for it, and a first re-install over a pre-manifest file will hit the standard overwrite prompt once, then track cleanly.
- Bundled skills ship no supporting files today, so the tests that pin "no `references/` under bundled skills" still hold. The user-facing surface (`railtracks add <tool>:<skill>` and `--list`) is unchanged.
