### PR TITLE
Fix type hints collapsing to Never when combining prebuilt middleware

### DIFF
--- a/docs/scripts/prebuilt_middleware.py
+++ b/docs/scripts/prebuilt_middleware.py
@@ -6,11 +6,9 @@ pages by MkDocs. Type-checked in CI via scripts/docs_validation.sh.
 
 from __future__ import annotations
 
-
 # --8<-- [start: retry]
 import railtracks as rt
 from railtracks.prebuilt.middleware import Retry
-
 
 # Retry is slot-agnostic: use it as node middleware, model middleware, or both.
 RetryAgent = rt.agent_node(
@@ -61,6 +59,22 @@ LimitedApiCall = rt.function_node(
 # --8<-- [end: max_calls]
 
 
+# --8<-- [start: combined]
+import railtracks as rt
+from railtracks.prebuilt.middleware import Retry, Timeout
+
+
+# Prebuilt middleware can be freely combined in one list. Each class is
+# parameterized as Middleware[Any, Any] so mypy keeps the wrapped function's
+# real (*args, **kwargs) signature instead of collapsing it to Never.
+@rt.function_node(middleware=[Retry(3), Timeout(seconds=5)])
+def combined_example(x: str) -> str:
+    return x
+
+
+# --8<-- [end: combined]
+
+
 # --8<-- [start: lock]
 import railtracks as rt
 from railtracks.prebuilt.middleware import Lock
@@ -77,7 +91,6 @@ LockedAgent = rt.agent_node(
 # --8<-- [start: context_injection]
 import railtracks as rt
 from railtracks.prebuilt.middleware import ContextInjection
-
 
 # ContextInjection is model-level only. It fills {placeholders} in the prompt
 # from the active session context before each model call.

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -6,6 +6,7 @@ import inspect
 import warnings
 from types import BuiltinFunctionType
 from typing import (
+    Any,
     Callable,
     Coroutine,
     Iterable,
@@ -43,7 +44,7 @@ def function_node(  # pyright: ignore[reportOverlappingOverload]
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> CallableAsyncRTFunction[_P, _TOutput]: ...
 
 
@@ -54,7 +55,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput]:
     pass
 
@@ -78,7 +79,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> Callable[
     [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
     RTFunction[_P, _TOutput],
@@ -182,7 +183,7 @@ def _single_function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput] | CallableAsyncRTFunction[_P, _TOutput]:
     """
     Creates a new Node type from a function that can be used in `rt.call()`.
@@ -261,7 +262,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> (
     CallableAsyncRTFunction[_P, _TOutput]
     | CallableSyncRTFunction[_P, _TOutput]

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Lock(Middleware):
+class Lock(Middleware[Any, Any]):
     """Serialize concurrent invocations of the wrapped call.
 
     Reuse one instance across nodes that must not execute concurrently.

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from railtracks.middleware.core import Middleware
 
 
-class MaxCalls(Middleware):
+class MaxCalls(Middleware[Any, Any]):
     """Fail the wrapped call once it has been invoked ``max_calls`` times.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
+
 from railtracks.llm.retries import ExponentialRetry, RetryApproach
 from railtracks.middleware.core import Middleware
 
 
-class Retry(Middleware):
+class Retry(Middleware[Any, Any]):
     """Retry the wrapped call when it raises a transient error.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Timeout(Middleware):
+class Timeout(Middleware[Any, Any]):
     """Fail the wrapped call when it runs longer than ``seconds``.
 
     The timeout applies to the complete wrapped call. When the deadline expires,


### PR DESCRIPTION
Fixes #1538.

## Root cause

`function_node`'s `middleware` parameter was typed as `Iterable[Middleware[_P, _TOutput]]`, coupling the middleware list's generic parameters to the decorated function's own `ParamSpec`/return type. In the parametrized-decorator form (`@rt.function_node(middleware=[...])`, no `func` yet), mypy has to solve `_P`/`_TOutput` purely from the `middleware` argument before the decorated function is known. Since `Retry`/`Timeout`/`MaxCalls`/`Lock` were generic-erased (bare `Middleware`), mypy infers `_P` as `Never` from that `Any`-typed source, and that `Never` gets baked into the decorator's return type, breaking type-checking of the function it's later applied to. This reproduces with any two prebuilt middleware combined in one list, not just `Retry`+`Timeout` (confirmed `Retry`+`pre_verifier`, `post_verifier`+`Retry` too, per the issue).

I confirmed with a minimal isolated mypy repro that the issue's own suggested fix (parameterizing the four classes as `Middleware[Any, Any]`) does **not** by itself resolve this -- it changes the error but doesn't fix it. The actual fix needed is at the `function_node` signature level (see below).

## Fix

1. Parameterize `Retry`, `Timeout`, `MaxCalls`, and `Lock` as `Middleware[Any, Any]` instead of leaving them as bare `Middleware`, matching the more correct design suggested in the issue.
2. Decouple `middleware`'s type in all of `function_node`'s overloads (and its two internal implementations, `_single_function_node` and the runtime `function_node` body) from `_P`/`_TOutput`, typing it as `Iterable[Middleware[Any, Any]]` instead. This matches the style already used in the existing `List[Callable]` overload in the same file, and is more correct anyway: middleware is documented as slot-agnostic (it only re-invokes `call` and never inspects the decorated function's specific signature), so it was never correct for its generic parameters to be unified with the function's.

Also adds a `combined` snippet to `docs/scripts/prebuilt_middleware.py` (mypy-checked in CI via `scripts/docs_validation.sh`) that combines two prebuilt middleware in one `middleware=[...]` list, as a regression guard, since none of the existing per-middleware snippets combined two in one list.

## Testing

- `mypy` on `docs/scripts/` (the exact command `scripts/docs_validation.sh` runs) is clean. Before the fix, the new `combined` snippet reproduced the exact `def (*Never, **Never) -> ...` error from the issue.
- Full `tests/unit_tests/middlewares`, `tests/integration_tests/middlewares`, and `tests/unit_tests/built_nodes` suites pass (168 + 168 tests, no regressions).
- `ruff check .` and `ruff format --check .` both pass cleanly from the repo root.