### PR TITLE
feat(retrieval): add structured content extractors

### DIFF
--- a/docs/retrieval/components/ingestion/methods.md
+++ b/docs/retrieval/components/ingestion/methods.md
@@ -125,12 +125,12 @@ For `.jsonl`:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `file_path` | `str` | required | Path to a `.json` / `.jsonl` file, or a directory containing them |
-| `content_keys` | `list[str] | "*"` | `"*"` | Keys whose values form `content`. `"*"` serialises the whole object. |
-| `id_key` | `str | None` | `None` | Top-level key whose value is the per-object id in `Document.source`. Falls back to position (array index or JSONL line). |
-| `ignore_keys` | `list[str] | None` | `None` | Keys dropped entirely |
+| `content_keys` | `list[str] \| "*"` | `"*"` | Keys whose values form `content`. `"*"` serialises the whole object. |
+| `id_key` | `str \| None` | `None` | Top-level key whose value is the per-object id in `Document.source`. Falls back to position (array index or JSONL line). |
+| `ignore_keys` | `list[str] \| None` | `None` | Keys dropped entirely |
 | `content_separator` | `str` | `"\n"` | Used to join content-key values |
 | `encoding` | `str` | `"utf-8-sig"` | File encoding |
-| `content_extractor` | `ContentExtractor | None` | `None` | Converts selected values to text. Omitted preserves existing serialization. |
+| `content_extractor` | `ContentExtractor \| None` | `None` | Converts selected values to text. Omitted preserves existing serialization. |
 
 ---
 
@@ -307,7 +307,7 @@ For gated datasets set `HF_TOKEN` in your environment, or pass
 **Document metadata**: `row_index` plus any column listed in
 `metadata_columns`. `Document.source` is `"{dataset_name}/{split}"`.
 
-### Structured content extractors
+## Structured content extractors
 
 Both `JSONLoader` and `HuggingFaceDatasetLoader` accept any callable matching
 `ContentExtractor`: it receives one selected value and returns a string. The
@@ -315,12 +315,14 @@ built-ins are importable from `railtracks.retrieval`:
 
 - `StrExtractor` uses `str(value)` and is the Hugging Face loader default.
 - `JsonExtractor` produces valid JSON and preserves Unicode text.
-- `ProseExtractor` renders nested dictionaries and lists as labelled prose.
+- `ProseExtractor` renders nested dictionaries and lists as labelled prose, with braces around nested dictionaries and brackets around lists to show their boundaries.
 
 For example, the `passages` column in `ms_marco` is structured. The
 `hf_kwargs` example above uses `ProseExtractor` so the nested labels and values
-become useful embedding input. Extractors apply only to content fields;
+remain visible in the extracted text, including `is_selected` flags and raw URLs. For retrieval focused on passage content, use a custom extractor that selects only `passage_text`. Extractors apply only to content fields;
 `metadata_columns` stay as their original Python values.
+
+Extraction failures stop loading and raise a `ValueError` naming the content column or key, zero-based row or object index, and source; the original exception is preserved as the cause. They do not currently produce per-document recovery events. For `JSONLoader(content_keys="*")`, the reported key is `"*"` because the extractor receives the entire filtered object.
 
 ---
 # LangChain Loaders

--- a/docs/retrieval/components/ingestion/methods.md
+++ b/docs/retrieval/components/ingestion/methods.md
@@ -108,6 +108,12 @@ Each object — array element or JSONL line — becomes one `Document`.
 --8<-- "docs/scripts/retrieval/ingestion_example.py:json_loader"
 ```
 
+Nested values can be normalized before embedding with a content extractor:
+
+```python
+--8<-- "docs/scripts/retrieval/ingestion_example.py:json_structured_content"
+```
+
 For `.jsonl`:
 
 ```python
@@ -124,6 +130,7 @@ For `.jsonl`:
 | `ignore_keys` | `list[str] | None` | `None` | Keys dropped entirely |
 | `content_separator` | `str` | `"\n"` | Used to join content-key values |
 | `encoding` | `str` | `"utf-8-sig"` | File encoding |
+| `content_extractor` | `ContentExtractor | None` | `None` | Converts selected values to text. Omitted preserves existing serialization. |
 
 ---
 
@@ -295,9 +302,25 @@ For gated datasets set `HF_TOKEN` in your environment, or pass
 | `metadata_columns` | `list[str] \| None` | `None` | Columns copied into `metadata` |
 | `content_separator` | `str` | `"\n"` | Used to join `content_columns` values |
 | `dataset_kwargs` | `dict \| None` | `None` | Forwarded to `datasets.load_dataset` |
+| `content_extractor` | `ContentExtractor \| None` | `None` | Converts each selected content-column value to text. Omitted uses `StrExtractor`. |
 
 **Document metadata**: `row_index` plus any column listed in
 `metadata_columns`. `Document.source` is `"{dataset_name}/{split}"`.
+
+### Structured content extractors
+
+Both `JSONLoader` and `HuggingFaceDatasetLoader` accept any callable matching
+`ContentExtractor`: it receives one selected value and returns a string. The
+built-ins are importable from `railtracks.retrieval`:
+
+- `StrExtractor` uses `str(value)` and is the Hugging Face loader default.
+- `JsonExtractor` produces valid JSON and preserves Unicode text.
+- `ProseExtractor` renders nested dictionaries and lists as labelled prose.
+
+For example, the `passages` column in `ms_marco` is structured. The
+`hf_kwargs` example above uses `ProseExtractor` so the nested labels and values
+become useful embedding input. Extractors apply only to content fields;
+`metadata_columns` stay as their original Python values.
 
 ---
 # LangChain Loaders

--- a/docs/retrieval/runtime/ingestion.md
+++ b/docs/retrieval/runtime/ingestion.md
@@ -27,6 +27,11 @@ Use `ingest_all` for batch jobs and tests where you only care about the
 summary. Use `ingest` (below) anywhere you need to surface progress, react to
 failures, or stream events to another system.
 
+If a JSON or Hugging Face content field contains a dictionary or list, normalize
+it at the loader boundary before chunking and embedding. The built-in
+[`JsonExtractor` and `ProseExtractor`](../components/ingestion/methods.md#structured-content-extractors)
+preserve structure as valid JSON or labelled prose while leaving metadata raw.
+
 ---
 
 ## Streaming events

--- a/docs/scripts/retrieval/ingestion_example.py
+++ b/docs/scripts/retrieval/ingestion_example.py
@@ -412,15 +412,18 @@ HuggingFaceDatasetLoader(
 
 # --8<-- [start:hf_kwargs]
 
+from railtracks.retrieval import ProseExtractor
 from railtracks.retrieval.loaders.huggingface_loader import HuggingFaceDatasetLoader
 
 # dataset_kwargs is forwarded straight to datasets.load_dataset.
-# Use it for subsets, revisions, gated-dataset tokens, or to disable streaming.
+# ms_marco's passages field is nested, so ProseExtractor turns its structure
+# into labelled searchable text while metadata values remain unchanged.
 HuggingFaceDatasetLoader(
     dataset_name="ms_marco",
     split="validation",
     content_columns=["query", "passages"],
     dataset_kwargs={"name": "v2.1"},
+    content_extractor=ProseExtractor(),
 )
 # --8<-- [end:hf_kwargs]
 
@@ -440,6 +443,20 @@ docs = JSONLoader(
 print(docs[0].content)   # "title: Getting started\nbody: ..."
 print(docs[0].metadata)  # {"author": "Alice", "index": 0}
 # --8<-- [end:json_loader]
+
+
+# --8<-- [start:json_structured_content]
+
+from railtracks.retrieval import JsonExtractor
+from railtracks.retrieval.loaders import JSONLoader
+
+# Preserve a nested field as valid JSON instead of Python's dict repr.
+JSONLoader(
+    "questions.json",
+    content_keys=["question"],
+    content_extractor=JsonExtractor(),
+)
+# --8<-- [end:json_structured_content]
 
 
 # --8<-- [start:jsonl_loader]

--- a/packages/railtracks/src/railtracks/retrieval/__init__.py
+++ b/packages/railtracks/src/railtracks/retrieval/__init__.py
@@ -8,6 +8,12 @@ by :mod:`railtracks.retrieval.loaders`, :mod:`railtracks.retrieval.chunking`,
 and :mod:`railtracks.retrieval.embedding`.
 """
 
+from .content_extraction import (
+    ContentExtractor,
+    JsonExtractor,
+    ProseExtractor,
+    StrExtractor,
+)
 from .embedding.models import EmbeddingFailure
 from .errors import EmbeddingModelMismatchError
 from .models import (
@@ -31,6 +37,7 @@ from .stores import Store, StoreEntry, StoreQuery, StoreScope, VectorStore
 __all__ = [
     "BatchIngested",
     "Chunk",
+    "ContentExtractor",
     "Document",
     "DocumentFailed",
     "DocumentSkipped",
@@ -39,7 +46,9 @@ __all__ = [
     "EmbeddingFailure",
     "EmbeddingModelMismatchError",
     "IngestionStats",
+    "JsonExtractor",
     "OCRResult",
+    "ProseExtractor",
     "RetrievalResult",
     "RetrievalRuntime",
     "RetrievedChunk",
@@ -47,5 +56,6 @@ __all__ = [
     "StoreEntry",
     "StoreQuery",
     "StoreScope",
+    "StrExtractor",
     "VectorStore",
 ]

--- a/packages/railtracks/src/railtracks/retrieval/content_extraction.py
+++ b/packages/railtracks/src/railtracks/retrieval/content_extraction.py
@@ -1,0 +1,46 @@
+"""Content extraction strategies for structured loader fields."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Protocol
+
+
+class ContentExtractor(Protocol):
+    """Convert one loader field value into searchable text."""
+
+    def __call__(self, value: Any) -> str: ...
+
+
+class StrExtractor:
+    """Render values with Python's built-in string conversion."""
+
+    def __call__(self, value: Any) -> str:
+        return str(value)
+
+
+class JsonExtractor:
+    """Render values as valid JSON while preserving Unicode text."""
+
+    def __call__(self, value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False)
+
+
+class ProseExtractor:
+    """Flatten nested JSON-like values into readable, labelled text."""
+
+    def __call__(self, value: Any) -> str:
+        return self._render(value)
+
+    def _render(self, value: Any) -> str:
+        if isinstance(value, dict):
+            return "; ".join(
+                f"{key}: {self._render(item)}" for key, item in value.items()
+            )
+        if isinstance(value, (list, tuple)):
+            return f"[{', '.join(self._render(item) for item in value)}]"
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)

--- a/packages/railtracks/src/railtracks/retrieval/content_extraction.py
+++ b/packages/railtracks/src/railtracks/retrieval/content_extraction.py
@@ -9,7 +9,7 @@ from typing import Any, Protocol
 class ContentExtractor(Protocol):
     """Convert one loader field value into searchable text."""
 
-    def __call__(self, value: Any) -> str: ...
+    def __call__(self, value: Any, /) -> str: ...
 
 
 class StrExtractor:
@@ -30,13 +30,14 @@ class ProseExtractor:
     """Flatten nested JSON-like values into readable, labelled text."""
 
     def __call__(self, value: Any) -> str:
-        return self._render(value)
+        return self._render(value, nested=False)
 
-    def _render(self, value: Any) -> str:
+    def _render(self, value: Any, *, nested: bool = True) -> str:
         if isinstance(value, dict):
-            return "; ".join(
+            rendered = "; ".join(
                 f"{key}: {self._render(item)}" for key, item in value.items()
             )
+            return f"{{{rendered}}}" if nested else rendered
         if isinstance(value, (list, tuple)):
             return f"[{', '.join(self._render(item) for item in value)}]"
         if value is None:

--- a/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import AsyncGenerator, Iterator
 from typing import Any, Final
 
+from railtracks.retrieval.content_extraction import ContentExtractor, StrExtractor
 from railtracks.retrieval.loaders.base import BaseDocumentLoader
 from railtracks.retrieval.models import Document, DocumentType
 
@@ -59,6 +60,10 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
             Default : None.
         content_separator: Separator used to join `content_columns`
             values. Default: `"\\n"`.
+        content_extractor: Callable used to turn each content-column value
+            into text. Defaults to `StrExtractor`, preserving the existing
+            `str(value)` behavior. Use `JsonExtractor`, `ProseExtractor`, or
+            any custom callable for nested values.
         dataset_kwargs: Extra keyword arguments forwarded to
             `datasets.load_dataset`. Use this for subset selection
             (`{"name": "v2.1"}`), pinning a revision, or passing an
@@ -80,6 +85,7 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         metadata_columns: list[str] | None = None,
         content_separator: str = "\n",
         dataset_kwargs: dict[str, Any] | None = None,
+        content_extractor: ContentExtractor | None = None,
     ) -> None:
         if not content_columns:
             raise ValueError("content_columns must be a non-empty list of column names")
@@ -89,6 +95,9 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
         self._id_column = id_column
         self._metadata_columns = list(metadata_columns or [])
         self._content_separator = content_separator
+        self._content_extractor = (
+            content_extractor if content_extractor is not None else StrExtractor()
+        )
         self._dataset_kwargs = dict(dataset_kwargs or {})
 
     async def astream(self) -> AsyncGenerator[Document, None]:
@@ -152,7 +161,7 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                 validated = True
 
             content = self._content_separator.join(
-                str(row[col]) for col in self._content_columns
+                self._content_extractor(row[col]) for col in self._content_columns
             )
             metadata: dict[str, Any] = {col: row[col] for col in self._metadata_columns}
             metadata["row_index"] = row_index

--- a/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/huggingface_loader.py
@@ -60,20 +60,21 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
             Default : None.
         content_separator: Separator used to join `content_columns`
             values. Default: `"\\n"`.
-        content_extractor: Callable used to turn each content-column value
-            into text. Defaults to `StrExtractor`, preserving the existing
-            `str(value)` behavior. Use `JsonExtractor`, `ProseExtractor`, or
-            any custom callable for nested values.
         dataset_kwargs: Extra keyword arguments forwarded to
             `datasets.load_dataset`. Use this for subset selection
             (`{"name": "v2.1"}`), pinning a revision, or passing an
             auth token. `streaming=True` is always set; any `streaming`
             entry here is ignored.
+        content_extractor: Callable used to turn each content-column value
+            into text. Defaults to `StrExtractor`, preserving the existing
+            `str(value)` behavior. Use `JsonExtractor`, `ProseExtractor`, or
+            any custom callable for nested values.
 
     Raises:
         ValueError: If `content_columns` is empty, or if any name in
             `content_columns`, `metadata_columns`, or `id_column` isn't
-            present in the dataset schema.
+            present in the dataset schema, or content extraction fails (with
+            column, row index, and dataset source).
     """
 
     def __init__(
@@ -161,7 +162,8 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                 validated = True
 
             content = self._content_separator.join(
-                self._content_extractor(row[col]) for col in self._content_columns
+                self._extract_content(row[col], col, row_index)
+                for col in self._content_columns
             )
             metadata: dict[str, Any] = {col: row[col] for col in self._metadata_columns}
             metadata["row_index"] = row_index
@@ -179,3 +181,12 @@ class HuggingFaceDatasetLoader(BaseDocumentLoader):
                 metadata=metadata,
             )
             row_index += 1
+
+    def _extract_content(self, value: Any, column: str, row_index: int) -> str:
+        try:
+            return self._content_extractor(value)
+        except Exception as exc:
+            raise ValueError(
+                f"Content extraction failed for column {column!r} at row index {row_index} "
+                f"in {self._dataset_name}/{self._split}: {exc!r}"
+            ) from exc

--- a/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Literal
 
+from railtracks.retrieval.content_extraction import ContentExtractor
 from railtracks.retrieval.loaders.base import BaseDocumentLoader
 from railtracks.retrieval.models import Document, DocumentType
 
@@ -47,6 +48,10 @@ class JSONLoader(BaseDocumentLoader):
         ignore_keys: Keys to drop entirely from both content and metadata.
         content_separator: String used to join multiple content-key values.
             Defaults to `"\\n"`.
+        content_extractor: Optional callable used to turn content-key values
+            into text. When omitted, the loader preserves its existing JSON
+            serialization for `content_keys="*"` and `str(value)` behavior
+            for explicit keys.
         encoding: File encoding. Defaults to `utf-8-sig`.
 
     Raises:
@@ -67,12 +72,14 @@ class JSONLoader(BaseDocumentLoader):
         ignore_keys: list[str] | None = None,
         content_separator: str = "\n",
         encoding: str = "utf-8-sig",
+        content_extractor: ContentExtractor | None = None,
     ) -> None:
         self._path = Path(file_path)
         self._content_keys = content_keys
         self._id_key = id_key
         self._ignore_keys = set(ignore_keys or [])
         self._content_separator = content_separator
+        self._content_extractor = content_extractor
         self._encoding = encoding
 
     def _object_to_document(
@@ -99,9 +106,11 @@ class JSONLoader(BaseDocumentLoader):
                 present in `obj`.
         """
         if self._content_keys == "*":
-            content = json.dumps(
-                {k: v for k, v in obj.items() if k not in self._ignore_keys},
-                ensure_ascii=False,
+            content_value = {k: v for k, v in obj.items() if k not in self._ignore_keys}
+            content = (
+                self._content_extractor(content_value)
+                if self._content_extractor is not None
+                else json.dumps(content_value, ensure_ascii=False)
             )
             metadata: dict[str, Any] = {}
         else:
@@ -111,7 +120,7 @@ class JSONLoader(BaseDocumentLoader):
                     f"content_keys {unknown} not found in object at index {index} in {source_prefix}"
                 )
             content = self._content_separator.join(
-                f"{k}: {obj[k]}" for k in self._content_keys
+                f"{k}: {self._extract_content(obj[k])}" for k in self._content_keys
             )
             content_key_set = set(self._content_keys)
             metadata = {
@@ -133,6 +142,11 @@ class JSONLoader(BaseDocumentLoader):
             source=f"{source_prefix}#{obj_id}",
             metadata=metadata,
         )
+
+    def _extract_content(self, value: Any) -> str:
+        if self._content_extractor is None:
+            return str(value)
+        return self._content_extractor(value)
 
     async def _stream_file(self, path: Path) -> AsyncGenerator[Document, None]:
         """Stream documents from a single JSON or JSONL file.

--- a/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
+++ b/packages/railtracks/src/railtracks/retrieval/loaders/json_loader.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, Literal
 
-from railtracks.retrieval.content_extraction import ContentExtractor
+from railtracks.retrieval.content_extraction import ContentExtractor, JsonExtractor
 from railtracks.retrieval.loaders.base import BaseDocumentLoader
 from railtracks.retrieval.models import Document, DocumentType
 
@@ -48,11 +48,11 @@ class JSONLoader(BaseDocumentLoader):
         ignore_keys: Keys to drop entirely from both content and metadata.
         content_separator: String used to join multiple content-key values.
             Defaults to `"\\n"`.
+        encoding: File encoding. Defaults to `utf-8-sig`.
         content_extractor: Optional callable used to turn content-key values
             into text. When omitted, the loader preserves its existing JSON
             serialization for `content_keys="*"` and `str(value)` behavior
             for explicit keys.
-        encoding: File encoding. Defaults to `utf-8-sig`.
 
     Raises:
         FileNotFoundError: If `file_path` does not exist.
@@ -61,7 +61,7 @@ class JSONLoader(BaseDocumentLoader):
             (e.g. a `.json` file that is neither object nor array of
             objects, or a `.jsonl` line that is not a JSON object), or any
             key in `content_keys` or `id_key` is not found in a parsed
-            object.
+            object, or a content extractor fails (with key, index, and source).
     """
 
     def __init__(
@@ -79,6 +79,7 @@ class JSONLoader(BaseDocumentLoader):
         self._id_key = id_key
         self._ignore_keys = set(ignore_keys or [])
         self._content_separator = content_separator
+        # Unlike the HF loader, the default depends on the content-keys mode.
         self._content_extractor = content_extractor
         self._encoding = encoding
 
@@ -107,10 +108,8 @@ class JSONLoader(BaseDocumentLoader):
         """
         if self._content_keys == "*":
             content_value = {k: v for k, v in obj.items() if k not in self._ignore_keys}
-            content = (
-                self._content_extractor(content_value)
-                if self._content_extractor is not None
-                else json.dumps(content_value, ensure_ascii=False)
+            content = self._extract_content(
+                content_value, JsonExtractor(), "*", source_prefix, index
             )
             metadata: dict[str, Any] = {}
         else:
@@ -120,7 +119,8 @@ class JSONLoader(BaseDocumentLoader):
                     f"content_keys {unknown} not found in object at index {index} in {source_prefix}"
                 )
             content = self._content_separator.join(
-                f"{k}: {self._extract_content(obj[k])}" for k in self._content_keys
+                f"{k}: {self._extract_content(obj[k], str, k, source_prefix, index)}"
+                for k in self._content_keys
             )
             content_key_set = set(self._content_keys)
             metadata = {
@@ -143,10 +143,23 @@ class JSONLoader(BaseDocumentLoader):
             metadata=metadata,
         )
 
-    def _extract_content(self, value: Any) -> str:
-        if self._content_extractor is None:
-            return str(value)
-        return self._content_extractor(value)
+    def _extract_content(
+        self,
+        value: Any,
+        fallback: ContentExtractor,
+        key: str,
+        source_prefix: str,
+        index: int,
+    ) -> str:
+        extractor = (
+            self._content_extractor if self._content_extractor is not None else fallback
+        )
+        try:
+            return extractor(value)
+        except Exception as exc:
+            raise ValueError(
+                f"Content extraction failed for key {key!r} at index {index} in {source_prefix}: {exc!r}"
+            ) from exc
 
     async def _stream_file(self, path: Path) -> AsyncGenerator[Document, None]:
         """Stream documents from a single JSON or JSONL file.

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
@@ -6,6 +6,7 @@ import pytest
 
 pytest.importorskip("datasets")
 
+from railtracks.retrieval import JsonExtractor, ProseExtractor  # noqa: E402
 from railtracks.retrieval.loaders.huggingface_loader import (  # noqa: E402
     HuggingFaceDatasetLoader,
 )
@@ -270,3 +271,63 @@ class TestHuggingFaceLoaderSyncWrapper:
         ).load()
         assert len(docs) == len(fake_rows)
         assert docs[0].metadata["row_index"] == 0
+
+
+class TestHuggingFaceLoaderContentExtractors:
+    async def test_json_extractor_serializes_nested_columns(self, mock_load_dataset):
+        mock_load_dataset.return_value = _FakeIterableDataset(
+            [{"question": {"text": "Why?", "tokens": ["Why", "?"]}}]
+        )
+
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["question"],
+            content_extractor=JsonExtractor(),
+        ).aload()
+
+        assert docs[0].content == '{"text": "Why?", "tokens": ["Why", "?"]}'
+
+    async def test_prose_extractor_keeps_metadata_values_raw(self, mock_load_dataset):
+        nested = {"text": "Why?", "tokens": ["Why", "?"]}
+        mock_load_dataset.return_value = _FakeIterableDataset(
+            [{"question": nested, "metadata": {"source": "manual"}}]
+        )
+
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["question"],
+            metadata_columns=["metadata"],
+            content_extractor=ProseExtractor(),
+        ).aload()
+
+        assert docs[0].content == "text: Why?; tokens: [Why, ?]"
+        assert docs[0].metadata["metadata"] == {"source": "manual"}
+
+    async def test_custom_content_extractor_is_supported(self, mock_load_dataset):
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            content_extractor=lambda value: str(value).upper(),
+        ).aload()
+
+        assert docs[0].content == "WHAT IS RAG"
+
+    async def test_falsey_custom_extractor_is_not_replaced(self, mock_load_dataset):
+        class FalseyExtractor:
+            def __bool__(self) -> bool:
+                return False
+
+            def __call__(self, value: object) -> str:
+                return f"custom:{value}"
+
+        docs = await HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["query"],
+            content_extractor=FalseyExtractor(),
+        ).aload()
+
+        assert docs[0].content == "custom:what is rag"

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_huggingface_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -274,6 +275,26 @@ class TestHuggingFaceLoaderSyncWrapper:
 
 
 class TestHuggingFaceLoaderContentExtractors:
+    async def test_json_extractor_failure_names_column_row_and_dataset(
+        self, mock_load_dataset
+    ):
+        mock_load_dataset.return_value = _FakeIterableDataset(
+            [{"question": "valid"}, {"question": datetime(2026, 1, 1)}]
+        )
+        stream = HuggingFaceDatasetLoader(
+            "fake/ds",
+            split="train",
+            content_columns=["question"],
+            content_extractor=JsonExtractor(),
+        ).astream()
+        assert (await anext(stream)).metadata["row_index"] == 0
+        with pytest.raises(ValueError) as exc:
+            await anext(stream)
+        assert "column 'question'" in str(exc.value)
+        assert "row index 1" in str(exc.value)
+        assert "fake/ds/train" in str(exc.value)
+        assert isinstance(exc.value.__cause__, TypeError)
+
     async def test_json_extractor_serializes_nested_columns(self, mock_load_dataset):
         mock_load_dataset.return_value = _FakeIterableDataset(
             [{"question": {"text": "Why?", "tokens": ["Why", "?"]}}]

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from railtracks.retrieval import JsonExtractor, ProseExtractor
 from railtracks.retrieval.loaders.json_loader import JSONLoader
 from railtracks.retrieval.models import DocumentType
 
@@ -320,3 +321,48 @@ class TestJSONLoaderErrors:
         loader = JSONLoader(str(f))
         with pytest.raises(ValueError):
             await loader.aload()
+
+
+class TestJSONLoaderContentExtractors:
+    async def test_json_extractor_serializes_nested_content_key(self, tmp_path):
+        f = tmp_path / "nested.json"
+        f.write_text(
+            json.dumps({"question": {"text": "Why?", "tokens": ["Why", "?"]}}),
+            encoding="utf-8",
+        )
+
+        docs = await JSONLoader(
+            str(f),
+            content_keys=["question"],
+            content_extractor=JsonExtractor(),
+        ).aload()
+
+        assert docs[0].content == ('question: {"text": "Why?", "tokens": ["Why", "?"]}')
+
+    async def test_prose_extractor_applies_to_whole_object(self, tmp_path):
+        f = tmp_path / "nested.json"
+        f.write_text(
+            json.dumps({"text": "Why?", "tokens": ["Why", "?"]}),
+            encoding="utf-8",
+        )
+
+        docs = await JSONLoader(str(f), content_extractor=ProseExtractor()).aload()
+
+        assert docs[0].content == "text: Why?; tokens: [Why, ?]"
+
+    async def test_custom_extractor_preserves_unselected_metadata(self, tmp_path):
+        f = tmp_path / "nested.json"
+        metadata = {"source": "manual"}
+        f.write_text(
+            json.dumps({"question": {"text": "Why?"}, "metadata": metadata}),
+            encoding="utf-8",
+        )
+
+        docs = await JSONLoader(
+            str(f),
+            content_keys=["question"],
+            content_extractor=lambda value: value["text"].upper(),
+        ).aload()
+
+        assert docs[0].content == "question: WHY?"
+        assert docs[0].metadata["metadata"] == metadata

--- a/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/loaders/test_json_loader.py
@@ -324,6 +324,36 @@ class TestJSONLoaderErrors:
 
 
 class TestJSONLoaderContentExtractors:
+    @pytest.mark.parametrize("content_keys", ["*", ["question"]])
+    @pytest.mark.parametrize("suffix", [".json", ".jsonl"])
+    async def test_extractor_failure_names_key_index_and_source(
+        self, tmp_path, content_keys, suffix
+    ):
+        f = tmp_path / f"rows{suffix}"
+        rows = [{"question": "valid"}, {"question": "invalid"}]
+        f.write_text(
+            json.dumps(rows) if suffix == ".json" else "\n".join(map(json.dumps, rows)),
+            encoding="utf-8",
+        )
+        original_error = TypeError("unsupported content")
+
+        def extract(value: object) -> str:
+            if value == "invalid" or value == rows[1]:
+                raise original_error
+            return str(value)
+
+        stream = JSONLoader(
+            str(f), content_keys=content_keys, content_extractor=extract
+        ).astream()
+        assert (await anext(stream)).metadata["index"] == 0
+        with pytest.raises(ValueError) as exc:
+            await anext(stream)
+        key = "*" if content_keys == "*" else "question"
+        assert f"key {key!r}" in str(exc.value)
+        assert "index 1" in str(exc.value)
+        assert str(f) in str(exc.value)
+        assert exc.value.__cause__ is original_error
+
     async def test_json_extractor_serializes_nested_content_key(self, tmp_path):
         f = tmp_path / "nested.json"
         f.write_text(

--- a/packages/railtracks/tests/unit_tests/retrieval/test_content_extraction.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/test_content_extraction.py
@@ -1,6 +1,20 @@
 import json
 
-from railtracks.retrieval import JsonExtractor, ProseExtractor, StrExtractor
+from railtracks.retrieval import (
+    ContentExtractor,
+    JsonExtractor,
+    ProseExtractor,
+    StrExtractor,
+)
+
+
+def differently_named_extractor(v: object) -> str:
+    return str(v)
+
+
+def test_protocol_accepts_builtin_and_differently_named_callable() -> None:
+    extractors: tuple[ContentExtractor, ...] = (str, differently_named_extractor)
+    assert [extractor(42) for extractor in extractors] == ["42", "42"]
 
 
 def test_str_extractor_preserves_python_string_conversion() -> None:
@@ -27,5 +41,14 @@ def test_prose_extractor_flattens_nested_json_values() -> None:
 
     assert ProseExtractor()(value) == (
         "text: What is retrieval?; tokens: [What, is, retrieval]; "
-        "metadata: reviewed: true; score: null"
+        "metadata: {reviewed: true; score: null}"
     )
+
+
+def test_prose_extractor_distinguishes_nested_dicts_from_flat_strings() -> None:
+    extractor = ProseExtractor()
+    assert extractor({"a": {"b": 1, "c": 2}, "d": 3}) == "a: {b: 1; c: 2}; d: 3"
+    assert extractor({"a": {"b": 1, "c": 2}, "d": 3}) != extractor(
+        {"a": "b: 1; c: 2", "d": 3}
+    )
+    assert extractor([{"x": 1}, {"y": 2}]) == "[{x: 1}, {y: 2}]"

--- a/packages/railtracks/tests/unit_tests/retrieval/test_content_extraction.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/test_content_extraction.py
@@ -1,0 +1,31 @@
+import json
+
+from railtracks.retrieval import JsonExtractor, ProseExtractor, StrExtractor
+
+
+def test_str_extractor_preserves_python_string_conversion() -> None:
+    value = {"answer": None, "verified": True}
+
+    assert StrExtractor()(value) == str(value)
+
+
+def test_json_extractor_returns_valid_unicode_json() -> None:
+    value = {"city": "München", "active": True, "score": None}
+
+    rendered = JsonExtractor()(value)
+
+    assert json.loads(rendered) == value
+    assert "München" in rendered
+
+
+def test_prose_extractor_flattens_nested_json_values() -> None:
+    value = {
+        "text": "What is retrieval?",
+        "tokens": ["What", "is", "retrieval"],
+        "metadata": {"reviewed": True, "score": None},
+    }
+
+    assert ProseExtractor()(value) == (
+        "text: What is retrieval?; tokens: [What, is, retrieval]; "
+        "metadata: reviewed: true; score: null"
+    )


### PR DESCRIPTION
Closes #1100

- add shared string, JSON, prose, and custom callable extraction support
- apply extractors to Hugging Face and JSON structured content while preserving existing defaults and raw metadata
- document nested `ms_marco` and JSON usage

Validation: 41 focused tests and 147 non-cloud loader tests passed; Ruff, focused mypy, and strict MkDocs passed.
