### PR TITLE
docs: soften model-specific references in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,7 @@ where each concept lives internally, plus a doc link for the how-to:
 ## Code conventions
 
 See `.claude/skills/code-style/SKILL.md` for this repo's code-style conventions. It's a
-project-scoped Claude Code skill: Claude auto-invokes it based on its description whenever it's writing or
+project-scoped coding-assistant skill: the assistant auto-invokes it based on its description whenever it's writing or
 editing code here, which is a model-driven nudge from the skill matching, not a hard-enforced hook, so
 still sanity-check the diff against it yourself.
 

--- a/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
+++ b/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
@@ -40,7 +40,7 @@ rt.llm.OpenAICompatibleProvider(
 4. **Define the agent** — call `rt.agent_node()` with (note: it returns a class/type, so use PascalCase for the variable name):
    - A descriptive name
    - `tool_nodes` listing the tools (if any), **or** `output_schema` as a Pydantic `BaseModel` for structured output — one or the other, never both (passing both raises `NodeCreationError`)
-   - `llm` — default to `rt.llm.AnthropicLLM("claude-sonnet-4-6")` unless the user specifies otherwise
+   - `llm` — pick a model from the providers above for the agent; ask the user which LLM they use rather than defaulting to a specific one
    - `system_message` — a clear, specific system prompt
 5. **Wrap in a Flow** — create `rt.Flow(name="...", entry_point=agent)` for simple cases. For multi-step or multi-agent workflows, define an `async def` function as the entry point and use `await rt.call(agent, ...)` inside it.
 6. **Add invocation code** — include a `if __name__ == "__main__":` block that calls `flow.invoke(...)` with a representative example so the user can run it immediately.

--- a/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
+++ b/packages/railtracks/src/railtracks/cli/skills/agent-builder.md
@@ -40,7 +40,7 @@ rt.llm.OpenAICompatibleProvider(
 4. **Define the agent** — call `rt.agent_node()` with (note: it returns a class/type, so use PascalCase for the variable name):
    - A descriptive name
    - `tool_nodes` listing the tools (if any), **or** `output_schema` as a Pydantic `BaseModel` for structured output — one or the other, never both (passing both raises `NodeCreationError`)
-   - `llm` — pick a model from the providers above for the agent; ask the user which LLM they use rather than defaulting to a specific one
+   - `llm` — follow the repo's current convention and available keys; otherwise ask the user which LLM to use
    - `system_message` — a clear, specific system prompt
 5. **Wrap in a Flow** — create `rt.Flow(name="...", entry_point=agent)` for simple cases. For multi-step or multi-agent workflows, define an `async def` function as the entry point and use `await rt.call(agent, ...)` inside it.
 6. **Add invocation code** — include a `if __name__ == "__main__":` block that calls `flow.invoke(...)` with a representative example so the user can run it immediately.


### PR DESCRIPTION
## What

Two doc edits to soften model-specific instructions:

- `AGENTS.md` — generalize "project-scoped Claude Code skill: Claude auto-invokes it" to "project-scoped coding-assistant skill: the assistant auto-invokes it".
- `cli/skills/agent-builder.md` — stop defaulting the `llm` instruction to `rt.llm.AnthropicLLM("claude-sonnet-4-6")`; instead ask the user which LLM they use, pointing at the providers list above.

## Why

Fixes #1547. The docs assumed the reader works with Claude Code / Anthropic, which isn't true for everyone.

## How verified

Docs-only change; reviewed the full diff. No code paths affected.