### PR TITLE
ci: scope the e2e workflow token to contents: read

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,6 +3,9 @@ name: Run E2E Tests (Manual)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.10"
 


### PR DESCRIPTION
## Summary

`.github/workflows/e2e.yaml` was the only workflow without a `permissions:` block, so its `GITHUB_TOKEN` inherited the repository default instead of the least privilege the job needs. The job only checks out the repo and runs pytest, so `contents: read` covers it.

Brings it in line with `pr_tests.yaml`, `push_main.yaml`, `release_docs.yaml` and `release_package.yaml`, which all scope their token already.

closes #1549

## Type of change

- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

No Python touched. The workflow is `workflow_dispatch` only, so verification is a manual run.