### PR TITLE
fix(middleware): treat middleware as shared instances so MaxCalls and Lock work in the node slot (#1560)

### DIFF
--- a/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
@@ -7,5 +7,42 @@
 ```
 
 Because it only controls the wrapped call, `Max Calls` works in both
-`middleware=` and `model_middleware=`. The limit is enforced on the complete call in
-the selected slot.
+`middleware=` (capping whole-node invocations) and `model_middleware=` (capping raw model calls inside the agent tool loop). The limit is enforced on the complete call in the selected slot.
+
+### Budget Scoping (`per_run`)
+
+By default (`per_run=True`), the budget is scoped to each workflow run / session. When a new run begins (e.g. via `flow.invoke()` or `rt.call()`), the call counter starts fresh.
+
+If you want a cumulative budget across multiple runs for the lifetime of the Python instance, set `per_run=False`:
+
+```python
+# Lifetime budget: allows 10 calls total across all runs
+lifetime_budget = MaxCalls(max_calls=10, per_run=False)
+```
+
+### Shared Budgets Across Nodes
+
+A single `MaxCalls` instance shared across multiple nodes enforces a combined budget:
+
+```python
+shared_budget = MaxCalls(max_calls=5)
+
+ToolA = rt.function_node(func_a, middleware=[shared_budget])
+ToolB = rt.function_node(func_b, middleware=[shared_budget])
+```
+
+Calls to either `ToolA` or `ToolB` accumulate against the same budget of 5.
+
+### Inspecting and Resetting
+
+You can inspect the current call count and reset the counter programmatically:
+
+```python
+budget = MaxCalls(max_calls=3)
+
+# Inspect current spend
+print(budget.call_count)
+
+# Reset counter
+budget.reset()
+```

--- a/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
@@ -9,16 +9,10 @@
 Because it only controls the wrapped call, `Max Calls` works in both
 `middleware=` (capping whole-node invocations) and `model_middleware=` (capping raw model calls inside the agent tool loop). The limit is enforced on the complete call in the selected slot.
 
-### Budget Scoping (`per_run`)
+### Workflow Run Scoping
 
-By default (`per_run=True`), the budget is scoped to each workflow run / session. When a new run begins (e.g. via `flow.invoke()` or `rt.call()`), the call counter starts fresh.
+The budget is scoped to each workflow run / session. When a new run begins (e.g. via `flow.invoke()` or `rt.call()`), the call counter starts fresh.
 
-If you want a cumulative budget across multiple runs for the lifetime of the Python instance, set `per_run=False`:
-
-```python
-# Lifetime budget: allows 10 calls total across all runs
-lifetime_budget = MaxCalls(max_calls=10, per_run=False)
-```
 
 ### Shared Budgets Across Nodes
 

--- a/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
+++ b/docs/documentation/agent_design/middleware/prebuilt/list/max_calls.md
@@ -11,8 +11,7 @@ Because it only controls the wrapped call, `Max Calls` works in both
 
 ### Workflow Run Scoping
 
-The budget is scoped to each workflow run / session. When a new run begins (e.g. via `flow.invoke()` or `rt.call()`), the call counter starts fresh.
-
+The budget is scoped to each workflow run / session. When a new run begins (e.g. via `flow.invoke()` or `rt.call()`), the call counter starts fresh automatically.
 
 ### Shared Budgets Across Nodes
 
@@ -34,9 +33,12 @@ You can inspect the current call count and reset the counter programmatically:
 ```python
 budget = MaxCalls(max_calls=3)
 
-# Inspect current spend
+# Inspect current spend (scoped to the active session)
 print(budget.call_count)
 
-# Reset counter
+# Reset counter for the current session
 budget.reset()
-```
+
+# Reset counters for all sessions
+budget.reset_all()
+```

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node_builder.py
@@ -89,9 +89,11 @@ class LLMNodeBuilder(NodeBuilder[[UserInput], _R], Generic[_R]):
         casted_instance._node_class = "Agent"
 
         unwrapped_model_middleware: list[ModelMiddleware] = (
-            list(model_middleware) if model_middleware is not None else []
+            list(deepcopy(model_middleware)) if model_middleware is not None else []
         )
-        unwrapped_middleware = list(middleware) if middleware is not None else []
+        unwrapped_middleware = (
+            list(deepcopy(middleware)) if middleware is not None else []
+        )
 
         tool_nodes = list(deepcopy(connected_nodes)) if connected_nodes else None
         _check_duplicate_tool_names(tool_nodes)

--- a/packages/railtracks/src/railtracks/built_nodes/llm/node_builder.py
+++ b/packages/railtracks/src/railtracks/built_nodes/llm/node_builder.py
@@ -89,11 +89,9 @@ class LLMNodeBuilder(NodeBuilder[[UserInput], _R], Generic[_R]):
         casted_instance._node_class = "Agent"
 
         unwrapped_model_middleware: list[ModelMiddleware] = (
-            list(deepcopy(model_middleware)) if model_middleware is not None else []
+            list(model_middleware) if model_middleware is not None else []
         )
-        unwrapped_middleware = (
-            list(deepcopy(middleware)) if middleware is not None else []
-        )
+        unwrapped_middleware = list(middleware) if middleware is not None else []
 
         tool_nodes = list(deepcopy(connected_nodes)) if connected_nodes else None
         _check_duplicate_tool_names(tool_nodes)

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import copy
 from typing import (
+    Any,
     Awaitable,
     Callable,
     Generic,
@@ -68,6 +70,17 @@ class MiddlewareChain(Generic[_P, _R]):
             list(middleware) if middleware is not None else []
         )
         self.get_scope_manager = get_scope_manager
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> MiddlewareChain[_P, _R]:
+        """Shallow-copy the middleware list so stateful middleware instances
+        (e.g. ``MaxCalls``, ``Lock``) are preserved by reference across
+        ``Node.safe_copy()``.  Other attributes are still deep-copied."""
+        cls = type(self)
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        result._middleware = list(self._middleware)  # shallow copy
+        result.get_scope_manager = copy.deepcopy(self.get_scope_manager, memo)
+        return result
 
     def add_middleware(self, m: Middleware[_P, _R]) -> None:
         """Append a user outer middleware (outermost band). Runs around the whole call."""

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import (
-    Any,
     Awaitable,
     Callable,
     Generic,
@@ -92,18 +90,5 @@ class MiddlewareChain(Generic[_P, _R]):
 
         return await func(*args, **kwargs)
 
-    def __deepcopy__(self, memo: dict[int, Any]) -> MiddlewareChain[_P, _R]:
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-        for k, v in self.__dict__.items():
-            if k == "_middleware":
-                # Shallow copy the list, preserving middleware instances by reference
-                # so stateful middleware (e.g. MaxCalls, Lock) are shared and not duplicated.
-                setattr(result, k, list(v))
-            else:
-                setattr(result, k, deepcopy(v, memo))
-        return result
-
     def __repr__(self) -> str:
-        return f"MiddlewareChain(middleware={self._middleware!r})"
+        return f"MiddlewareChain(middleware={self._middleware!r}, "

--- a/packages/railtracks/src/railtracks/middleware/chain.py
+++ b/packages/railtracks/src/railtracks/middleware/chain.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import (
+    Any,
     Awaitable,
     Callable,
     Generic,
@@ -90,5 +92,18 @@ class MiddlewareChain(Generic[_P, _R]):
 
         return await func(*args, **kwargs)
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> MiddlewareChain[_P, _R]:
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k == "_middleware":
+                # Shallow copy the list, preserving middleware instances by reference
+                # so stateful middleware (e.g. MaxCalls, Lock) are shared and not duplicated.
+                setattr(result, k, list(v))
+            else:
+                setattr(result, k, deepcopy(v, memo))
+        return result
+
     def __repr__(self) -> str:
-        return f"MiddlewareChain(middleware={self._middleware!r}, "
+        return f"MiddlewareChain(middleware={self._middleware!r})"

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -184,7 +184,7 @@ class Node(ABC, Generic[_P, _TOutput]):
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
             *middleware,
-            *deepcopy(cls._user_middleware),
+            *cls._user_middleware,
         ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_middleware": new_middleware})
 
@@ -194,7 +194,7 @@ class Node(ABC, Generic[_P, _TOutput]):
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
             *middleware,
-            *deepcopy(cls._user_model_middleware),
+            *cls._user_model_middleware,
         ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_model_middleware": new_middleware})
 

--- a/packages/railtracks/src/railtracks/nodes/nodes.py
+++ b/packages/railtracks/src/railtracks/nodes/nodes.py
@@ -184,7 +184,7 @@ class Node(ABC, Generic[_P, _TOutput]):
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
             *middleware,
-            *cls._user_middleware,
+            *deepcopy(cls._user_middleware),
         ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_middleware": new_middleware})
 
@@ -194,7 +194,7 @@ class Node(ABC, Generic[_P, _TOutput]):
     ) -> type[Node[_P, _TOutput]]:
         new_middleware = [
             *middleware,
-            *cls._user_model_middleware,
+            *deepcopy(cls._user_model_middleware),
         ]  # new middleware goes outermost; fresh list as a nice protection around things
         return type(cls.__name__, (cls,), {"_user_model_middleware": new_middleware})
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 from railtracks.middleware.core import Middleware
 
@@ -15,10 +14,6 @@ class Lock(Middleware):
     def __init__(self):
         self._lock = asyncio.Lock()
         super().__init__(self._middleware_fn)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> Lock:
-        memo[id(self)] = self
-        return self
 
     async def _middleware_fn(self, call, *args, **kwargs):
         async with self._lock:

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/lock.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from railtracks.middleware.core import Middleware
 
@@ -14,6 +15,10 @@ class Lock(Middleware):
     def __init__(self):
         self._lock = asyncio.Lock()
         super().__init__(self._middleware_fn)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Lock:
+        memo[id(self)] = self
+        return self
 
     async def _middleware_fn(self, call, *args, **kwargs):
         async with self._lock:

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+import uuid
+from collections import defaultdict
+from typing import ClassVar
 
 from railtracks.context.central import get_session_identity, is_context_present
 from railtracks.middleware.core import Middleware
@@ -45,6 +47,9 @@ class MaxCalls(Middleware):
             ``max_calls`` times.
     """
 
+    _session_counts: ClassVar[dict[tuple[str, str], int]] = defaultdict(int)
+    _lifetime_counts: ClassVar[dict[str, int]] = defaultdict(int)
+
     def __init__(
         self,
         max_calls: int,
@@ -53,15 +58,10 @@ class MaxCalls(Middleware):
         per_run: bool = True,
     ):
         self._max_calls = max_calls
-        self._call_count = 0
+        self._budget_id = str(uuid.uuid4())
         self._custom_message = custom_message
         self._per_run = per_run
-        self._session_counts: dict[str, int] = {}
         super().__init__(self._middleware_fn)
-
-    def __deepcopy__(self, memo: dict[int, Any]) -> MaxCalls:
-        memo[id(self)] = self
-        return self
 
     @property
     def max_calls(self) -> int:
@@ -78,33 +78,41 @@ class MaxCalls(Middleware):
         """The current number of calls made against this budget.
 
         When ``per_run=True`` and inside an active session, returns the call count
-        for the current session. Otherwise, returns the instance-level call count.
+        for the current session. Otherwise, returns the lifetime call count.
         """
         if self._per_run and is_context_present():
             try:
                 sess_id = get_session_identity().session_id
-                return self._session_counts.get(sess_id, 0)
+                return self._session_counts.get((self._budget_id, sess_id), 0)
             except Exception:
                 pass
-        return self._call_count
+        return self._lifetime_counts.get(self._budget_id, 0)
+
+    @property
+    def _call_count(self) -> int:
+        return self.call_count
 
     @property
     def total_call_count(self) -> int:
         """The total number of calls made across all sessions for the lifetime of this instance."""
-        return self._call_count
+        return self._lifetime_counts.get(self._budget_id, 0)
 
     def reset(self, session_id: str | None = None) -> None:
         """Reset the call counter.
 
         Args:
             session_id: If provided, resets only the counter for that session ID.
-                If None, clears all session counters and resets the instance counter.
+                If None, clears all session counters and resets the lifetime counter for this budget.
         """
         if session_id is not None:
-            self._session_counts.pop(session_id, None)
+            self._session_counts.pop((self._budget_id, session_id), None)
         else:
-            self._session_counts.clear()
-            self._call_count = 0
+            keys_to_remove = [
+                k for k in self._session_counts if k[0] == self._budget_id
+            ]
+            for k in keys_to_remove:
+                del self._session_counts[k]
+            self._lifetime_counts.pop(self._budget_id, None)
 
     async def _middleware_fn(self, call, *args, **kwargs):
         in_session = False
@@ -117,19 +125,23 @@ class MaxCalls(Middleware):
                 in_session = False
 
         if in_session and sess_id is not None:
-            current_count = self._session_counts.get(sess_id, 0)
+            key = (self._budget_id, sess_id)
+            current_count = self._session_counts.get(key, 0)
             if current_count >= self._max_calls:
                 if self._custom_message:
                     raise MaxCallsExceededError(self._custom_message)
                 raise MaxCallsExceededError("Maximum number of calls exceeded")
-            self._session_counts[sess_id] = current_count + 1
-            self._call_count += 1
+            self._session_counts[key] = current_count + 1
+            self._lifetime_counts[self._budget_id] = (
+                self._lifetime_counts.get(self._budget_id, 0) + 1
+            )
         else:
-            if self._call_count >= self._max_calls:
+            current_count = self._lifetime_counts.get(self._budget_id, 0)
+            if current_count >= self._max_calls:
                 if self._custom_message:
                     raise MaxCallsExceededError(self._custom_message)
                 raise MaxCallsExceededError("Maximum number of calls exceeded")
-            self._call_count += 1
+            self._lifetime_counts[self._budget_id] = current_count + 1
         return await call(*args, **kwargs)
 
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -25,42 +25,31 @@ class MaxCalls(Middleware):
             model_middleware=[middleware.MaxCalls(5)],  # cap raw model calls
         )
 
-    The count is tracked per ``MaxCalls`` instance, so a single instance shared
-    across nodes enforces a combined budget, while a fresh instance per node
-    gives each its own limit.
-
-    By default (``per_run=True``), the budget applies to each workflow run / session,
-    resetting to zero when a new session begins. If ``per_run=False``, the budget
-    accumulates across runs for the lifetime of this ``MaxCalls`` instance until
-    explicitly reset via :meth:`reset`.
+    The count is tracked per workflow run / session, resetting to zero when a new
+    session begins. A single ``MaxCalls`` instance shared across nodes within the
+    same run enforces a combined budget, while a fresh instance per node gives
+    each its own limit.
 
     Args:
         max_calls: Number of calls allowed before the limit is enforced.
         custom_message: Message to raise once the limit is exceeded. Defaults
             to ``"Maximum number of calls exceeded"``.
-        per_run: If True (default), the budget resets per execution session / run.
-            If False, the budget accumulates across multiple runs for the lifetime
-            of this instance.
 
     Raises:
         MaxCallsExceededError: Once ``call`` has already been invoked
             ``max_calls`` times.
     """
 
-    _session_counts: ClassVar[dict[tuple[str, str], int]] = defaultdict(int)
-    _lifetime_counts: ClassVar[dict[str, int]] = defaultdict(int)
+    _counts: ClassVar[dict[tuple[str, str | None], int]] = defaultdict(int)
 
     def __init__(
         self,
         max_calls: int,
         custom_message: str | None = None,
-        *,
-        per_run: bool = True,
     ):
         self._max_calls = max_calls
         self._budget_id = str(uuid.uuid4())
         self._custom_message = custom_message
-        self._per_run = per_run
         super().__init__(self._middleware_fn)
 
     @property
@@ -68,80 +57,46 @@ class MaxCalls(Middleware):
         """The maximum number of calls allowed before raising."""
         return self._max_calls
 
-    @property
-    def per_run(self) -> bool:
-        """Whether the budget resets per execution session / run."""
-        return self._per_run
+    def _get_current_key(self) -> tuple[str, str | None]:
+        sess_id = None
+        if is_context_present():
+            try:
+                sess_id = get_session_identity().session_id
+            except Exception:
+                sess_id = None
+        return (self._budget_id, sess_id)
 
     @property
     def call_count(self) -> int:
-        """The current number of calls made against this budget.
-
-        When ``per_run=True`` and inside an active session, returns the call count
-        for the current session. Otherwise, returns the lifetime call count.
-        """
-        if self._per_run and is_context_present():
-            try:
-                sess_id = get_session_identity().session_id
-                return self._session_counts.get((self._budget_id, sess_id), 0)
-            except Exception:
-                pass
-        return self._lifetime_counts.get(self._budget_id, 0)
+        """The current number of calls made against this budget in the active session."""
+        return self._counts.get(self._get_current_key(), 0)
 
     @property
     def _call_count(self) -> int:
         return self.call_count
-
-    @property
-    def total_call_count(self) -> int:
-        """The total number of calls made across all sessions for the lifetime of this instance."""
-        return self._lifetime_counts.get(self._budget_id, 0)
 
     def reset(self, session_id: str | None = None) -> None:
         """Reset the call counter.
 
         Args:
             session_id: If provided, resets only the counter for that session ID.
-                If None, clears all session counters and resets the lifetime counter for this budget.
+                If None, clears all session counters for this budget.
         """
         if session_id is not None:
-            self._session_counts.pop((self._budget_id, session_id), None)
+            self._counts.pop((self._budget_id, session_id), None)
         else:
-            keys_to_remove = [
-                k for k in self._session_counts if k[0] == self._budget_id
-            ]
+            keys_to_remove = [k for k in self._counts if k[0] == self._budget_id]
             for k in keys_to_remove:
-                del self._session_counts[k]
-            self._lifetime_counts.pop(self._budget_id, None)
+                del self._counts[k]
 
     async def _middleware_fn(self, call, *args, **kwargs):
-        in_session = False
-        sess_id = None
-        if self._per_run and is_context_present():
-            try:
-                sess_id = get_session_identity().session_id
-                in_session = True
-            except Exception:
-                in_session = False
-
-        if in_session and sess_id is not None:
-            key = (self._budget_id, sess_id)
-            current_count = self._session_counts.get(key, 0)
-            if current_count >= self._max_calls:
-                if self._custom_message:
-                    raise MaxCallsExceededError(self._custom_message)
-                raise MaxCallsExceededError("Maximum number of calls exceeded")
-            self._session_counts[key] = current_count + 1
-            self._lifetime_counts[self._budget_id] = (
-                self._lifetime_counts.get(self._budget_id, 0) + 1
-            )
-        else:
-            current_count = self._lifetime_counts.get(self._budget_id, 0)
-            if current_count >= self._max_calls:
-                if self._custom_message:
-                    raise MaxCallsExceededError(self._custom_message)
-                raise MaxCallsExceededError("Maximum number of calls exceeded")
-            self._lifetime_counts[self._budget_id] = current_count + 1
+        key = self._get_current_key()
+        current_count = self._counts.get(key, 0)
+        if current_count >= self._max_calls:
+            if self._custom_message:
+                raise MaxCallsExceededError(self._custom_message)
+            raise MaxCallsExceededError("Maximum number of calls exceeded")
+        self._counts[key] = current_count + 1
         return await call(*args, **kwargs)
 
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,3 +1,8 @@
+from __future__ import annotations
+
+from typing import Any
+
+from railtracks.context.central import get_session_identity, is_context_present
 from railtracks.middleware.core import Middleware
 
 
@@ -22,28 +27,109 @@ class MaxCalls(Middleware):
     across nodes enforces a combined budget, while a fresh instance per node
     gives each its own limit.
 
+    By default (``per_run=True``), the budget applies to each workflow run / session,
+    resetting to zero when a new session begins. If ``per_run=False``, the budget
+    accumulates across runs for the lifetime of this ``MaxCalls`` instance until
+    explicitly reset via :meth:`reset`.
+
     Args:
         max_calls: Number of calls allowed before the limit is enforced.
         custom_message: Message to raise once the limit is exceeded. Defaults
             to ``"Maximum number of calls exceeded"``.
+        per_run: If True (default), the budget resets per execution session / run.
+            If False, the budget accumulates across multiple runs for the lifetime
+            of this instance.
 
     Raises:
         MaxCallsExceededError: Once ``call`` has already been invoked
             ``max_calls`` times.
     """
 
-    def __init__(self, max_calls: int, custom_message: str | None = None):
+    def __init__(
+        self,
+        max_calls: int,
+        custom_message: str | None = None,
+        *,
+        per_run: bool = True,
+    ):
         self._max_calls = max_calls
         self._call_count = 0
         self._custom_message = custom_message
+        self._per_run = per_run
+        self._session_counts: dict[str, int] = {}
         super().__init__(self._middleware_fn)
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> MaxCalls:
+        memo[id(self)] = self
+        return self
+
+    @property
+    def max_calls(self) -> int:
+        """The maximum number of calls allowed before raising."""
+        return self._max_calls
+
+    @property
+    def per_run(self) -> bool:
+        """Whether the budget resets per execution session / run."""
+        return self._per_run
+
+    @property
+    def call_count(self) -> int:
+        """The current number of calls made against this budget.
+
+        When ``per_run=True`` and inside an active session, returns the call count
+        for the current session. Otherwise, returns the instance-level call count.
+        """
+        if self._per_run and is_context_present():
+            try:
+                sess_id = get_session_identity().session_id
+                return self._session_counts.get(sess_id, 0)
+            except Exception:
+                pass
+        return self._call_count
+
+    @property
+    def total_call_count(self) -> int:
+        """The total number of calls made across all sessions for the lifetime of this instance."""
+        return self._call_count
+
+    def reset(self, session_id: str | None = None) -> None:
+        """Reset the call counter.
+
+        Args:
+            session_id: If provided, resets only the counter for that session ID.
+                If None, clears all session counters and resets the instance counter.
+        """
+        if session_id is not None:
+            self._session_counts.pop(session_id, None)
+        else:
+            self._session_counts.clear()
+            self._call_count = 0
+
     async def _middleware_fn(self, call, *args, **kwargs):
-        if self._call_count >= self._max_calls:
-            if self._custom_message:
-                raise MaxCallsExceededError(self._custom_message)
-            raise MaxCallsExceededError("Maximum number of calls exceeded")
-        self._call_count += 1
+        in_session = False
+        sess_id = None
+        if self._per_run and is_context_present():
+            try:
+                sess_id = get_session_identity().session_id
+                in_session = True
+            except Exception:
+                in_session = False
+
+        if in_session and sess_id is not None:
+            current_count = self._session_counts.get(sess_id, 0)
+            if current_count >= self._max_calls:
+                if self._custom_message:
+                    raise MaxCallsExceededError(self._custom_message)
+                raise MaxCallsExceededError("Maximum number of calls exceeded")
+            self._session_counts[sess_id] = current_count + 1
+            self._call_count += 1
+        else:
+            if self._call_count >= self._max_calls:
+                if self._custom_message:
+                    raise MaxCallsExceededError(self._custom_message)
+                raise MaxCallsExceededError("Maximum number of calls exceeded")
+            self._call_count += 1
         return await call(*args, **kwargs)
 
 

--- a/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
+++ b/packages/railtracks/src/railtracks/prebuilt/middleware/max_calls.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import uuid
-from collections import defaultdict
-from typing import ClassVar
-
 from railtracks.context.central import get_session_identity, is_context_present
+from railtracks.exceptions.errors import ContextError
 from railtracks.middleware.core import Middleware
 
 
@@ -40,16 +37,16 @@ class MaxCalls(Middleware):
             ``max_calls`` times.
     """
 
-    _counts: ClassVar[dict[tuple[str, str | None], int]] = defaultdict(int)
-
     def __init__(
         self,
         max_calls: int,
         custom_message: str | None = None,
     ):
         self._max_calls = max_calls
-        self._budget_id = str(uuid.uuid4())
         self._custom_message = custom_message
+        # Keyed by session_id (str) when inside a run; None when outside.
+        # Each session gets its own independent counter.
+        self._session_counts: dict[str | None, int] = {}
         super().__init__(self._middleware_fn)
 
     @property
@@ -57,46 +54,42 @@ class MaxCalls(Middleware):
         """The maximum number of calls allowed before raising."""
         return self._max_calls
 
-    def _get_current_key(self) -> tuple[str, str | None]:
-        sess_id = None
+    def _current_session_id(self) -> str | None:
+        """Return the active session ID, or ``None`` if not inside a run."""
         if is_context_present():
             try:
-                sess_id = get_session_identity().session_id
-            except Exception:
-                sess_id = None
-        return (self._budget_id, sess_id)
+                return get_session_identity().session_id
+            except ContextError:
+                return None
+        return None
 
     @property
     def call_count(self) -> int:
         """The current number of calls made against this budget in the active session."""
-        return self._counts.get(self._get_current_key(), 0)
+        return self._session_counts.get(self._current_session_id(), 0)
 
-    @property
-    def _call_count(self) -> int:
-        return self.call_count
+    def reset(self) -> None:
+        """Reset the call counter for the current session.
 
-    def reset(self, session_id: str | None = None) -> None:
-        """Reset the call counter.
-
-        Args:
-            session_id: If provided, resets only the counter for that session ID.
-                If None, clears all session counters for this budget.
+        When called inside a run, clears only the active session's counter.
+        When called outside a run, clears the out-of-session counter.
         """
-        if session_id is not None:
-            self._counts.pop((self._budget_id, session_id), None)
-        else:
-            keys_to_remove = [k for k in self._counts if k[0] == self._budget_id]
-            for k in keys_to_remove:
-                del self._counts[k]
+        self._session_counts.pop(self._current_session_id(), None)
+
+    def reset_all(self) -> None:
+        """Reset call counters for all sessions."""
+        self._session_counts.clear()
 
     async def _middleware_fn(self, call, *args, **kwargs):
-        key = self._get_current_key()
-        current_count = self._counts.get(key, 0)
+        sess_id = self._current_session_id()
+        # Read-modify-write is safe under a single event loop (no await
+        # between the read and the write).
+        current_count = self._session_counts.get(sess_id, 0)
         if current_count >= self._max_calls:
             if self._custom_message:
                 raise MaxCallsExceededError(self._custom_message)
             raise MaxCallsExceededError("Maximum number of calls exceeded")
-        self._counts[key] = current_count + 1
+        self._session_counts[sess_id] = current_count + 1
         return await call(*args, **kwargs)
 
 

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -64,7 +64,7 @@ async def test_count_is_not_incremented_once_limit_is_hit():
         ):
             await max_calls.wrap(noop)()
 
-    assert max_calls._call_count == 0
+    assert max_calls.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -77,7 +77,7 @@ async def test_wrapped_exception_propagates_and_still_counts_the_call():
     with pytest.raises(ValueError, match="broken"):
         await max_calls.wrap(broken)()
 
-    assert max_calls._call_count == 1
+    assert max_calls.call_count == 1
 
 
 def test_node_middleware_slot_enforces_limit_inside_single_run():
@@ -194,3 +194,57 @@ def test_agent_node_middleware_slot_enforces_limit(mock_llm):
     flow = rt.Flow("agent-node-slot", entry_point=driver)
     results = flow.invoke(n=3)
     assert results == ["hello", "hello", "MaxCallsExceededError"]
+
+
+def test_lock_middleware_shared_across_nodes_preserves_reference():
+    """Lock instances survive Node.safe_copy() via MiddlewareChain.__deepcopy__."""
+    import railtracks as rt
+    from railtracks.prebuilt.middleware.lock import Lock
+
+    shared_lock = Lock()
+
+    @rt.function_node(middleware=[shared_lock])
+    def t1(x: int) -> int:
+        return x
+
+    @rt.function_node(middleware=[shared_lock])
+    def t2(x: int) -> int:
+        return x
+
+    node1 = t1.node_type()
+    node2 = t2.node_type()
+
+    # safe_copy must preserve the Lock reference
+    copied_node = node1.safe_copy()
+    assert copied_node.middleware.middleware[0] is shared_lock
+
+    # Both nodes share the same Lock
+    assert node1.middleware.middleware[0] is node2.middleware.middleware[0]
+
+
+def test_concurrent_sessions_get_independent_budgets():
+    """Two concurrent runs sharing a MaxCalls instance get independent counters."""
+    import railtracks as rt
+
+    shared = MaxCalls(2, custom_message="cap hit")
+
+    @rt.function_node(middleware=[shared])
+    def tool(x: str) -> str:
+        return x
+
+    @rt.function_node
+    async def driver(n: int) -> list[str]:
+        out = []
+        for i in range(n):
+            try:
+                out.append(await rt.call(tool, x=str(i)))
+            except Exception as e:
+                out.append(type(e).__name__)
+        return out
+
+    flow_a = rt.Flow("session-a", entry_point=driver)
+    flow_b = rt.Flow("session-b", entry_point=driver)
+
+    # Each flow gets its own session, so each gets a fresh budget of 2
+    assert flow_a.invoke(n=3) == ["0", "1", "MaxCallsExceededError"]
+    assert flow_b.invoke(n=3) == ["0", "1", "MaxCallsExceededError"]

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -152,30 +152,6 @@ def test_multiple_nodes_share_combined_budget():
     assert flow.invoke() == ["A:1", "A:2", "B:3", "MaxCallsExceededError"]
 
 
-def test_lifetime_budget_with_per_run_false():
-    import railtracks as rt
-
-    budget = MaxCalls(2, custom_message="lifetime hit", per_run=False)
-
-    @rt.function_node(middleware=[budget])
-    def tool(x: str) -> str:
-        return x
-
-    @rt.function_node
-    async def driver(x: str) -> str:
-        return await rt.call(tool, x=x)
-
-    flow = rt.Flow("lifetime-flow", entry_point=driver)
-    assert flow.invoke(x="1") == "1"
-    assert flow.invoke(x="2") == "2"
-
-    with pytest.raises(Exception) as exc_info:
-        flow.invoke(x="3")
-    assert "lifetime hit" in str(exc_info.value) or isinstance(
-        exc_info.value, MaxCallsExceededError
-    )
-
-
 @pytest.mark.asyncio
 async def test_call_count_property_and_reset():
     async def noop():

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -78,3 +78,169 @@ async def test_wrapped_exception_propagates_and_still_counts_the_call():
         await max_calls.wrap(broken)()
 
     assert max_calls._call_count == 1
+
+
+def test_node_middleware_slot_enforces_limit_inside_single_run():
+    import railtracks as rt
+
+    @rt.function_node(middleware=[MaxCalls(2, custom_message="tool budget hit")])
+    def limited(x: str) -> str:
+        return x
+
+    @rt.function_node
+    async def driver(n: int) -> list[str]:
+        out = []
+        for i in range(n):
+            try:
+                out.append(await rt.call(limited, x=str(i)))
+            except Exception as e:
+                out.append(type(e).__name__)
+        return out
+
+    flow = rt.Flow("node-slot-repro", entry_point=driver)
+    results = flow.invoke(n=4)
+    assert results == ["0", "1", "MaxCallsExceededError", "MaxCallsExceededError"]
+
+
+def test_node_middleware_slot_starts_fresh_on_subsequent_run():
+    import railtracks as rt
+
+    @rt.function_node(middleware=[MaxCalls(2, custom_message="tool budget hit")])
+    def limited(x: str) -> str:
+        return x
+
+    @rt.function_node
+    async def driver(n: int) -> list[str]:
+        out = []
+        for i in range(n):
+            try:
+                out.append(await rt.call(limited, x=str(i)))
+            except Exception as e:
+                out.append(type(e).__name__)
+        return out
+
+    flow = rt.Flow("node-slot-fresh-run", entry_point=driver)
+    assert flow.invoke(n=2) == ["0", "1"]
+    assert flow.invoke(n=2) == ["0", "1"]
+
+
+def test_multiple_nodes_share_combined_budget():
+    import railtracks as rt
+
+    shared_budget = MaxCalls(3, custom_message="shared cap hit")
+
+    @rt.function_node(middleware=[shared_budget])
+    def tool_a(x: str) -> str:
+        return f"A:{x}"
+
+    @rt.function_node(middleware=[shared_budget])
+    def tool_b(x: str) -> str:
+        return f"B:{x}"
+
+    @rt.function_node
+    async def driver() -> list[str]:
+        out = []
+        for f, arg in [(tool_a, "1"), (tool_a, "2"), (tool_b, "3"), (tool_b, "4")]:
+            try:
+                out.append(await rt.call(f, x=arg))
+            except Exception as e:
+                out.append(type(e).__name__)
+        return out
+
+    flow = rt.Flow("shared-budget-flow", entry_point=driver)
+    assert flow.invoke() == ["A:1", "A:2", "B:3", "MaxCallsExceededError"]
+    assert flow.invoke() == ["A:1", "A:2", "B:3", "MaxCallsExceededError"]
+
+
+def test_lifetime_budget_with_per_run_false():
+    import railtracks as rt
+
+    budget = MaxCalls(2, custom_message="lifetime hit", per_run=False)
+
+    @rt.function_node(middleware=[budget])
+    def tool(x: str) -> str:
+        return x
+
+    @rt.function_node
+    async def driver(x: str) -> str:
+        return await rt.call(tool, x=x)
+
+    flow = rt.Flow("lifetime-flow", entry_point=driver)
+    assert flow.invoke(x="1") == "1"
+    assert flow.invoke(x="2") == "2"
+
+    with pytest.raises(Exception) as exc_info:
+        flow.invoke(x="3")
+    assert "lifetime hit" in str(exc_info.value) or isinstance(
+        exc_info.value, MaxCallsExceededError
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_count_property_and_reset():
+    async def noop():
+        return None
+
+    max_calls = MaxCalls(3)
+    assert max_calls.call_count == 0
+
+    await max_calls.wrap(noop)()
+    await max_calls.wrap(noop)()
+    assert max_calls.call_count == 2
+
+    max_calls.reset()
+    assert max_calls.call_count == 0
+
+    await max_calls.wrap(noop)()
+    assert max_calls.call_count == 1
+
+
+def test_lock_middleware_shared_across_nodes_preserves_reference():
+    import railtracks as rt
+    from railtracks.prebuilt.middleware.lock import Lock
+
+    shared_lock = Lock()
+
+    @rt.function_node(middleware=[shared_lock])
+    def t1(x: int) -> int:
+        return x
+
+    @rt.function_node(middleware=[shared_lock])
+    def t2(x: int) -> int:
+        return x
+
+    assert t1.node_type._user_middleware[0] is shared_lock
+    assert t2.node_type._user_middleware[0] is shared_lock
+
+    node1 = t1.node_type()
+    node2 = t2.node_type()
+    assert node1.middleware.middleware[0] is shared_lock
+    assert node2.middleware.middleware[0] is shared_lock
+
+    # safe_copy must also keep the reference
+    copied_node = node1.safe_copy()
+    assert copied_node.middleware.middleware[0] is shared_lock
+
+
+def test_agent_node_preserves_middleware_reference(mock_llm):
+    from railtracks.built_nodes.llm.node import agent_node
+
+    budget = MaxCalls(5)
+    agent_a = agent_node("AgentA", llm=mock_llm, middleware=[budget])
+    agent_b = agent_node("AgentB", llm=mock_llm, middleware=[budget])
+
+    assert agent_a._user_middleware[0] is budget
+    assert agent_b._user_middleware[0] is budget
+    assert agent_a._user_middleware[0] is agent_b._user_middleware[0]
+
+
+def test_agent_node_preserves_model_middleware_reference(mock_llm):
+    from railtracks.built_nodes.llm.node import agent_node
+
+    budget = MaxCalls(5)
+    agent_a = agent_node("AgentA", llm=mock_llm, model_middleware=[budget])
+    agent_b = agent_node("AgentB", llm=mock_llm, model_middleware=[budget])
+
+    assert agent_a._user_model_middleware[0] is budget
+    assert agent_b._user_model_middleware[0] is budget
+    assert agent_a._user_model_middleware[0] is agent_b._user_model_middleware[0]

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_max_calls.py
@@ -195,52 +195,26 @@ async def test_call_count_property_and_reset():
     assert max_calls.call_count == 1
 
 
-def test_lock_middleware_shared_across_nodes_preserves_reference():
+def test_agent_node_middleware_slot_enforces_limit(mock_llm):
     import railtracks as rt
-    from railtracks.prebuilt.middleware.lock import Lock
 
-    shared_lock = Lock()
+    agent = rt.agent_node(
+        "Agent",
+        llm=mock_llm(custom_response="hello"),
+        middleware=[MaxCalls(2, custom_message="agent limit hit")],
+    )
 
-    @rt.function_node(middleware=[shared_lock])
-    def t1(x: int) -> int:
-        return x
+    @rt.function_node
+    async def driver(n: int) -> list[str]:
+        out = []
+        for i in range(n):
+            try:
+                res = await rt.call(agent, user_input=f"query {i}")
+                out.append(res.content)
+            except Exception as e:
+                out.append(type(e).__name__)
+        return out
 
-    @rt.function_node(middleware=[shared_lock])
-    def t2(x: int) -> int:
-        return x
-
-    assert t1.node_type._user_middleware[0] is shared_lock
-    assert t2.node_type._user_middleware[0] is shared_lock
-
-    node1 = t1.node_type()
-    node2 = t2.node_type()
-    assert node1.middleware.middleware[0] is shared_lock
-    assert node2.middleware.middleware[0] is shared_lock
-
-    # safe_copy must also keep the reference
-    copied_node = node1.safe_copy()
-    assert copied_node.middleware.middleware[0] is shared_lock
-
-
-def test_agent_node_preserves_middleware_reference(mock_llm):
-    from railtracks.built_nodes.llm.node import agent_node
-
-    budget = MaxCalls(5)
-    agent_a = agent_node("AgentA", llm=mock_llm, middleware=[budget])
-    agent_b = agent_node("AgentB", llm=mock_llm, middleware=[budget])
-
-    assert agent_a._user_middleware[0] is budget
-    assert agent_b._user_middleware[0] is budget
-    assert agent_a._user_middleware[0] is agent_b._user_middleware[0]
-
-
-def test_agent_node_preserves_model_middleware_reference(mock_llm):
-    from railtracks.built_nodes.llm.node import agent_node
-
-    budget = MaxCalls(5)
-    agent_a = agent_node("AgentA", llm=mock_llm, model_middleware=[budget])
-    agent_b = agent_node("AgentB", llm=mock_llm, model_middleware=[budget])
-
-    assert agent_a._user_model_middleware[0] is budget
-    assert agent_b._user_model_middleware[0] is budget
-    assert agent_a._user_model_middleware[0] is agent_b._user_model_middleware[0]
+    flow = rt.Flow("agent-node-slot", entry_point=driver)
+    results = flow.invoke(n=3)
+    assert results == ["hello", "hello", "MaxCallsExceededError"]


### PR DESCRIPTION
## Summary

Fixes #1560.

`MaxCalls` in the node-level `middleware=` slot never enforced its cap, for any `max_calls > 0`. `Node.safe_copy()` deep-copies a node on every invocation, so each invocation got a fresh `MaxCalls` clone with a zeroed counter.

The root cause is that middleware instances were treated as per-node payload state rather than as shared policy objects. Fixing that one assumption fixes `MaxCalls`, `Lock`, and any future stateful middleware at the same time.

### 1. Preserve middleware identity across copies

`MiddlewareChain.__deepcopy__` shallow-copies the middleware list, so `Node.safe_copy()` keeps the same middleware instances instead of cloning them. Every other attribute is still deep-copied.

`agent_node` additionally deep-copied the `middleware=` and `model_middleware=` lists at build time (`node_builder.py`). That silently defeated the fix for agents: two agents sharing one `MaxCalls` each got their own clone, `Lock` never serialized between them, and `call_count`/`reset()` on the caller's handle acted on an instance nothing was incrementing. Only the list is copied now, matching `function_node`, whose builder has always used `list(middleware)` with no `deepcopy`.

### 2. Scope the budget per run

Counts are tracked per session id, so a new run starts fresh while all calls within one run — across every node sharing the instance — spend one budget. Overlapping runs keep independent counters.

### 3. Inspection and control

`call_count` and `reset()` act on the live session inside a run. Outside one they fall back to the most recently counted session, so the budget a flow spent is readable after `invoke()` returns rather than reporting zero. Counting itself always uses the live session and never falls back, so a call made outside a run cannot spend a finished run's budget. `reset_all()` clears every session; retained counters are capped at the 64 most recent so a long-lived instance cannot grow without bound.

### 4. Tests and docs

Regression coverage for node-level enforcement, fresh budgets on subsequent runs, genuinely overlapping runs via `asyncio.gather`, post-run inspection, counter eviction, shared budgets across nodes, and instance preservation through `safe_copy()` and the agent builder for both `MaxCalls` and `Lock`. `max_calls.md` documents run scoping, shared budgets, post-run inspection and the retention cap.

## Behavior change

Passing one middleware instance to two `agent_node`s now shares it rather than giving each a private clone. This is the documented intent, and it aligns `agent_node` with `function_node`, which already behaved this way. Passing a fresh instance per node still gives each its own budget, and mutating your list after building a node still has no effect on it.

`Node.extend_middleware` (reachable only through `rt.couple`) still deep-copies, so coupling a node that carries a shared instance produces a clone. Left alone here as a separate, narrower path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Breaking change
- [x] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check packages/railtracks && ruff format --check packages/railtracks`)
- [x] Tests added/updated and pass locally
- [x] Docs updated

## Verification

- Reproduction from #1560: 4 calls to a node budgeted at 2 return `['0', '1', 'MaxCallsExceededError', 'MaxCallsExceededError']`; the next run starts fresh.
- Unit + integration suites green (2132 passed, 6 skipped), excluding the retrieval/cli/tools/mcp dirs that need optional deps or network.
