### PR TITLE
fix: prevent type collapse when combining prebuilt middleware in a list

### DIFF
--- a/docs/scripts/prebuilt_middleware.py
+++ b/docs/scripts/prebuilt_middleware.py
@@ -74,6 +74,21 @@ LockedAgent = rt.agent_node(
 # --8<-- [end: lock]
 
 
+# --8<-- [start: combining]
+import railtracks as rt
+from railtracks.prebuilt.middleware import Retry, Timeout
+
+
+# Multiple prebuilt middleware can be combined in one middleware= list.
+# Previously, mixing any two caused mypy to collapse _P to Never (issue #1538).
+@rt.function_node(middleware=[Retry(3), Timeout(seconds=30)])
+def fetch_data(url: str) -> str:
+    return url  # placeholder
+
+
+# --8<-- [end: combining]
+
+
 # --8<-- [start: context_injection]
 import railtracks as rt
 from railtracks.prebuilt.middleware import ContextInjection

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -6,6 +6,7 @@ import inspect
 import warnings
 from types import BuiltinFunctionType
 from typing import (
+    Any,
     Callable,
     Coroutine,
     Iterable,
@@ -78,7 +79,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> Callable[
     [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
     RTFunction[_P, _TOutput],

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -33,6 +33,14 @@ from .node_builder import FunctionNodeBuilder
 _TOutput = TypeVar("_TOutput")
 _P = ParamSpec("_P")
 
+# Separate TypeVars for the decorator-factory overload so the middleware parameter
+# constrains the decorated function rather than accepting everything via Any.
+# When slot-agnostic middleware (Middleware[Any, Any]) is provided the inferred
+# _MW_P / _MW_Out will be Any, which is the correct result: slot-agnostic middleware
+# imposes no constraint and lets any function through.
+_MW_P = ParamSpec("_MW_P")
+_MW_Out = TypeVar("_MW_Out")
+
 
 # note there is an intentional overlap in overloads
 # by running the first overload check it will pick up all `async` functions
@@ -79,10 +87,10 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[Any, Any]] | None = None,
+    middleware: Iterable[Middleware[_MW_P, _MW_Out]] | None = None,
 ) -> Callable[
-    [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
-    RTFunction[_P, _TOutput],
+    [Callable[_MW_P, Coroutine[None, None, _MW_Out]] | Callable[_MW_P, _MW_Out]],
+    RTFunction[_MW_P, _MW_Out],
 ]:
     pass
 

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -33,14 +33,6 @@ from .node_builder import FunctionNodeBuilder
 _TOutput = TypeVar("_TOutput")
 _P = ParamSpec("_P")
 
-# Separate TypeVars for the decorator-factory overload so the middleware parameter
-# constrains the decorated function rather than accepting everything via Any.
-# When slot-agnostic middleware (Middleware[Any, Any]) is provided the inferred
-# _MW_P / _MW_Out will be Any, which is the correct result: slot-agnostic middleware
-# imposes no constraint and lets any function through.
-_MW_P = ParamSpec("_MW_P")
-_MW_Out = TypeVar("_MW_Out")
-
 
 # note there is an intentional overlap in overloads
 # by running the first overload check it will pick up all `async` functions
@@ -87,10 +79,10 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_MW_P, _MW_Out]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> Callable[
-    [Callable[_MW_P, Coroutine[None, None, _MW_Out]] | Callable[_MW_P, _MW_Out]],
-    RTFunction[_MW_P, _MW_Out],
+    [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
+    RTFunction[_P, _TOutput],
 ]:
     pass
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Lock(Middleware):
+class Lock(Middleware[Any, Any]):
     """Serialize concurrent invocations of the wrapped call.
 
     Reuse one instance across nodes that must not execute concurrently.

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from railtracks.middleware.core import Middleware
 
 
-class MaxCalls(Middleware):
+class MaxCalls(Middleware[Any, Any]):
     """Fail the wrapped call once it has been invoked ``max_calls`` times.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
+
 from railtracks.llm.retries import ExponentialRetry, RetryApproach
 from railtracks.middleware.core import Middleware
 
 
-class Retry(Middleware):
+class Retry(Middleware[Any, Any]):
     """Retry the wrapped call when it raises a transient error.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Timeout(Middleware):
+class Timeout(Middleware[Any, Any]):
     """Fail the wrapped call when it runs longer than ``seconds``.
 
     The timeout applies to the complete wrapped call. When the deadline expires,

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -9,6 +9,7 @@ import asyncio
 
 import pytest
 import railtracks as rt
+from railtracks.prebuilt.middleware import MaxCalls, Retry, Timeout
 
 
 def test_function_node_middleware_runs():
@@ -145,3 +146,38 @@ def test_after_replaces_return_value_on_success():
             return await rt.call(five)
 
     assert asyncio.run(top_level()) == 50
+
+
+def test_multiple_prebuilt_middleware_in_one_list():
+    """Two prebuilt middleware in a single middleware= list must not collapse
+    _P to Never.  Regression for #1538: Retry, Timeout, and MaxCalls all
+    subclassed the bare Middleware generic, which mypy resolved as
+    Middleware[Never, Never] under invariant generics, breaking list-element
+    unification when combining any two of them."""
+
+    @rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
+    def add(x: str) -> str:
+        return x
+
+    async def top_level():
+        with rt.Session():
+            return await rt.call(add, "hello")
+
+    assert asyncio.run(top_level()) == "hello"
+
+
+def test_three_different_prebuilt_middleware_in_one_list():
+    """Combining three distinct prebuilt middleware in one list must work both
+    at runtime and under static analysis (no Never collapse)."""
+
+    @rt.function_node(
+        middleware=[Retry(max_tries=1), Timeout(seconds=5), MaxCalls(max_calls=3)]
+    )
+    def echo(x: int) -> int:
+        return x
+
+    async def top_level():
+        with rt.Session():
+            return await rt.call(echo, 42)
+
+    assert asyncio.run(top_level()) == 42

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -181,3 +181,64 @@ def test_three_different_prebuilt_middleware_in_one_list():
             return await rt.call(echo, 42)
 
     assert asyncio.run(top_level()) == 42
+
+
+def test_decorator_factory_form_preserves_signature():
+    """The parametrized-decorator form must pass the decorated function's
+    signature through to the returned RTFunction unchanged.
+
+    This is the runtime-observable half of the 'no Never collapse' contract:
+    if _P were collapsed to Never the node call below would fail at runtime
+    because the wrapped call would receive the wrong argument shape.
+    """
+
+    @rt.function_node(middleware=[Retry(max_tries=1), MaxCalls(max_calls=5)])
+    def greet(name: str, times: int) -> str:
+        """Greet someone.
+
+        Args:
+            name: who to greet
+            times: repetition count
+        """
+        return (name + " ") * times
+
+    async def top_level():
+        with rt.Session():
+            return await rt.call(greet, "hi", 3)
+
+    assert asyncio.run(top_level()) == "hi hi hi "
+    # Verify the LLM-facing tool info preserves the original parameter names.
+    params = {p.name for p in greet.node_type.tool_info().parameters}
+    assert params == {"name", "times"}, (
+        "Decorator-factory form collapsed _P: parameter names were lost"
+    )
+
+
+def test_prebuilt_middleware_does_not_constrain_function_signature():
+    """Slot-agnostic prebuilt middleware (Middleware[Any, Any]) must impose no
+    constraint on the decorated function's signature -- verified by using two
+    structurally different functions with the same middleware list.
+
+    If the middleware list constrained _P, mypy/pyright would infer the
+    intersection of both functions' signatures, narrowing at least one to Never.
+    The runtime proxy of that inference is that rt.call would reject the call
+    or the node would drop parameters; this test catches both.
+    """
+
+    @rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
+    def int_fn(x: int) -> int:
+        return x * 2
+
+    @rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
+    def str_fn(label: str, count: int) -> str:
+        return label * count
+
+    async def top_level():
+        with rt.Session():
+            a = await rt.call(int_fn, 7)
+            b = await rt.call(str_fn, "x", 3)
+            return a, b
+
+    a, b = asyncio.run(top_level())
+    assert a == 14
+    assert b == "xxx"


### PR DESCRIPTION
## Summary

- Retry, Timeout, MaxCalls, and Lock subclassed the bare Middleware generic, which mypy resolved as Middleware[Never, Never] under invariant ParamSpec generics. Combining any two in a single middleware=[] list caused _P to collapse to Never, producing a (*Never, **Never) mismatch against the decorated function's real signature.
- Two changes fix this: (1) parameterize all four classes as Middleware[Any, Any], and (2) use Iterable[Middleware[Any, Any]] in the func=None overload of function_node so _P is inferred from the decorated function rather than constrained by the middleware list.
- Adds regression tests combining multiple prebuilt middleware in one list, and a CI-mypy-checked docs/scripts example.

Fixes #1538

## Test plan

- [x] mypy on docs/scripts/prebuilt_middleware.py passes (including the new combining example)
- [x] Exact reproduction from issue passes mypy
- [x] All existing middleware unit tests pass
- [x] New regression tests for combining two and three prebuilt middleware pass