### PR TITLE
fix(hil): sanitize chat UI message rendering

### DIFF
--- a/packages/railtracks/src/railtracks/utils/visuals/browser/chat.css
+++ b/packages/railtracks/src/railtracks/utils/visuals/browser/chat.css
@@ -1038,6 +1038,11 @@ template {
     word-wrap: break-word;
 }
 
+/* Messages rendered as plain text keep their line breaks without markup. */
+.message-text.plain-text {
+    white-space: pre-wrap;
+}
+
 /* Upload modal visibility states */
 .upload-modal.modal-visible {
     display: flex;

--- a/packages/railtracks/src/railtracks/utils/visuals/browser/chat.html
+++ b/packages/railtracks/src/railtracks/utils/visuals/browser/chat.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="chat.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/css/all.min.css" integrity="sha512-DxV+EoADOkOygM4IR9yXP8Sb2qwgidEmeqAEmDKIOfPRQZOWbXCzLC6vjbZyy0vPisbH2SyW27+ddLVCN+OMzQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 </head>
 <body>
     <div class="main-container">

--- a/packages/railtracks/src/railtracks/utils/visuals/browser/chat.js
+++ b/packages/railtracks/src/railtracks/utils/visuals/browser/chat.js
@@ -163,10 +163,7 @@ function handleSSEMessage(data) {
             break;
             
         case 'error':
-            const errorIcon = document.createElement('i');
-            errorIcon.className = 'fa-solid fa-circle-xmark status-icon-error';
-            const errorMessage = `${errorIcon.outerHTML} ${data.data}`;
-            addMessage('system', errorMessage, data.timestamp);
+            addMessage('system', data.data, data.timestamp, 'fa-solid fa-circle-xmark status-icon-error');
             setProcessing(false);
             endButton.disabled = false;
             break;
@@ -184,33 +181,53 @@ function handleSSEMessage(data) {
     }
 }
 
-function addMessage(type, content, timestamp) {
+// Render markdown for assistant messages, sanitizing the result before it reaches the
+// DOM. Model output is attacker-influenceable through the content an agent reads, so it
+// is never trusted markup. Returns null when either library is unavailable, which leaves
+// the caller on the plain-text path.
+function renderMarkdown(content) {
+    if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') {
+        return null;
+    }
+    try {
+        return DOMPurify.sanitize(marked.parse(content));
+    } catch (error) {
+        console.warn('Markdown rendering failed, falling back to plain text:', error);
+        return null;
+    }
+}
+
+function addMessage(type, content, timestamp, iconClass) {
     const messagesContainer = document.getElementById('chatMessages');
     const template = document.getElementById('messageTemplate');
     const messageElement = template.content.cloneNode(true);
-    
+
     const messageDiv = messageElement.querySelector('.message');
     messageDiv.classList.add(type);
-    
+
     const messageText = messageElement.querySelector('.message-text');
     const timestampElement = messageElement.querySelector('.timestamp');
-    
-    // Parse markdown for assistant messages using marked.js, keep plain text for user/system messages
-    let processedContent;
-    if (type === 'assistant' && typeof marked !== 'undefined') {
-        try {
-            processedContent = marked.parse(content);
-        } catch (error) {
-            console.warn('Markdown parsing failed, falling back to plain text:', error);
-            processedContent = content.replace(/\n/g, '<br>');
-        }
-    } else {
-        processedContent = content.replace(/\n/g, '<br>');
+
+    if (iconClass) {
+        const icon = document.createElement('i');
+        icon.className = iconClass;
+        messageText.appendChild(icon);
+        messageText.appendChild(document.createTextNode(' '));
     }
-    
-    messageText.innerHTML = processedContent;
+
+    const rendered = type === 'assistant' ? renderMarkdown(content) : null;
+    if (rendered === null) {
+        // Plain text, so the CSS class supplies the line breaks that markup would.
+        messageText.classList.add('plain-text');
+        messageText.appendChild(document.createTextNode(content));
+    } else {
+        const markdownBody = document.createElement('span');
+        markdownBody.innerHTML = rendered;
+        messageText.appendChild(markdownBody);
+    }
+
     timestampElement.textContent = timestamp || new Date().toLocaleTimeString();
-    
+
     messagesContainer.appendChild(messageElement);
     
     // Auto-scroll to bottom with smooth behavior
@@ -347,9 +364,7 @@ async function sendMessage() {
         
     } catch (error) {
         console.error('Error sending message:', error);
-        const errorIcon = document.createElement('i');
-        errorIcon.className = 'fa-solid fa-circle-xmark status-icon-error';
-        addMessage('system', `${errorIcon.outerHTML} Error: ${error.message}`, new Date().toLocaleTimeString());
+        addMessage('system', `Error: ${error.message}`, new Date().toLocaleTimeString(), 'fa-solid fa-circle-xmark status-icon-error');
         setProcessing(false);
         endButton.disabled = false;
     }
@@ -398,15 +413,11 @@ async function endSession(event) {
         }
         
         console.log('Shutdown triggered successfully:', result);
-        const successIcon = document.createElement('i');
-        successIcon.className = 'fa-solid fa-circle-check status-icon-success';
-        addMessage('system', `${successIcon.outerHTML} Server shutting down`, new Date().toLocaleTimeString());
+        addMessage('system', 'Server shutting down', new Date().toLocaleTimeString(), 'fa-solid fa-circle-check status-icon-success');
         
     } catch (error) {
         console.error('Error shutting down:', error);
-        const errorIcon = document.createElement('i');
-        errorIcon.className = 'fa-solid fa-circle-xmark status-icon-error';
-        addMessage('system', `${errorIcon.outerHTML} Error shutting down: ${error.message}`, new Date().toLocaleTimeString());
+        addMessage('system', `Error shutting down: ${error.message}`, new Date().toLocaleTimeString(), 'fa-solid fa-circle-xmark status-icon-error');
         
         // Re-enable UI elements on error
         endButton.disabled = false;


### PR DESCRIPTION
## Summary

`addMessage()` in the local HIL chat UI wrote message content straight to `innerHTML`. Assistant messages went through `marked.parse()` with no sanitizer, and user/system messages were the raw string with `\n` spliced into `<br>` tags, so both paths put untrusted text into the DOM as live markup. Model output is the one that matters: an agent that reads an injected tool result or web page can be steered into emitting `<img src=x onerror=...>`, which then runs same-origin with the local server and its `/send` and `/shutdown` endpoints.

Changes:

- Load DOMPurify next to `marked`, and run the rendered markdown through it in a new `renderMarkdown()` helper.
- `renderMarkdown()` returns `null` when either library is missing or parsing throws, which drops the caller onto the plain-text path. Previously that fallback still went through `innerHTML`, so an offline page with no `marked` rendered raw content.
- User and system messages now go in as a text node, with `.message-text.plain-text { white-space: pre-wrap; }` supplying the line breaks the `<br>` splice used to.
- The four `system` callers passed `icon.outerHTML` inside the message string, which no longer works once that path stops interpreting HTML. `addMessage()` takes an optional `iconClass` and builds the `<i>` element itself.

closes #1548

## Type of change

- [x] Bug fix

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

Frontend-only, no Python touched and no test suite covers these assets. Verified with `node --check`; the rendering itself wants a manual pass over a HIL session, checking that assistant markdown still formats, that multi-line user input keeps its line breaks, and that the error and shutdown system messages still show their icons.