### PR TITLE
fix: preserve function node middleware type inference

### DIFF
--- a/docs/scripts/function_node_typing.py
+++ b/docs/scripts/function_node_typing.py
@@ -1,0 +1,161 @@
+"""Static regression cases for ``function_node`` middleware inference."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Awaitable, Callable
+
+import railtracks as rt
+from railtracks.middleware import Verdict
+from railtracks.prebuilt.middleware import (
+    Lock,
+    MaxCalls,
+    Retry,
+    Timeout,
+    post_verifier,
+    pre_verifier,
+)
+from typing_extensions import assert_type
+
+neutral_middleware = [
+    Retry(max_tries=1),
+    Timeout(seconds=5),
+    MaxCalls(max_calls=3),
+    Lock(),
+]
+
+
+@rt.function_node()
+def empty_factory(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=[])
+def empty_list(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=[Retry(max_tries=1)])
+def one_prebuilt(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=neutral_middleware)
+def reusable_for_strings(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=neutral_middleware)
+def reusable_for_ints(value: int) -> str:
+    return str(value)
+
+
+@rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
+async def async_prebuilt(value: str) -> int:
+    return len(value)
+
+
+def approve_input(value: str) -> Verdict:
+    return Verdict(accepted=bool(value))
+
+
+def approve_output(result: int, value: str) -> Verdict[int]:
+    return Verdict(accepted=result == len(value))
+
+
+@rt.wrap_node
+async def custom_middleware(call: Callable[[str], Awaitable[int]], value: str) -> int:
+    return await call(value)
+
+
+@rt.function_node(middleware=[pre_verifier(approve_input)])
+def pre_only(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=[post_verifier(approve_output)])
+def post_only(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=[Retry(max_tries=1), pre_verifier(approve_input)])
+def pre_mixed(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(middleware=[post_verifier(approve_output), Timeout(seconds=5)])
+def post_mixed(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(
+    middleware=[
+        Retry(max_tries=1),
+        pre_verifier(approve_input),
+        custom_middleware,
+        post_verifier(approve_output),
+        Timeout(seconds=5),
+    ]
+)
+def fully_mixed(value: str) -> int:
+    return len(value)
+
+
+def direct_target(value: str) -> int:
+    return len(value)
+
+
+direct = rt.function_node(direct_target, middleware=neutral_middleware)
+
+assert_type(empty_factory("value"), int)
+assert_type(empty_list("value"), int)
+assert_type(one_prebuilt("value"), int)
+assert_type(reusable_for_strings("value"), int)
+assert_type(reusable_for_ints(1), str)
+assert_type(pre_only("value"), int)
+assert_type(post_only("value"), int)
+assert_type(pre_mixed("value"), int)
+assert_type(post_mixed("value"), int)
+assert_type(fully_mixed("value"), int)
+assert_type(direct("value"), int)
+
+
+async def check_async_signature() -> None:
+    assert_type(await async_prebuilt("value"), int)
+
+
+def approve_wrong_input(value: int) -> Verdict:
+    return Verdict(accepted=value > 0)
+
+
+def approve_wrong_output(result: str, value: str) -> Verdict[str]:
+    return Verdict(accepted=result == value)
+
+
+def approve_wrong_argument(result: int, value: int) -> Verdict[int]:
+    return Verdict(accepted=result == value)
+
+
+@rt.function_node(  # type: ignore[arg-type]
+    middleware=[pre_verifier(approve_wrong_input)]
+)
+def rejected_pre_verifier(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(  # type: ignore[arg-type]
+    middleware=[Retry(max_tries=1), post_verifier(approve_wrong_output)]
+)
+def rejected_mixed_verifier(value: str) -> int:
+    return len(value)
+
+
+@rt.function_node(  # type: ignore[arg-type]
+    middleware=[post_verifier(approve_wrong_argument), Timeout(seconds=5)]
+)
+def rejected_post_argument(value: str) -> int:
+    return len(value)
+
+
+if TYPE_CHECKING:
+    empty_factory(1)  # type: ignore[arg-type]
+    rt.function_node(direct_target, middleware=[pre_verifier(approve_wrong_input)])  # type: ignore[misc, arg-type]

--- a/docs/scripts/prebuilt_middleware.py
+++ b/docs/scripts/prebuilt_middleware.py
@@ -74,6 +74,21 @@ LockedAgent = rt.agent_node(
 # --8<-- [end: lock]
 
 
+# --8<-- [start: combining]
+import railtracks as rt
+from railtracks.prebuilt.middleware import Retry, Timeout
+
+
+# Multiple prebuilt middleware can be combined in one middleware= list.
+# Previously, mixing any two caused mypy to collapse _P to Never (issue #1538).
+@rt.function_node(middleware=[Retry(3), Timeout(seconds=30)])
+def fetch_data(url: str) -> str:
+    return url  # placeholder
+
+
+# --8<-- [end: combining]
+
+
 # --8<-- [start: context_injection]
 import railtracks as rt
 from railtracks.prebuilt.middleware import ContextInjection

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -6,6 +6,7 @@ import inspect
 import warnings
 from types import BuiltinFunctionType
 from typing import (
+    Any,
     Callable,
     Coroutine,
     Iterable,
@@ -78,7 +79,7 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any]] | None = None,
 ) -> Callable[
     [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
     RTFunction[_P, _TOutput],

--- a/packages/railtracks/src/railtracks/built_nodes/function/node.py
+++ b/packages/railtracks/src/railtracks/built_nodes/function/node.py
@@ -12,14 +12,17 @@ from typing import (
     Iterable,
     List,
     ParamSpec,
+    Protocol,
     TypeVar,
     cast,
     overload,
 )
 
+from typing_extensions import Never
+
 from railtracks.built_nodes.function.base import RTFunction
 from railtracks.exceptions import NodeCreationError
-from railtracks.middleware.core import Middleware
+from railtracks.middleware.core import Middleware, _MiddlewareSignature
 from railtracks.nodes.manifest import ToolManifest
 from railtracks.nodes.nodes import Node
 from railtracks.validation.node_creation.validation import (
@@ -32,6 +35,57 @@ from .node_builder import FunctionNodeBuilder
 
 _TOutput = TypeVar("_TOutput")
 _P = ParamSpec("_P")
+_TDecoratedOutput = TypeVar("_TDecoratedOutput")
+_PDecorated = ParamSpec("_PDecorated")
+_Constraint = TypeVar("_Constraint", covariant=True)
+
+
+class _FunctionNodeDecorator(Protocol[_Constraint]):
+    """Apply deferred, argument-only, or complete middleware constraints."""
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        self: _FunctionNodeDecorator[Never],
+        func: Callable[_PDecorated, Coroutine[None, None, _TDecoratedOutput]],
+        /,
+    ) -> CallableAsyncRTFunction[_PDecorated, _TDecoratedOutput]: ...
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        self: _FunctionNodeDecorator[_MiddlewareSignature[_P, Never]],
+        func: Callable[_P, Coroutine[None, None, _TDecoratedOutput]],
+        /,
+    ) -> CallableAsyncRTFunction[_P, _TDecoratedOutput]: ...
+
+    @overload
+    def __call__(  # type: ignore[overload-overlap]
+        self: _FunctionNodeDecorator[_MiddlewareSignature[_P, _TOutput]],
+        func: Callable[_P, Coroutine[None, None, _TOutput]],
+        /,
+    ) -> CallableAsyncRTFunction[_P, _TOutput]: ...
+
+    @overload
+    def __call__(
+        self: _FunctionNodeDecorator[Never],
+        func: Callable[_PDecorated, _TDecoratedOutput],
+        /,
+    ) -> CallableSyncRTFunction[_PDecorated, _TDecoratedOutput]: ...
+
+    @overload
+    def __call__(
+        self: _FunctionNodeDecorator[_MiddlewareSignature[_P, Never]],
+        func: Callable[_P, _TDecoratedOutput],
+        /,
+    ) -> CallableSyncRTFunction[_P, _TDecoratedOutput]: ...
+
+    @overload
+    def __call__(
+        self: _FunctionNodeDecorator[_MiddlewareSignature[_P, _TOutput]],
+        func: Callable[_P, _TOutput],
+        /,
+    ) -> CallableSyncRTFunction[_P, _TOutput]: ...
+
+    def __call__(self, func: Callable[..., Any], /) -> RTFunction[..., Any]: ...
 
 
 # note there is an intentional overlap in overloads
@@ -44,7 +98,8 @@ def function_node(  # pyright: ignore[reportOverlappingOverload]
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any, _MiddlewareSignature[_P, _TOutput]]]
+    | None = None,
 ) -> CallableAsyncRTFunction[_P, _TOutput]: ...
 
 
@@ -55,7 +110,8 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[_P, _TOutput]] | None = None,
+    middleware: Iterable[Middleware[Any, Any, _MiddlewareSignature[_P, _TOutput]]]
+    | None = None,
 ) -> CallableSyncRTFunction[_P, _TOutput]:
     pass
 
@@ -79,11 +135,32 @@ def function_node(
     *,
     name: str | None = None,
     manifest: ToolManifest | None = None,
-    middleware: Iterable[Middleware[Any, Any]] | None = None,
-) -> Callable[
-    [Callable[_P, Coroutine[None, None, _TOutput]] | Callable[_P, _TOutput]],
-    RTFunction[_P, _TOutput],
-]:
+    middleware: None = None,
+) -> _FunctionNodeDecorator[Never]:
+    pass
+
+
+@overload
+def function_node(
+    func: None = None,
+    /,
+    *,
+    name: str | None = None,
+    manifest: ToolManifest | None = None,
+    middleware: Iterable[Middleware[Any, Any, Never]],
+) -> _FunctionNodeDecorator[Never]:
+    pass
+
+
+@overload
+def function_node(
+    func: None = None,
+    /,
+    *,
+    name: str | None = None,
+    manifest: ToolManifest | None = None,
+    middleware: Iterable[Middleware[Any, Any, _Constraint]],
+) -> _FunctionNodeDecorator[_Constraint]:
     pass
 
 

--- a/packages/railtracks/src/railtracks/middleware/core.py
+++ b/packages/railtracks/src/railtracks/middleware/core.py
@@ -13,12 +13,32 @@ from typing import (
     overload,
 )
 
+from typing_extensions import TypeVar as TypeVarWithDefault
+
 from railtracks.events.middleware import MiddlewareCreationEvent
 from railtracks.events.send import emit
 from railtracks.utils.logging.create import get_rt_logger
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
+_SignatureOutput = TypeVar("_SignatureOutput", covariant=True)
+
+
+class _MiddlewareSignature(Generic[_P, _SignatureOutput]):
+    """Carry a middleware's callable constraints through collection inference.
+
+    The output is covariant so ``Never`` can represent an unconstrained output,
+    as needed by middleware that only inspects call arguments.
+    """
+
+
+# The default preserves the public two-parameter ``Middleware[P, R]`` form while
+# allowing slot-agnostic middleware to opt out with a third argument of ``Never``.
+_Constraint = TypeVarWithDefault(
+    "_Constraint",
+    covariant=True,
+    default=_MiddlewareSignature[_P, _R],
+)
 
 
 def _require_callable(fn: Callable, role: str) -> None:
@@ -37,7 +57,7 @@ def _require_async(fn: Callable, role: str) -> None:
 logger = get_rt_logger(__name__)
 
 
-class Middleware(Generic[_P, _R]):
+class Middleware(Generic[_P, _R, _Constraint]):
     """Execution-control middleware: wraps a callable to control how it is invoked.
 
     Built from an async call-style function ``fn(call, *args, **kwargs)`` where

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from typing_extensions import Never
+
 from railtracks.middleware.core import Middleware
 
 
-class Lock(Middleware[Any, Any]):
+class Lock(Middleware[Any, Any, Never]):
     """Serialize concurrent invocations of the wrapped call.
 
     Reuse one instance across nodes that must not execute concurrently.

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Lock(Middleware):
+class Lock(Middleware[Any, Any]):
     """Serialize concurrent invocations of the wrapped call.
 
     Reuse one instance across nodes that must not execute concurrently.

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from railtracks.middleware.core import Middleware
 
 
-class MaxCalls(Middleware):
+class MaxCalls(Middleware[Any, Any]):
     """Fail the wrapped call once it has been invoked ``max_calls`` times.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+from typing_extensions import Never
+
 from railtracks.middleware.core import Middleware
 
 
-class MaxCalls(Middleware[Any, Any]):
+class MaxCalls(Middleware[Any, Any, Never]):
     """Fail the wrapped call once it has been invoked ``max_calls`` times.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/pre_verifier.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/pre_verifier.py
@@ -4,7 +4,9 @@ import asyncio
 import functools
 from typing import Any, Awaitable, Callable, ParamSpec, TypeVar, overload
 
-from railtracks.middleware.core import Middleware, wrap_node
+from typing_extensions import Never
+
+from railtracks.middleware.core import Middleware, _MiddlewareSignature, wrap_node
 from railtracks.middleware.verdict import Verdict, VerifierRejectedError
 from railtracks.utils.logging.create import get_rt_logger
 from railtracks.utils.unpack import unpack_async_sync
@@ -17,6 +19,7 @@ _R = TypeVar("_R")
 _ApproveFn = Callable[_P, Verdict | Awaitable[Verdict]]
 
 
+# A pre-verifier constrains the call arguments but leaves the node output free.
 @overload
 def pre_verifier(
     approve_fn: _ApproveFn[_P],
@@ -24,11 +27,13 @@ def pre_verifier(
     *,
     timeout: float | None = None,
     name: str | None = None,
-) -> Middleware[_P, Any]: ...
+) -> Middleware[_P, Any, _MiddlewareSignature[_P, Never]]: ...
 @overload
 def pre_verifier(
     *, timeout: float | None = None, name: str | None = None
-) -> Callable[[_ApproveFn[_P]], Middleware[_P, Any]]: ...
+) -> Callable[
+    [_ApproveFn[_P]], Middleware[_P, Any, _MiddlewareSignature[_P, Never]]
+]: ...
 
 
 def pre_verifier(
@@ -37,7 +42,10 @@ def pre_verifier(
     *,
     timeout: float | None = None,
     name: str | None = None,
-) -> Middleware[_P, Any] | Callable[[_ApproveFn[_P]], Middleware[_P, Any]]:
+) -> (
+    Middleware[_P, Any, _MiddlewareSignature[_P, Never]]
+    | Callable[[_ApproveFn[_P]], Middleware[_P, Any, _MiddlewareSignature[_P, Never]]]
+):
     """Build a node-verification middleware around ``approve_fn`` that gates a call
     BEFORE it runs.
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from typing import Any
+
 from railtracks.llm.retries import ExponentialRetry, RetryApproach
 from railtracks.middleware.core import Middleware
 
 
-class Retry(Middleware):
+class Retry(Middleware[Any, Any]):
     """Retry the wrapped call when it raises a transient error.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/retry.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import Never
+
 from railtracks.llm.retries import ExponentialRetry, RetryApproach
 from railtracks.middleware.core import Middleware
 
 
-class Retry(Middleware[Any, Any]):
+class Retry(Middleware[Any, Any, Never]):
     """Retry the wrapped call when it raises a transient error.
 
     Slot-agnostic: works both as node middleware (``middleware=``) and as model

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
 
-class Timeout(Middleware):
+class Timeout(Middleware[Any, Any]):
     """Fail the wrapped call when it runs longer than ``seconds``.
 
     The timeout applies to the complete wrapped call. When the deadline expires,

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/timeout.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from typing_extensions import Never
+
 from railtracks.middleware.core import Middleware
 
 
-class Timeout(Middleware[Any, Any]):
+class Timeout(Middleware[Any, Any, Never]):
     """Fail the wrapped call when it runs longer than ``seconds``.
 
     The timeout applies to the complete wrapped call. When the deadline expires,

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -9,6 +9,7 @@ import asyncio
 
 import pytest
 import railtracks as rt
+from railtracks.prebuilt.middleware import MaxCalls, Retry, Timeout
 
 
 def test_function_node_middleware_runs():
@@ -145,3 +146,38 @@ def test_after_replaces_return_value_on_success():
             return await rt.call(five)
 
     assert asyncio.run(top_level()) == 50
+
+
+def test_multiple_prebuilt_middleware_in_one_list():
+    """Two prebuilt middleware in a single middleware= list must not collapse
+    _P to Never.  Regression for #1538: Retry, Timeout, and MaxCalls all
+    subclassed the bare Middleware generic, which mypy resolved as
+    Middleware[Never, Never] under invariant generics, breaking list-element
+    unification when combining any two of them."""
+
+    @rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
+    def add(x: str) -> str:
+        return x
+
+    async def top_level():
+        with rt.Session():
+            return await rt.call(add, "hello")
+
+    assert asyncio.run(top_level()) == "hello"
+
+
+def test_three_different_prebuilt_middleware_in_one_list():
+    """Combining three distinct prebuilt middleware in one list must work both
+    at runtime and under static analysis (no Never collapse)."""
+
+    @rt.function_node(
+        middleware=[Retry(max_tries=1), Timeout(seconds=5), MaxCalls(max_calls=3)]
+    )
+    def echo(x: int) -> int:
+        return x
+
+    async def top_level():
+        with rt.Session():
+            return await rt.call(echo, 42)
+
+    assert asyncio.run(top_level()) == 42

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -149,11 +149,7 @@ def test_after_replaces_return_value_on_success():
 
 
 def test_multiple_prebuilt_middleware_in_one_list():
-    """Two prebuilt middleware in a single middleware= list must not collapse
-    _P to Never.  Regression for #1538: Retry, Timeout, and MaxCalls all
-    subclassed the bare Middleware generic, which mypy resolved as
-    Middleware[Never, Never] under invariant generics, breaking list-element
-    unification when combining any two of them."""
+    """Two prebuilt middleware in one list must compose around a function node."""
 
     @rt.function_node(middleware=[Retry(max_tries=1), Timeout(seconds=5)])
     def add(x: str) -> str:
@@ -167,8 +163,7 @@ def test_multiple_prebuilt_middleware_in_one_list():
 
 
 def test_three_different_prebuilt_middleware_in_one_list():
-    """Combining three distinct prebuilt middleware in one list must work both
-    at runtime and under static analysis (no Never collapse)."""
+    """Three distinct prebuilt middleware must compose in one list."""
 
     @rt.function_node(
         middleware=[Retry(max_tries=1), Timeout(seconds=5), MaxCalls(max_calls=3)]

--- a/scripts/docs_validation.sh
+++ b/scripts/docs_validation.sh
@@ -12,8 +12,10 @@ if [ ! -d "docs/scripts" ]; then
     exit 1
 fi
 
-DISABLE_CODES="top-level-await"
-mypy --disable-error-code=top-level-await --disable-error-code=import-untyped --disable-error-code=empty-body --disable-error-code=var-annotated docs/scripts/
-
-
-
+mypy \
+    --warn-unused-ignores \
+    --disable-error-code=top-level-await \
+    --disable-error-code=import-untyped \
+    --disable-error-code=empty-body \
+    --disable-error-code=var-annotated \
+    docs/scripts/


### PR DESCRIPTION
## Summary

Fixes #1538.

`Retry`, `Timeout`, `MaxCalls`, and `Lock` can wrap any node signature, so this keeps their `Middleware[Any, Any]` parameterization from #1541. The decorator-factory overload still needs to defer inference until it receives the decorated function without losing the signature checks from verifier and custom middleware.

This patch carries that signature constraint separately from the middleware's runtime parameter and return slots. The prebuilt middleware uses an unconstrained carrier; signature-aware middleware keeps its parameter and output constraints. `function_node(...)` returns a private overloaded callable protocol, which preserves the exact sync or async function signature.

The regression fixture covers empty factories, reusable prebuilt lists, mixed verifier lists, async functions, direct calls, and deliberately invalid verifier signatures. `docs_validation.sh` now uses `--warn-unused-ignores`, so widening the factory back to `Any` makes the negative cases fail CI.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint and format pass (`ruff check .` and `ruff format --check .`)
- [x] Tests added and pass locally
- [x] Docs updated with a mypy-checked regression fixture
- [x] No breaking changes

## Notes

The first commit is Christian-Sidak's work from #1541 with the original authorship preserved. The follow-up commit replaces the factory-wide `Any` annotation with the constraint carrier and adds the static coverage.

Local checks:

- mypy 1.19.1: all 48 files under `docs/scripts`
- mypy 2.3.1: `docs/scripts/function_node_typing.py`
- fixture with the expected ignores removed: six errors under both mypy versions
- middleware tests: 104 passed
- Ruff, dependency ordering, the executable fixture, and `git diff --check`
