### PR TITLE
docs: position railtracks as an agent harness framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 ## Repository Overview
 
-Railtracks (`rt`) is a Python framework for building agentic systems: agents, tools, and multi-step flows
-defined entirely in standard Python (no YAML/DSLs). This is a `uv` workspace monorepo:
+Railtracks (`rt`) is a Python framework for building agent harnesses: the loop, tools, context, controls,
+and record around a model, defined entirely in standard Python (no YAML/DSLs). This is a `uv` workspace
+monorepo:
 
 ```
 Root
@@ -75,6 +76,10 @@ For usage patterns (how to define tools/agents/flows, structured output, agent-a
 users via `railtracks add claude:agent-builder`) or the docs linked below; don't re-teach usage here. Just
 where each concept lives internally, plus a doc link for the how-to:
 
+- **Harness**: not a class, the assembled whole (loop + tool surface + context + controls + record). The
+  page mapping each part to the primitive that covers it is `docs/documentation/harness/overview.md`
+  ([Agent Harness](https://docs.railtracks.org/documentation/harness/overview/)), with runnable versions
+  in `examples/harness/`. Use it as the framing when someone asks "how do I build an agent that does X".
 - **Tool** (`rt.function_node`): `built_nodes/function/node.py`.
   [Function Tools](https://docs.railtracks.org/documentation/agent_design/tools/function_tools/).
 - **Agent** (`rt.agent_node`): `built_nodes/llm/node.py`; always a single dynamically built node, no

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Five parts. Take the ones your problem needs, wire them together in plain Python
 | **Tool surface** | What the agent can actually do | `rt.function_node`, `rt.ToolManifest` for agents-as-tools, `rt.connect_mcp` for MCP servers |
 | **Context** | What the model sees on this turn | `system_message`, `rt.context`, todo and key-value memory toolsets, retrieval |
 | **Controls** | What it's allowed to do, and how much of it | `MaxCalls`, `Timeout`, `Retry`, `Lock`, human-in-the-loop verifiers, guardrails |
-| **Record** | What happened, and whether you can replay it | Session state, `railtracks viz`, `rt.evaluate` |
+| **Record** | What happened, and whether you can replay it | Session state, `railtracks viz`, `rt.evaluations.evaluate` |
 
 The shapes this usually takes:
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@
   </a>
 </p>
 
+<p align="center">
+  <b>Own the AI!</b><br>
+  Assemble a custom agent harness in plain Python. The loop, the tools, the context, the controls, the record. All yours.
+</p>
+
 ## What is Railtracks?
 
-Railtracks is a Python framework for building agentic systems. Agent behavior, tools, and multi-step flows are defined entirely in standard Python using the control flow and abstractions you already know.
+Railtracks is a Python **agent framework** for building your own **harness**. Every piece is an ordinary Python object you assemble yourself: a tool-calling loop, a tool surface of functions, sub-agents and MCP servers, context management, permission and budget controls, and a replayable record of every run. No YAML, no DSL, no black-box runtime.
 
 
 ```python
@@ -55,6 +60,28 @@ print(result.text)  # "Based on the current data, it's sunny in Paris!"
 ```
 
 Execution order, branching, and looping are expressed using standard Python control flow.
+
+## What is an agent harness?
+
+Everything around the model call. The model brings judgment. The harness brings the loop that keeps calling it, the tools it can reach, what lands in its context, the limits on what it may do, and the record of what it did. Change your model tomorrow and the harness is what you still own.
+
+Five parts. Take the ones your problem needs, wire them together in plain Python, leave the rest out.
+
+| Part | What it decides | Railtracks primitives |
+|---|---|---|
+| **Loop** | When the agent keeps going, and when it's done | `rt.agent_node` runs the tool-calling loop; `rt.Flow` and `rt.call` drive multi-step work |
+| **Tool surface** | What the agent can actually do | `rt.function_node`, `rt.ToolManifest` for agents-as-tools, `rt.connect_mcp` for MCP servers |
+| **Context** | What the model sees on this turn | `system_message`, `rt.context`, todo and key-value memory toolsets, retrieval |
+| **Controls** | What it's allowed to do, and how much of it | `MaxCalls`, `Timeout`, `Retry`, `Lock`, human-in-the-loop verifiers, guardrails |
+| **Record** | What happened, and whether you can replay it | Session state, `railtracks viz`, `rt.evaluate` |
+
+The shapes this usually takes:
+
+- **Coding harness.** Read, edit, and shell tools, a todo list that survives across turns, human approval on anything that touches the working tree. Runnable in [`examples/harness/coding_harness.py`](examples/harness/coding_harness.py).
+- **Research harness.** Search and fetch, retrieval over what it has gathered, memory for findings, a structured-output pass to force the report into a schema.
+- **Operations harness.** A few high-consequence tools, each behind a real approver, with an audit trail you can hand to someone else.
+
+Start with the [Agent Harness guide](https://docs.railtracks.org/documentation/harness/overview/), or run the [harness examples](examples/harness) as they are: a read-only harness in under 80 lines, and a coding harness whose file writes and shell commands each stop for your approval.
 
 ## Why Railtracks?
 

--- a/docs/documentation/agent_design/tools/prebuilt/todos.md
+++ b/docs/documentation/agent_design/tools/prebuilt/todos.md
@@ -89,7 +89,7 @@ The `callback` parameter fires every time a new todo is added, letting the outer
 --8<-- "docs/scripts/todos.py:todo_callback"
 ```
 
-You can also inspect the todo list directly at any point via the `ToDoToolSet` instance — useful for logging, assertions, or driving downstream logic once the agent finishes.
+You can also inspect the todo list directly at any point via the `ToDoToolSet` instance — useful for logging, assertions, or driving downstream logic once the agent finishes. Every read on the toolset is async, `pretty_dashboard()` included.
 
 ```python
 --8<-- "docs/scripts/todos.py:todo_inspection"

--- a/docs/documentation/harness/overview.md
+++ b/docs/documentation/harness/overview.md
@@ -1,0 +1,119 @@
+# Agent Harness
+
+## What is an agent harness?
+
+An **agent harness** is the code that surrounds a model call. The model brings judgment; the harness brings everything else: the loop that keeps calling it, the tools it can reach, what lands in its context, the limits on what it is allowed to do, and the record of what it actually did. Change your model tomorrow and the harness is what you still own, which is what makes it the part worth owning outright.
+
+Railtracks is an agent harness framework. Every part of that list is an ordinary Python object you assemble yourself, so an agentic harness here is code you can read, step through in a debugger, and unit test; not a runtime you configure from the outside.
+
+## The five parts
+
+| Part | Question it answers | Railtracks primitives |
+|---|---|---|
+| **Loop** | When does the agent keep going, and when is it done? | [`rt.agent_node`](../agent_design/overview.md) runs the tool-calling loop; [`rt.Flow`](../invocation/flows.md) and [`rt.call`](../invocation/call.md) drive multi-step work |
+| **Tool surface** | What can the agent actually do? | [`rt.function_node`](../agent_design/tools/function_tools.md), [`rt.ToolManifest`](../agent_design/tools/agents_as_tools.md), [`rt.connect_mcp`](../agent_design/tools/mcp.md) |
+| **Context** | What does the model see on this turn? | `system_message`, [`rt.context`](../advanced/context.md), [`ToDoToolSet`](../agent_design/tools/prebuilt/todos.md), [`KeyValueMemoryToolSet`](../agent_design/tools/prebuilt/key_value_memory.md), [retrieval](../../retrieval/runtime/quickstart.md) |
+| **Controls** | What is it allowed to do, and how much of it? | [`middleware=` / `model_middleware=`](../agent_design/middleware/overview.md): `MaxCalls`, `Timeout`, `Retry`, `Lock`, [verifiers](../agent_design/middleware/verifiers/overview.md), [guardrails](../agent_design/middleware/guardrails/overview.md) |
+| **Record** | What happened, and can I replay it? | session state, [`railtracks viz`](../../observability/agenthub/local.md), [`rt.evaluate`](../../evaluations/quickstart.md) |
+
+The sections below build one harness up part by part: a repository assistant that reads code, plans its work, and runs shell commands only with permission.
+
+## 1. The loop
+
+An agent with tools is already a loop: the model proposes a tool call, the tool runs, the result goes back into the conversation, and it repeats until the model answers instead of calling a tool. `rt.agent_node` owns that loop, so the smallest useful harness is a model, a prompt, and one tool.
+
+```python
+--8<-- "docs/scripts/documentation/harness.py:loop"
+```
+
+`rt.Flow` is the entry point that runs it: it opens a session, tracks state, and applies run-wide settings like `timeout` and `context`. Inside a node, `rt.call` invokes another node directly, which is how you nest loops (an agent that delegates to sub-agents) or write the outer loop yourself in plain Python when a tool-calling loop is the wrong shape.
+
+## 2. The tool surface
+
+The tool surface *is* the agent's capability. Nothing else in the harness matters as much: an agent with a shell tool can do anything the shell can, and an agent with only a read tool cannot damage anything. Any Python function becomes a tool, and its signature and docstring become the schema the model sees.
+
+```python
+--8<-- "docs/scripts/documentation/harness.py:tools"
+```
+
+`run_shell` above is deliberately left as a plain function rather than a `@rt.function_node`, because a shell tool should not reach the model without a gate on it. Section 4 wraps it before it is handed to an agent.
+
+Two things to get right here:
+
+- **Keep the surface small.** Every tool is context the model spends on every turn and another path it can pick wrongly. Prefer three sharp tools over ten overlapping ones.
+- **Write docstrings for the model, not for reviewers.** The docstring is the prompt for that tool. Say when to use it, what the arguments mean, and what it returns.
+
+Tools do not have to be functions you wrote. [Agents-as-tools](../agent_design/tools/agents_as_tools.md) puts a whole sub-harness behind a single tool call, and [MCP](../agent_design/tools/mcp.md) pulls in tool servers you did not write.
+
+## 3. Context
+
+The model is stateless. Everything it "knows" on a given turn was put there by the harness, and context is finite, so a harness has to decide what earns a place in it. Railtracks gives you three levers:
+
+- **`system_message`** is the standing instructions. Assemble it from parts rather than hardcoding one string; toolsets ship their own guidance via `prompt()`.
+- **Tool-mediated state** lets the agent read and write its own working memory instead of pushing everything into the prompt. `ToDoToolSet` gives it a plan it can revise; `KeyValueMemoryToolSet` gives it facts that survive the run.
+- **`rt.context`** holds run-scoped values your Python code sets and reads, invisible to the model unless you inject them.
+
+```python
+--8<-- "docs/scripts/documentation/harness.py:context"
+```
+
+For large corpora the answer is retrieval rather than a bigger prompt: see the [Retrieval Runtime](../../retrieval/runtime/quickstart.md).
+
+## 4. Controls
+
+Controls are what make a harness safe to point at real systems. In Railtracks they are middleware, applied at two boundaries: `middleware=` wraps the whole node (one call in, one result out) and `model_middleware=` wraps each individual model call inside the loop. The distinction matters for budgets: `MaxCalls(40)` as node middleware allows forty runs of the agent, while the same thing as model middleware caps the agent at forty turns within a single run.
+
+```python
+--8<-- "docs/scripts/documentation/harness.py:controls"
+```
+
+The pieces worth knowing:
+
+| Control | What it does |
+|---|---|
+| [`pre_verifier`](../agent_design/middleware/verifiers/overview.md) | Gates a call **before** it runs. The approval function is any callable: an allowlist, a policy service, another model, or a human at a terminal or webhook. Declining means the tool body never executes. |
+| [`post_verifier`](../agent_design/middleware/verifiers/overview.md) | Gates or rewrites a call's **result** after it ran. Use it to redact, or to confirm output before it propagates. |
+| `MaxCalls` | Hard cap on invocations, so a confused agent cannot loop forever on your budget. |
+| `Timeout` | Wall-clock deadline on a call. |
+| `Retry` | Re-runs transient failures with backoff. |
+| `Lock` | Serialises access to something that cannot take concurrent calls. |
+| [Guardrails](../agent_design/middleware/guardrails/overview.md) | `input_guard` and `output_guard` checks on what goes into and comes out of the model. |
+
+Middleware order is significant: the first entry in the list is the outermost. `pre_verifier` listed before `Timeout` means approval happens outside the deadline, so time spent waiting on a human does not count against the tool's own timeout.
+
+The general rule is to place each control at the narrowest boundary that still catches the problem. Gating the individual shell tool, as above, leaves the agent free to read files without interruption while still requiring a human for anything that mutates state.
+
+## 5. The record
+
+A harness you cannot inspect is a harness you cannot improve. Runs are recorded as session state, so `railtracks viz` replays the full request graph locally: every tool call, its arguments, token usage, and where time went. That same recorded data is what [evaluations](../../evaluations/quickstart.md) score, which is how you tell whether a prompt or tool change actually helped.
+
+```python
+--8<-- "docs/scripts/documentation/harness.py:record"
+```
+
+## How much harness do you need?
+
+Scale the controls to the blast radius of the tools, not to the sophistication of the agent.
+
+| Tool surface | Minimum harness |
+|---|---|
+| Read-only (search, retrieval, public APIs) | Turn budget and timeout. Little else can go wrong. |
+| Writes to systems you own (files, internal databases, tickets) | Add a verifier on the mutating tools, and record every run. |
+| Writes with external effects (payments, emails, production infrastructure) | Human approval on mutating tools, guardrails on inputs and outputs, and an audit trail you can hand to someone else. |
+
+## Harness patterns
+
+- **Coding harness** uses read, edit, and shell tools, a todo list so multi-file work survives across turns, and an allowlist plus human approval on anything that mutates the working tree. See [`examples/harness/`](https://github.com/RailtownAI/railtracks/tree/main/examples/harness).
+- **Research harness** uses search and fetch tools, retrieval over what has been gathered, key-value memory for findings, and a structured-output agent at the end to force the report into a schema. See [Structured Output](../agent_design/structured_extraction.md).
+- **Operations harness** uses a small number of high-consequence tools, each behind `pre_verifier` with a real approver, `Lock` on anything that cannot run concurrently, and a full record of who approved what. See the [Human-in-the-Loop walkthroughs](../../tutorials/walkthroughs/hil_webhook_approval.md).
+
+!!! info "Not an evaluation harness"
+    "Harness" is also used for benchmark runners that score a model on a fixed task set. This page is about the *agent* harness: the production scaffolding a model runs inside. For scoring agent behaviour, see [Evaluations](../../evaluations/preface.md).
+
+## Next steps
+
+- [Quickstart](../getting_started/quickstart.md) to install and run your first agent.
+- [Agent Design](../agent_design/overview.md) for the agent layer in detail.
+- [Middleware](../agent_design/middleware/overview.md) for the full control catalogue.
+- [Flows](../invocation/flows.md) for wiring multi-agent harnesses.
+- [Observability](../../observability/agenthub/local.md) for inspecting and replaying runs.

--- a/docs/documentation/harness/overview.md
+++ b/docs/documentation/harness/overview.md
@@ -61,7 +61,10 @@ For large corpora the answer is retrieval rather than a bigger prompt: see the [
 
 ## 4. Controls
 
-Controls are what make a harness safe to point at real systems. In Railtracks they are middleware, applied at two boundaries: `middleware=` wraps the whole node (one call in, one result out) and `model_middleware=` wraps each individual model call inside the loop. The distinction matters for budgets: `MaxCalls(40)` as node middleware allows forty invocations of the agent, while the same thing as model middleware allows forty raw model calls. Either way the counter is cumulative for the life of the agent you attached it to, not per run: a second `invoke` of the same agent inherits whatever it already spent. `agent_node` copies the middleware you hand it, so the budget belongs to that agent, and rebuilding the agent is what gives you a fresh one.
+Controls are what make a harness safe to point at real systems. In Railtracks they are middleware, applied at two boundaries: `middleware=` wraps the whole node (one call in, one result out) and `model_middleware=` wraps each individual model call inside the loop. The distinction matters for budgets: `MaxCalls(40)` as `model_middleware` caps the agent at forty model calls inside one run, which is how you stop a tool-calling loop from spinning. Counters do not carry across runs, so every `invoke` starts from a full budget.
+
+!!! warning "Put budgets in `model_middleware=`, not `middleware=`"
+    Node middleware is rebuilt on every invocation, so a `MaxCalls` counter in the `middleware=` slot resets each time and never reaches its limit. Use `model_middleware=` for budgets until [issue #1560](https://github.com/RailtownAI/railtracks/issues/1560) is resolved.
 
 ```python
 --8<-- "docs/scripts/documentation/harness.py:controls"

--- a/docs/documentation/harness/overview.md
+++ b/docs/documentation/harness/overview.md
@@ -14,7 +14,7 @@ Railtracks is an agent harness framework. Every part of that list is an ordinary
 | **Tool surface** | What can the agent actually do? | [`rt.function_node`](../agent_design/tools/function_tools.md), [`rt.ToolManifest`](../agent_design/tools/agents_as_tools.md), [`rt.connect_mcp`](../agent_design/tools/mcp.md) |
 | **Context** | What does the model see on this turn? | `system_message`, [`rt.context`](../advanced/context.md), [`ToDoToolSet`](../agent_design/tools/prebuilt/todos.md), [`KeyValueMemoryToolSet`](../agent_design/tools/prebuilt/key_value_memory.md), [retrieval](../../retrieval/runtime/quickstart.md) |
 | **Controls** | What is it allowed to do, and how much of it? | [`middleware=` / `model_middleware=`](../agent_design/middleware/overview.md): `MaxCalls`, `Timeout`, `Retry`, `Lock`, [verifiers](../agent_design/middleware/verifiers/overview.md), [guardrails](../agent_design/middleware/guardrails/overview.md) |
-| **Record** | What happened, and can I replay it? | session state, [`railtracks viz`](../../observability/agenthub/local.md), [`rt.evaluate`](../../evaluations/quickstart.md) |
+| **Record** | What happened, and can I replay it? | session state, [`railtracks viz`](../../observability/agenthub/local.md), [`rt.evaluations.evaluate`](../../evaluations/quickstart.md) |
 
 The sections below build one harness up part by part: a repository assistant that reads code, plans its work, and runs shell commands only with permission.
 
@@ -61,7 +61,7 @@ For large corpora the answer is retrieval rather than a bigger prompt: see the [
 
 ## 4. Controls
 
-Controls are what make a harness safe to point at real systems. In Railtracks they are middleware, applied at two boundaries: `middleware=` wraps the whole node (one call in, one result out) and `model_middleware=` wraps each individual model call inside the loop. The distinction matters for budgets: `MaxCalls(40)` as node middleware allows forty runs of the agent, while the same thing as model middleware caps the agent at forty turns within a single run.
+Controls are what make a harness safe to point at real systems. In Railtracks they are middleware, applied at two boundaries: `middleware=` wraps the whole node (one call in, one result out) and `model_middleware=` wraps each individual model call inside the loop. The distinction matters for budgets: `MaxCalls(40)` as node middleware allows forty invocations of the agent, while the same thing as model middleware allows forty raw model calls. Either way the counter is cumulative for the life of the agent you attached it to, not per run: a second `invoke` of the same agent inherits whatever it already spent. `agent_node` copies the middleware you hand it, so the budget belongs to that agent, and rebuilding the agent is what gives you a fresh one.
 
 ```python
 --8<-- "docs/scripts/documentation/harness.py:controls"

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ hide:
 <div class="rt-hero">
   <img src="assets/logo.svg" alt="Railtracks Logo" width="280">
   <h1>Made by Agent Builders<br>for Agent Builders</h1>
+  <p>A Python framework for building agent harnesses: the loop, tools, context, and controls around a model.</p>
 </div>
 
 <div class="grid cards rt-home-cards">
@@ -14,9 +15,9 @@ hide:
     <h3>Learn</h3>
     <p>If you are curious to learn about AI Agents, how they work, and other concepts.</p>
   </a>
-  <a class="card" href="documentation/agent_design/overview">
+  <a class="card" href="documentation/harness/overview">
     <h3>Build</h3>
-    <p>If you want to know how to build agents using Railtracks</p>
+    <p>If you want to build an agent harness: the loop, tools, context, and controls around a model</p>
   </a>
   <a class="card" href="observability/agenthub/local">
     <h3>Observe</h3>

--- a/docs/scripts/documentation/harness.py
+++ b/docs/scripts/documentation/harness.py
@@ -1,0 +1,129 @@
+# --8<-- [start: loop]
+from pathlib import Path
+
+import railtracks as rt
+
+
+@rt.function_node
+def read_file(path: str) -> str:
+    """Read a UTF-8 text file from disk.
+
+    Args:
+        path (str): Path of the file to read.
+    """
+    return Path(path).read_text(encoding="utf-8")
+
+
+RepoReader = rt.agent_node(
+    name="Repo Reader",
+    llm=rt.llm.AnthropicLLM("claude-sonnet-5"),
+    system_message="You answer questions about a repository. Read files before you answer.",
+    tool_nodes=[read_file],
+)
+
+reader_flow = rt.Flow("repo-reader", entry_point=RepoReader)
+answer = reader_flow.invoke("What package name does pyproject.toml declare?")
+print(answer.text)
+# --8<-- [end: loop]
+
+
+# --8<-- [start: tools]
+import shlex
+import subprocess
+
+
+@rt.function_node
+def list_files(directory: str) -> list[str]:
+    """List the file names directly inside a directory.
+
+    Args:
+        directory (str): Directory to list.
+    """
+    return sorted(p.name for p in Path(directory).iterdir())
+
+
+# Left as a plain function on purpose: section 4 wraps it with a permission gate.
+def run_shell(command: str) -> str:
+    """Run a shell command and return its combined output.
+
+    Args:
+        command (str): Command to run, as it would be typed in a terminal.
+    """
+    finished = subprocess.run(
+        shlex.split(command),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return f"exit={finished.returncode}\n{finished.stdout}{finished.stderr}"
+
+
+# --8<-- [end: tools]
+
+
+# --8<-- [start: context]
+todos = rt.prebuilt.tools.ToDoToolSet()
+memory = rt.prebuilt.tools.KeyValueMemoryToolSet()
+
+HARNESS_SYSTEM_MESSAGE = "\n\n".join(
+    [
+        "You are a repository assistant. Read before you write, and verify with tests.",
+        rt.prebuilt.tools.ToDoToolSet.prompt(),
+        rt.prebuilt.tools.KeyValueMemoryToolSet.prompt(),
+    ]
+)
+# --8<-- [end: context]
+
+
+# --8<-- [start: controls]
+from railtracks.middleware import Verdict
+from railtracks.prebuilt.middleware import MaxCalls, Timeout, pre_verifier
+
+ALLOWED_EXECUTABLES = {"git", "ls", "pytest", "ruff"}
+
+
+def approve_shell(command: str) -> Verdict:
+    """Allowlist the executable, then ask a human about the specific command."""
+    parts = shlex.split(command)
+    if not parts or parts[0] not in ALLOWED_EXECUTABLES:
+        return Verdict(accepted=False, comment=f"{command!r} is not on the allowlist")
+
+    answer = input(f"Run `{command}`? [y/N] ").strip().lower()
+    return Verdict(accepted=answer == "y", comment="declined by the operator")
+
+
+gated_shell = rt.function_node(
+    run_shell,
+    name="run_shell",
+    middleware=[pre_verifier(approve_shell), Timeout(90)],
+)
+# --8<-- [end: controls]
+
+
+# --8<-- [start: record]
+RepoHarness = rt.agent_node(
+    name="Repo Harness",
+    llm=rt.llm.AnthropicLLM("claude-sonnet-5"),
+    system_message=HARNESS_SYSTEM_MESSAGE,
+    tool_nodes=[
+        read_file,
+        list_files,
+        gated_shell,
+        *todos.tool_set(),
+        *memory.tool_set(),
+    ],
+    middleware=[Timeout(600)],
+    model_middleware=[MaxCalls(40, custom_message="turn budget exhausted")],
+)
+
+harness_flow = rt.Flow(
+    "repo-harness",
+    entry_point=RepoHarness,
+    save_state=True,
+    context={"repo_root": "."},
+)
+
+outcome = harness_flow.invoke("Find the slowest unit test and explain why it is slow.")
+print(outcome.text)
+print(todos.pretty_dashboard())
+# --8<-- [end: record]

--- a/docs/scripts/documentation/harness.py
+++ b/docs/scripts/documentation/harness.py
@@ -76,20 +76,25 @@ HARNESS_SYSTEM_MESSAGE = "\n\n".join(
 
 
 # --8<-- [start: controls]
+import asyncio
+
 from railtracks.middleware import Verdict
 from railtracks.prebuilt.middleware import MaxCalls, Timeout, pre_verifier
 
 ALLOWED_EXECUTABLES = {"git", "ls", "pytest", "ruff"}
 
 
-def approve_shell(command: str) -> Verdict:
+async def approve_shell(command: str) -> Verdict:
     """Allowlist the executable, then ask a human about the specific command."""
     parts = shlex.split(command)
     if not parts or parts[0] not in ALLOWED_EXECUTABLES:
         return Verdict(accepted=False, comment=f"{command!r} is not on the allowlist")
 
-    answer = input(f"Run `{command}`? [y/N] ").strip().lower()
-    return Verdict(accepted=answer == "y", comment="declined by the operator")
+    # approve_fn runs on the event loop, so never block it with a bare input()
+    answer = await asyncio.to_thread(input, f"Run `{command}`? [y/N] ")
+    if answer.strip().lower() == "y":
+        return Verdict(accepted=True)
+    return Verdict(accepted=False, comment="declined by the operator")
 
 
 gated_shell = rt.function_node(
@@ -113,17 +118,24 @@ RepoHarness = rt.agent_node(
         *memory.tool_set(),
     ],
     middleware=[Timeout(600)],
-    model_middleware=[MaxCalls(40, custom_message="turn budget exhausted")],
+    model_middleware=[MaxCalls(40, custom_message="model call budget exhausted")],
 )
 
 harness_flow = rt.Flow(
     "repo-harness",
     entry_point=RepoHarness,
-    save_state=True,
     context={"repo_root": "."},
 )
 
-outcome = harness_flow.invoke("Find the slowest unit test and explain why it is slow.")
-print(outcome.text)
-print(todos.pretty_dashboard())
+
+async def run_harness() -> None:
+    outcome = await harness_flow.ainvoke(
+        "Find the slowest unit test and explain why it is slow."
+    )
+    print(outcome.text)
+    # every ToDoToolSet read is async, pretty_dashboard included
+    print(await todos.pretty_dashboard())
+
+
+asyncio.run(run_harness())
 # --8<-- [end: record]

--- a/docs/scripts/todos.py
+++ b/docs/scripts/todos.py
@@ -44,14 +44,16 @@ agent = rt.agent_node(
 # --8<-- [end: todo_callback]
 
 # --8<-- [start: todo_inspection]
-# inspect the todo list after the agent run completes
-print(to_dos.pretty_dashboard())
+# inspect the todo list after the agent run completes (the reads are async)
+import asyncio
+
+print(asyncio.run(to_dos.pretty_dashboard()))
 # To-Dos
 # completed - fetch_data
 # completed - clean_data
 # completed - generate_report
 
-incomplete = to_dos.get_incomplete_todos()
+incomplete = asyncio.run(to_dos.get_incomplete_todos())
 if incomplete:
     raise RuntimeError(f"Agent left tasks unfinished: {incomplete}")
 # --8<-- [end: todo_inspection]

--- a/examples/harness/README.md
+++ b/examples/harness/README.md
@@ -4,8 +4,10 @@ A harness is the code around the model call: the loop, the tool surface, what go
 
 For the concepts behind them, see the [Agent Harness docs](../../docs/documentation/harness/overview.md).
 
-- `minimal_harness.py` -> read-only tools pointed at this repository. Because nothing can mutate state, the only controls it needs are a turn budget (`MaxCalls` as `model_middleware`) and a deadline (`Timeout`). Start here.
-- `coding_harness.py` -> file writes and shell commands, each behind `pre_verifier`. Adds path confinement to a scratch workspace, an executable allowlist, and operator approval on every mutating call, plus a `ToDoToolSet` plan and `KeyValueMemoryToolSet` facts. This is the shape a coding agent takes.
+- `minimal_harness.py` -> read-only tools pointed at this repository. Because nothing can mutate state, the only controls it needs are a model call budget (`MaxCalls` as `model_middleware`) and a deadline (`Timeout`). Start here.
+- `coding_harness.py` -> file writes and shell commands, each behind `pre_verifier`. Adds path confinement on `write_file`, an executable allowlist on `run_shell`, and operator approval on every mutating call, plus a `ToDoToolSet` plan and `KeyValueMemoryToolSet` facts. This is the shape a coding agent takes.
+
+> **`run_shell` is not a sandbox.** It sets `cwd` to the workspace, but an interpreter on the allowlist (`python`, or `pytest` running test files the agent just wrote) can reach the rest of the disk. The approval prompt is the real control there, which is why the example asks before every shell call.
 
 ## Running them
 
@@ -14,15 +16,15 @@ uv run python examples/harness/minimal_harness.py
 uv run python examples/harness/coding_harness.py
 ```
 
-Both need a provider key in your `.env` (`OPENAI_API_KEY` for the minimal harness, `ANTHROPIC_API_KEY` for the coding harness). Override the model with `HARNESS_MODEL`, and the coding harness' scratch directory with `HARNESS_WORKSPACE`.
+Each example hardcodes one provider, so it needs that provider's key in your `.env`: `OPENAI_API_KEY` for the minimal harness, `ANTHROPIC_API_KEY` for the coding harness. `HARNESS_MODEL` overrides the model *id* only, not the provider, so pass an id that provider accepts (`gpt-...` for the minimal harness, `claude-...` for the coding one). Edit the `rt.llm.*` call to switch provider. `HARNESS_WORKSPACE` overrides the coding harness' scratch directory.
 
-Both run with `save_state=True`, so `railtracks viz` replays the full request graph afterwards; every tool call, its arguments, and where the time went.
+Both are recorded by default, so `railtracks viz` replays the full request graph afterwards; every tool call, its arguments, and where the time went.
 
 ## Where the controls come from
 
 | Piece | Import | Used for |
 |---|---|---|
-| `MaxCalls` | `railtracks.prebuilt.middleware` | Capping turns so a confused agent cannot loop on your budget |
+| `MaxCalls` | `railtracks.prebuilt.middleware` | Capping calls so a confused agent cannot loop on your budget. Cumulative for the life of the agent, so it does not reset per run |
 | `Timeout` | `railtracks.prebuilt.middleware` | Wall-clock deadline on a tool or on the whole agent |
 | `pre_verifier` | `railtracks.prebuilt.middleware` | Gating a call before it runs; the approver is any callable |
 | `Verdict` | `railtracks.middleware` | What an approval function returns |

--- a/examples/harness/README.md
+++ b/examples/harness/README.md
@@ -1,0 +1,33 @@
+# Harness examples
+
+A harness is the code around the model call: the loop, the tool surface, what goes into context, the controls on what the agent may do, and the record of what it did. These two examples are the same five parts at two different risk levels.
+
+For the concepts behind them, see the [Agent Harness docs](../../docs/documentation/harness/overview.md).
+
+- `minimal_harness.py` -> read-only tools pointed at this repository. Because nothing can mutate state, the only controls it needs are a turn budget (`MaxCalls` as `model_middleware`) and a deadline (`Timeout`). Start here.
+- `coding_harness.py` -> file writes and shell commands, each behind `pre_verifier`. Adds path confinement to a scratch workspace, an executable allowlist, and operator approval on every mutating call, plus a `ToDoToolSet` plan and `KeyValueMemoryToolSet` facts. This is the shape a coding agent takes.
+
+## Running them
+
+```bash
+uv run python examples/harness/minimal_harness.py
+uv run python examples/harness/coding_harness.py
+```
+
+Both need a provider key in your `.env` (`OPENAI_API_KEY` for the minimal harness, `ANTHROPIC_API_KEY` for the coding harness). Override the model with `HARNESS_MODEL`, and the coding harness' scratch directory with `HARNESS_WORKSPACE`.
+
+Both run with `save_state=True`, so `railtracks viz` replays the full request graph afterwards; every tool call, its arguments, and where the time went.
+
+## Where the controls come from
+
+| Piece | Import | Used for |
+|---|---|---|
+| `MaxCalls` | `railtracks.prebuilt.middleware` | Capping turns so a confused agent cannot loop on your budget |
+| `Timeout` | `railtracks.prebuilt.middleware` | Wall-clock deadline on a tool or on the whole agent |
+| `pre_verifier` | `railtracks.prebuilt.middleware` | Gating a call before it runs; the approver is any callable |
+| `Verdict` | `railtracks.middleware` | What an approval function returns |
+| `ToDoToolSet`, `KeyValueMemoryToolSet` | `rt.prebuilt.tools` | Letting the agent manage its own plan and facts |
+
+`coding_harness.py` gates the individual write and shell tools rather than the agent as a whole, which is the general rule: put each control at the narrowest boundary that still catches the problem. Reads stay uninterrupted; anything that mutates state stops for a human.
+
+For more verifier shapes (LLM reviewers, webhook approvals, composing an automatic check that escalates to a human), see [`../human_in_the_loop/`](../human_in_the_loop/README.md).

--- a/examples/harness/README.md
+++ b/examples/harness/README.md
@@ -24,7 +24,7 @@ Both are recorded by default, so `railtracks viz` replays the full request graph
 
 | Piece | Import | Used for |
 |---|---|---|
-| `MaxCalls` | `railtracks.prebuilt.middleware` | Capping calls so a confused agent cannot loop on your budget. Cumulative for the life of the agent, so it does not reset per run |
+| `MaxCalls` | `railtracks.prebuilt.middleware` | Capping model calls inside a run so a tool loop cannot spin on your budget. Must go in the `model_middleware=` slot; the node slot does not enforce ([#1560](https://github.com/RailtownAI/railtracks/issues/1560)) |
 | `Timeout` | `railtracks.prebuilt.middleware` | Wall-clock deadline on a tool or on the whole agent |
 | `pre_verifier` | `railtracks.prebuilt.middleware` | Gating a call before it runs; the approver is any callable |
 | `Verdict` | `railtracks.middleware` | What an approval function returns |

--- a/examples/harness/coding_harness.py
+++ b/examples/harness/coding_harness.py
@@ -180,8 +180,8 @@ CodingHarness = rt.agent_node(
         *memory.tool_set(),
     ],
     middleware=[Timeout(900)],
-    # Cumulative for the life of this agent, not per run: a second invoke
-    # inherits whatever the first already spent.
+    # Caps model calls inside one run; the counter starts fresh each run.
+    # Budgets belong in model_middleware: the node slot does not enforce (see #1560).
     model_middleware=[MaxCalls(40, custom_message="model call budget exhausted")],
 )
 

--- a/examples/harness/coding_harness.py
+++ b/examples/harness/coding_harness.py
@@ -1,0 +1,184 @@
+"""A coding harness: writes and shell commands, both behind a permission gate.
+
+Shows the full set of harness parts on tools that actually mutate state:
+
+- tool surface   -> read/write/list files, plus an allowlisted shell
+- context        -> a todo list the agent revises, and key-value memory
+- controls       -> path confinement, an executable allowlist, human approval,
+                    a turn budget, and deadlines
+- record         -> `save_state=True`, replayable with `railtracks viz`
+
+Everything the agent writes is confined to a scratch workspace (override with
+HARNESS_WORKSPACE); paths that escape it are rejected before the model's request
+ever reaches the filesystem.
+
+Run: uv run python examples/harness/coding_harness.py
+"""
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+import railtracks as rt
+from railtracks.middleware import Verdict
+from railtracks.prebuilt.middleware import MaxCalls, Timeout, pre_verifier
+
+MODEL_NAME = os.environ.get("HARNESS_MODEL", "claude-sonnet-5")
+WORKSPACE = Path(
+    os.environ.get("HARNESS_WORKSPACE", Path(tempfile.gettempdir()) / "harness_workspace")
+)
+ALLOWED_EXECUTABLES = {"git", "ls", "pytest", "python", "ruff"}
+
+
+def _resolve_in_workspace(path: str) -> Path:
+    """Resolve a model-supplied path, refusing anything outside the workspace.
+
+    Args:
+        path (str): Path as the model supplied it, relative to the workspace root.
+
+    Raises:
+        ValueError: If the resolved path falls outside the workspace.
+    """
+    resolved = (WORKSPACE / path).resolve()
+    if not resolved.is_relative_to(WORKSPACE.resolve()):
+        raise ValueError(f"{path!r} resolves outside the workspace")
+    return resolved
+
+
+##### 1. Controls: an allowlist, then a human, before anything mutates #####
+
+
+def approve_write(path: str, content: str) -> Verdict:
+    """Ask the operator to approve a file write, showing what will change."""
+    print(f"\n--- write {path} ({len(content)} chars) ---\n{content[:400]}\n---")
+    answer = input(f"Write {path}? [y/N] ").strip().lower()
+    return Verdict(accepted=answer == "y", comment="declined by the operator")
+
+
+def approve_shell(command: str) -> Verdict:
+    """Allowlist the executable, then ask the operator about the exact command."""
+    parts = shlex.split(command)
+    if not parts:
+        return Verdict(accepted=False, comment="empty command")
+    if parts[0] not in ALLOWED_EXECUTABLES:
+        return Verdict(
+            accepted=False,
+            comment=f"{parts[0]!r} is not on the allowlist: {sorted(ALLOWED_EXECUTABLES)}",
+        )
+
+    answer = input(f"\nRun `{command}` in the workspace? [y/N] ").strip().lower()
+    return Verdict(accepted=answer == "y", comment="declined by the operator")
+
+
+##### 2. Tool surface: reads are free, writes are gated #####
+
+
+@rt.function_node
+def list_workspace(directory: str = ".") -> list[str]:
+    """List the files and folders directly inside a workspace directory.
+
+    Args:
+        directory (str): Path relative to the workspace root. Defaults to the root.
+    """
+    target = _resolve_in_workspace(directory)
+    return sorted(p.name + ("/" if p.is_dir() else "") for p in target.iterdir())
+
+
+@rt.function_node
+def read_file(path: str) -> str:
+    """Read a UTF-8 text file from the workspace.
+
+    Args:
+        path (str): Path relative to the workspace root.
+    """
+    return _resolve_in_workspace(path).read_text(encoding="utf-8")
+
+
+@rt.function_node(middleware=[pre_verifier(approve_write), Timeout(30)])
+def write_file(path: str, content: str) -> str:
+    """Create or overwrite a UTF-8 text file in the workspace.
+
+    Args:
+        path (str): Path relative to the workspace root.
+        content (str): Full new contents of the file. Overwrites, never appends.
+    """
+    target = _resolve_in_workspace(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+    return f"wrote {len(content)} chars to {path}"
+
+
+@rt.function_node(middleware=[pre_verifier(approve_shell), Timeout(120)])
+def run_shell(command: str) -> str:
+    """Run a shell command inside the workspace and return its output.
+
+    Only these executables are permitted: git, ls, pytest, python, ruff.
+
+    Args:
+        command (str): Command to run, as it would be typed in a terminal.
+    """
+    finished = subprocess.run(
+        shlex.split(command),
+        cwd=WORKSPACE,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return f"exit={finished.returncode}\n{finished.stdout}{finished.stderr}"
+
+
+##### 3. Context: a plan the agent can revise, and facts that outlive a turn #####
+
+todos = rt.prebuilt.tools.ToDoToolSet()
+memory = rt.prebuilt.tools.KeyValueMemoryToolSet()
+
+SYSTEM_MESSAGE = "\n\n".join(
+    [
+        "You are a coding agent working inside a scratch workspace. Plan before you act, "
+        "read a file before you overwrite it, and verify your work by running the tests. "
+        "Write and shell tools need operator approval, so batch your requests and explain "
+        "each one before asking.",
+        rt.prebuilt.tools.ToDoToolSet.prompt(),
+        rt.prebuilt.tools.KeyValueMemoryToolSet.prompt(),
+    ]
+)
+
+CodingHarness = rt.agent_node(
+    name="Coding Harness",
+    llm=rt.llm.AnthropicLLM(MODEL_NAME),
+    system_message=SYSTEM_MESSAGE,
+    tool_nodes=[
+        list_workspace,
+        read_file,
+        write_file,
+        run_shell,
+        *todos.tool_set(),
+        *memory.tool_set(),
+    ],
+    middleware=[Timeout(900)],
+    model_middleware=[MaxCalls(40, custom_message="turn budget exhausted")],
+)
+
+
+##### 4. The record #####
+
+if __name__ == "__main__":
+    WORKSPACE.mkdir(parents=True, exist_ok=True)
+    print(f"Workspace: {WORKSPACE}")
+
+    flow = rt.Flow(
+        "coding-harness",
+        entry_point=CodingHarness,
+        save_state=True,
+        context={"workspace": str(WORKSPACE)},
+    )
+    result = flow.invoke(
+        "Write a fizzbuzz(n) function in fizzbuzz.py, write pytest tests for it in "
+        "test_fizzbuzz.py, then run the tests and report the outcome."
+    )
+
+    print(f"\n{result.text}")
+    print(f"\n{todos.pretty_dashboard()}")
+    print("\nRun `railtracks viz` to replay this run.")

--- a/examples/harness/coding_harness.py
+++ b/examples/harness/coding_harness.py
@@ -5,16 +5,20 @@ Shows the full set of harness parts on tools that actually mutate state:
 - tool surface   -> read/write/list files, plus an allowlisted shell
 - context        -> a todo list the agent revises, and key-value memory
 - controls       -> path confinement, an executable allowlist, human approval,
-                    a turn budget, and deadlines
-- record         -> `save_state=True`, replayable with `railtracks viz`
+                    a call budget, and deadlines
+- record         -> every run replayable with `railtracks viz`
 
-Everything the agent writes is confined to a scratch workspace (override with
-HARNESS_WORKSPACE); paths that escape it are rejected before the model's request
-ever reaches the filesystem.
+`write_file` is confined to a scratch workspace (override with HARNESS_WORKSPACE):
+paths that escape it are rejected before the request reaches the filesystem.
+`run_shell` is NOT a sandbox. It only sets `cwd`, and an interpreter the agent is
+allowed to run (`python`, or `pytest` executing test files the agent just wrote)
+can reach the rest of the disk. That is exactly why every shell call stops for
+approval: the human is the real control here, not the allowlist.
 
 Run: uv run python examples/harness/coding_harness.py
 """
 
+import asyncio
 import os
 import shlex
 import subprocess
@@ -27,7 +31,9 @@ from railtracks.prebuilt.middleware import MaxCalls, Timeout, pre_verifier
 
 MODEL_NAME = os.environ.get("HARNESS_MODEL", "claude-sonnet-5")
 WORKSPACE = Path(
-    os.environ.get("HARNESS_WORKSPACE", Path(tempfile.gettempdir()) / "harness_workspace")
+    os.environ.get(
+        "HARNESS_WORKSPACE", Path(tempfile.gettempdir()) / "harness_workspace"
+    )
 )
 ALLOWED_EXECUTABLES = {"git", "ls", "pytest", "python", "ruff"}
 
@@ -50,14 +56,28 @@ def _resolve_in_workspace(path: str) -> Path:
 ##### 1. Controls: an allowlist, then a human, before anything mutates #####
 
 
-def approve_write(path: str, content: str) -> Verdict:
+async def _ask(prompt: str) -> bool:
+    """Prompt the operator without blocking the event loop.
+
+    `approve_fn` runs on the loop thread, so a bare `input()` would stall every
+    other in-flight node until the human answers.
+
+    Args:
+        prompt (str): Question to show the operator.
+    """
+    answer = await asyncio.to_thread(input, prompt)
+    return answer.strip().lower() == "y"
+
+
+async def approve_write(path: str, content: str) -> Verdict:
     """Ask the operator to approve a file write, showing what will change."""
     print(f"\n--- write {path} ({len(content)} chars) ---\n{content[:400]}\n---")
-    answer = input(f"Write {path}? [y/N] ").strip().lower()
-    return Verdict(accepted=answer == "y", comment="declined by the operator")
+    if await _ask(f"Write {path}? [y/N] "):
+        return Verdict(accepted=True)
+    return Verdict(accepted=False, comment="declined by the operator")
 
 
-def approve_shell(command: str) -> Verdict:
+async def approve_shell(command: str) -> Verdict:
     """Allowlist the executable, then ask the operator about the exact command."""
     parts = shlex.split(command)
     if not parts:
@@ -68,8 +88,9 @@ def approve_shell(command: str) -> Verdict:
             comment=f"{parts[0]!r} is not on the allowlist: {sorted(ALLOWED_EXECUTABLES)}",
         )
 
-    answer = input(f"\nRun `{command}` in the workspace? [y/N] ").strip().lower()
-    return Verdict(accepted=answer == "y", comment="declined by the operator")
+    if await _ask(f"\nRun `{command}` in the workspace? [y/N] "):
+        return Verdict(accepted=True)
+    return Verdict(accepted=False, comment="declined by the operator")
 
 
 ##### 2. Tool surface: reads are free, writes are gated #####
@@ -112,9 +133,10 @@ def write_file(path: str, content: str) -> str:
 
 @rt.function_node(middleware=[pre_verifier(approve_shell), Timeout(120)])
 def run_shell(command: str) -> str:
-    """Run a shell command inside the workspace and return its output.
+    """Run a shell command with the workspace as the working directory.
 
-    Only these executables are permitted: git, ls, pytest, python, ruff.
+    Only these executables are permitted: git, ls, pytest, python, ruff. Every
+    call needs operator approval before it runs.
 
     Args:
         command (str): Command to run, as it would be typed in a terminal.
@@ -158,27 +180,34 @@ CodingHarness = rt.agent_node(
         *memory.tool_set(),
     ],
     middleware=[Timeout(900)],
-    model_middleware=[MaxCalls(40, custom_message="turn budget exhausted")],
+    # Cumulative for the life of this agent, not per run: a second invoke
+    # inherits whatever the first already spent.
+    model_middleware=[MaxCalls(40, custom_message="model call budget exhausted")],
 )
 
 
 ##### 4. The record #####
 
-if __name__ == "__main__":
+
+async def main() -> None:
+    """Run the harness once, then print the plan it worked through."""
     WORKSPACE.mkdir(parents=True, exist_ok=True)
     print(f"Workspace: {WORKSPACE}")
 
     flow = rt.Flow(
         "coding-harness",
         entry_point=CodingHarness,
-        save_state=True,
         context={"workspace": str(WORKSPACE)},
     )
-    result = flow.invoke(
+    result = await flow.ainvoke(
         "Write a fizzbuzz(n) function in fizzbuzz.py, write pytest tests for it in "
         "test_fizzbuzz.py, then run the tests and report the outcome."
     )
 
     print(f"\n{result.text}")
-    print(f"\n{todos.pretty_dashboard()}")
+    print(f"\n{await todos.pretty_dashboard()}")
     print("\nRun `railtracks viz` to replay this run.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/harness/minimal_harness.py
+++ b/examples/harness/minimal_harness.py
@@ -61,14 +61,16 @@ RepoReader = rt.agent_node(
     ),
     tool_nodes=[list_files, read_file, find_files],
     middleware=[Timeout(300)],
-    model_middleware=[MaxCalls(20, custom_message="turn budget exhausted")],
+    # Cumulative for the life of this agent, not per run: a second invoke
+    # inherits whatever the first already spent.
+    model_middleware=[MaxCalls(20, custom_message="model call budget exhausted")],
 )
 
 
-##### 3. The record: save_state makes the run replayable in `railtracks viz` #####
+##### 3. The record: runs are recorded by default, replay with `railtracks viz` #####
 
 if __name__ == "__main__":
-    flow = rt.Flow("minimal-harness", entry_point=RepoReader, save_state=True)
+    flow = rt.Flow("minimal-harness", entry_point=RepoReader)
     result = flow.invoke(
         "Which optional dependency extras does the railtracks package declare, and what is in each?"
     )

--- a/examples/harness/minimal_harness.py
+++ b/examples/harness/minimal_harness.py
@@ -61,8 +61,8 @@ RepoReader = rt.agent_node(
     ),
     tool_nodes=[list_files, read_file, find_files],
     middleware=[Timeout(300)],
-    # Cumulative for the life of this agent, not per run: a second invoke
-    # inherits whatever the first already spent.
+    # Caps model calls inside one run; the counter starts fresh each run.
+    # Budgets belong in model_middleware: the node slot does not enforce (see #1560).
     model_middleware=[MaxCalls(20, custom_message="model call budget exhausted")],
 )
 

--- a/examples/harness/minimal_harness.py
+++ b/examples/harness/minimal_harness.py
@@ -1,0 +1,77 @@
+"""The smallest harness that is still a harness: loop, tools, budget, record.
+
+Points a read-only agent at this repository. Nothing here can mutate state, so
+the only controls it needs are a turn budget and a deadline.
+
+Run: uv run python examples/harness/minimal_harness.py
+"""
+
+import os
+from pathlib import Path
+
+import railtracks as rt
+from railtracks.prebuilt.middleware import MaxCalls, Timeout
+
+MODEL_NAME = os.environ.get("HARNESS_MODEL", "gpt-5.4-mini")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+##### 1. Tool surface: read-only, three sharp tools #####
+
+
+@rt.function_node
+def list_files(directory: str) -> list[str]:
+    """List the names of files and folders directly inside a repository directory.
+
+    Args:
+        directory (str): Path relative to the repository root, e.g. "packages/railtracks".
+    """
+    target = REPO_ROOT / directory
+    return sorted(p.name + ("/" if p.is_dir() else "") for p in target.iterdir())
+
+
+@rt.function_node
+def read_file(path: str) -> str:
+    """Read a UTF-8 text file from the repository.
+
+    Args:
+        path (str): Path relative to the repository root, e.g. "pyproject.toml".
+    """
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+@rt.function_node
+def find_files(pattern: str) -> list[str]:
+    """Find repository files whose path matches a glob pattern.
+
+    Args:
+        pattern (str): Glob pattern relative to the repository root, e.g. "**/*.toml".
+    """
+    matches = (p for p in REPO_ROOT.glob(pattern) if p.is_file())
+    return sorted(str(p.relative_to(REPO_ROOT)) for p in matches)[:100]
+
+
+##### 2. The loop, with a budget and a deadline #####
+
+RepoReader = rt.agent_node(
+    name="Repo Reader",
+    llm=rt.llm.OpenAILLM(MODEL_NAME),
+    system_message=(
+        "You answer questions about a Python repository. Locate files before reading them, "
+        "read before you answer, and cite the paths you used."
+    ),
+    tool_nodes=[list_files, read_file, find_files],
+    middleware=[Timeout(300)],
+    model_middleware=[MaxCalls(20, custom_message="turn budget exhausted")],
+)
+
+
+##### 3. The record: save_state makes the run replayable in `railtracks viz` #####
+
+if __name__ == "__main__":
+    flow = rt.Flow("minimal-harness", entry_point=RepoReader, save_state=True)
+    result = flow.invoke(
+        "Which optional dependency extras does the railtracks package declare, and what is in each?"
+    )
+
+    print(result.text)
+    print("\nRun `railtracks viz` to replay this run.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Railtracks Docs
 site_url: https://docs.railtracks.org/
-site_description: "Railtracks is a framework for building LLM-powered agents and applications."
+site_description: "Railtracks is a Python framework for building agent harnesses: the loop, tools, context, and controls around an LLM."
 
 hooks:
   - scripts/mkdocs_hooks.py
@@ -91,6 +91,8 @@ nav:
           - AI Coding Assistants: documentation/getting_started/ai_setup.md
           - Contributing to the Docs: documentation/getting_started/contributing_docs.md
           - Upgrading to 1.5.0: documentation/upgrading/1_5_0.md
+      - Harness:
+          - Agent Harness: documentation/harness/overview.md
       - Agent Design:
           - Overview: documentation/agent_design/overview.md
           - Tools:

--- a/packages/railtracks/pyproject.toml
+++ b/packages/railtracks/pyproject.toml
@@ -17,6 +17,21 @@ readme = "README.md"
 license = { file = "LICENSE" }
 dynamic = ["version", "description"]
 requires-python = ">=3.10"
+keywords = [
+    "agent",
+    "agent-harness",
+    "agentic",
+    "agentic-harness",
+    "agents",
+    "ai",
+    "harness",
+    "harness-framework",
+    "llm",
+    "llm-harness",
+    "mcp",
+    "multi-agent",
+    "tool-calling",
+]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/packages/railtracks/src/railtracks/__init__.py
+++ b/packages/railtracks/src/railtracks/__init__.py
@@ -2,7 +2,7 @@
 #   Copyright (c) Railtown AI. All rights reserved.
 #   Licensed under the MIT License. See LICENSE in project root for information.
 #   -------------------------------------------------------------
-"""The Railtracks Framework for building resilient agentic systems in simple python"""
+"""Build agent harnesses in plain Python: the loop, tools, context, and controls around an LLM"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Positions railtracks as an agent harness framework. No ticket.

Adds an Agent Harness page mapping the five parts of a harness (loop, tool surface, context, controls, record) to the primitives that cover each, with a snippet source under `docs/scripts/` and two runnable examples: a read-only harness, and a coding harness whose file writes and shell calls are gated by `pre_verifier`.

Repositions the README, docs home, site description and package summary around "agent harness" while keeping "agent framework" for search, and adds PyPI keywords.

No API, module or doc-page renames.

Two drive-by fixes to existing docs found while writing the examples: `ToDoToolSet.pretty_dashboard()` and `get_incomplete_todos()` are async, and the todos page was showing them called without `await`.

The controls section documents `MaxCalls` in the `model_middleware=` slot and carries a warning pointing at #1560, where the same middleware in the `middleware=` slot never reaches its limit.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [x] Docs
- [ ] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [ ] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

Known gap, left out of scope: `minimal_harness.py` joins model-supplied paths onto `REPO_ROOT` without confining them, so an absolute path or `..` escapes the repository. The tools are read-only. `coding_harness.py` has the confinement helper if we want to lift it across later.
