### PR TITLE
1431 surface thinking token in llm response

### DIFF
--- a/docs/documentation/agent_design/llms/common_hyperparams.md
+++ b/docs/documentation/agent_design/llms/common_hyperparams.md
@@ -24,6 +24,30 @@ controlling sampling, output length, and reasoning behavior.
 --8<-- "docs/scripts/documentation/common_hyperparams.py:reasoning_effort"
 ```
 
+## Accessing the reasoning a model returned
+
+Reasoning-capable providers (Anthropic, DeepSeek, Gemini, OpenAI in part) can return
+their intermediate "thinking" alongside the answer. When they do, railtracks surfaces it
+on the response so you never have to reach into provider internals:
+
+```python
+response = await model.achat(history)
+
+print(response.reasoning)              # human-readable reasoning text, or None
+print(response.message.reasoning_content)  # same text, on the message
+print(response.message.thinking_blocks)    # structured, signed blocks (or None)
+```
+
+- `response.reasoning` (and `response.message.reasoning_content`) is the plain-text
+  reasoning: `None` when the model returned none (a non-reasoning model, or one not
+  asked to expose its thinking).
+- `response.message.thinking_blocks` holds the structured blocks, including any provider
+  signatures. Because reasoning lives on the assistant *message*, it travels with the
+  message in history and is included when the run graph is serialized.
+
+Streaming works the same way: the reasoning is accumulated and attached to the final
+`Response` yielded by `astream_*` (reasoning is not emitted as separate stream chunks).
+
 ## Not every model supports every hyperparameter
 
 For example, only OpenAI's GPT-5-series supports `verbosity`, and newer Anthropic

--- a/packages/railtracks/src/railtracks/llm/message.py
+++ b/packages/railtracks/src/railtracks/llm/message.py
@@ -382,6 +382,11 @@ class AssistantMessage(Message[_T, Role.assistant], Generic[_T]):
         # it back without any manual reconstruction.
         self.raw_litellm_message: Any | None = None
 
+        # Reasoning/"thinking" the model surfaced alongside its answer, when the
+        # provider returns it (Anthropic, DeepSeek, Gemini, OpenAI in part).
+        self.reasoning_content: str | None = None  # human-readable text
+        self.thinking_blocks: list[dict[str, Any]] | None = None  # structured blocks of reasoning, e.g. Gemini's thought_signature
+
     def encode(self):
         encoded = super().encode()
 
@@ -389,6 +394,13 @@ class AssistantMessage(Message[_T, Role.assistant], Generic[_T]):
         # spoke with its calls; surface it the way providers put it on the wire.
         if isinstance(self.content, ToolCalls) and self.content.text is not None:
             encoded["text"] = self.content.text
+
+        # Surface reasoning in the serialized message so it is visible in the run
+        # graph/session data, not just on the live object.
+        if self.reasoning_content is not None:
+            encoded["reasoning_content"] = self.reasoning_content
+        if self.thinking_blocks is not None:
+            encoded["thinking_blocks"] = self.thinking_blocks
 
         return encoded
 

--- a/packages/railtracks/src/railtracks/llm/message.py
+++ b/packages/railtracks/src/railtracks/llm/message.py
@@ -385,7 +385,9 @@ class AssistantMessage(Message[_T, Role.assistant], Generic[_T]):
         # Reasoning/"thinking" the model surfaced alongside its answer, when the
         # provider returns it (Anthropic, DeepSeek, Gemini, OpenAI in part).
         self.reasoning_content: str | None = None  # human-readable text
-        self.thinking_blocks: list[dict[str, Any]] | None = None  # structured blocks of reasoning, e.g. Gemini's thought_signature
+        self.thinking_blocks: list[dict[str, Any]] | None = (
+            None  # structured blocks of reasoning, e.g. Gemini's thought_signature
+        )
 
     def encode(self):
         encoded = super().encode()

--- a/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
+++ b/packages/railtracks/src/railtracks/llm/models/_litellm_wrapper.py
@@ -207,6 +207,19 @@ def _to_litellm_tool(tool: Tool) -> Dict[str, Any]:
     return litellm_tool
 
 
+def _attach_reasoning(assistant_msg: AssistantMessage, source: Any) -> AssistantMessage:
+    """Copy any reasoning/thinking the provider returned from a litellm message or
+    delta onto the assistant message.
+
+    `reasoning_content` (text) and `thinking_blocks` (signed structured blocks) are
+    only present on `source` when the provider surfaced reasoning, so both are read
+    with `getattr(..., None)`. Returns the same message for convenient chaining.
+    """
+    assistant_msg.reasoning_content = getattr(source, "reasoning_content", None)
+    assistant_msg.thinking_blocks = getattr(source, "thinking_blocks", None)
+    return assistant_msg
+
+
 class StreamedToolCall(BaseModel):
     tool: ToolCall
     args: str | None = Field(default=None)  # accumulating string of arguments (in json)
@@ -548,6 +561,11 @@ class LiteLLMWrapper(ModelBase, ABC):
 
         """
         accumulated_content = ""
+        # Reasoning/"thinking" arrives in its own deltas (before the content deltas)
+        # on providers that surface it; accumulate the text and collect the signed
+        # blocks so the final Response carries them like a buffered call would.
+        accumulated_reasoning = ""
+        accumulated_thinking_blocks: List[dict] = []
 
         # fall back on empty message info if we don't get one from the stream.
         message_info = MessageInfo()
@@ -575,6 +593,13 @@ class LiteLLMWrapper(ModelBase, ABC):
                 stream_finished = True
                 continue
 
+            reasoning_delta = getattr(choice.delta, "reasoning_content", None)
+            if reasoning_delta:
+                accumulated_reasoning += reasoning_delta
+            thinking_delta = getattr(choice.delta, "thinking_blocks", None)
+            if thinking_delta:
+                accumulated_thinking_blocks.extend(thinking_delta)
+
             if choice.delta.tool_calls:
                 # Some providers batch several calls into a single delta, so every entry
                 # has to be consumed rather than just the first.
@@ -599,6 +624,8 @@ class LiteLLMWrapper(ModelBase, ABC):
             tools=tools,
             output_schema=output_schema,
             message_info=message_info,
+            reasoning_content=accumulated_reasoning or None,
+            thinking_blocks=accumulated_thinking_blocks or None,
         )
 
         yield r
@@ -611,11 +638,15 @@ class LiteLLMWrapper(ModelBase, ABC):
         tools: list[ToolCall],
         output_schema: type[BaseModel] | None,
         message_info: MessageInfo,
+        reasoning_content: str | None = None,
+        thinking_blocks: list[dict] | None = None,
     ):
         """
         From the provided content, creates a completes a response object dyanmically.
 
         This function handles the normalization of the different response `content` types.
+        Any `reasoning_content`/`thinking_blocks` accumulated from the stream are attached
+        to the built assistant message.
         """
         structured_response: BaseModel | None = None
 
@@ -623,24 +654,17 @@ class LiteLLMWrapper(ModelBase, ABC):
             structured_response = output_schema(**json.loads(accumulated_content))
 
         if structured_response is not None:
-            r = Response(
-                message=AssistantMessage(content=structured_response),
-                message_info=message_info,
-            )
+            message = AssistantMessage(content=structured_response)
         elif len(tools) > 0:
-            r = Response(
-                message=AssistantMessage(
-                    content=ToolCalls(tools, text=accumulated_content or None)
-                ),
-                message_info=message_info,
+            message = AssistantMessage(
+                content=ToolCalls(tools, text=accumulated_content or None)
             )
         else:
-            r = Response(
-                message=AssistantMessage(content=accumulated_content),
-                message_info=message_info,
-            )
+            message = AssistantMessage(content=accumulated_content)
 
-        return r
+        message.reasoning_content = reasoning_content
+        message.thinking_blocks = thinking_blocks
+        return Response(message=message, message_info=message_info)
 
     def _is_stream_finished(self, choice) -> bool:
         """Check if the stream has finished.
@@ -781,8 +805,11 @@ class LiteLLMWrapper(ModelBase, ABC):
     # ================ START Base Handlers ==================
 
     def _chat_handle_base(self, raw: ModelResponse, info: MessageInfo):
-        content = raw["choices"][0]["message"]["content"]
-        return Response(message=AssistantMessage(content=content), message_info=info)
+        message = raw["choices"][0]["message"]
+        assistant_msg = _attach_reasoning(
+            AssistantMessage(content=message["content"]), message
+        )
+        return Response(message=assistant_msg, message_info=info)
 
     def _structured_handle_base(
         self,
@@ -790,9 +817,10 @@ class LiteLLMWrapper(ModelBase, ABC):
         info: MessageInfo,
         schema: Type[BaseModel],
     ) -> Response:
-        content_str = raw["choices"][0]["message"]["content"]
-        parsed = schema(**json.loads(content_str))
-        return Response(message=AssistantMessage(content=parsed), message_info=info)
+        message = raw["choices"][0]["message"]
+        parsed = schema(**json.loads(message["content"]))
+        assistant_msg = _attach_reasoning(AssistantMessage(content=parsed), message)
+        return Response(message=assistant_msg, message_info=info)
 
     def _chat_with_tools_handler_base(
         self, raw: ModelResponse, info: MessageInfo
@@ -805,10 +833,11 @@ class LiteLLMWrapper(ModelBase, ABC):
         if choice.finish_reason == "stop" and not choice.message.tool_calls:
             # litellm types content as str | None, but a plain "stop" completion always
             # carries (possibly empty) text content.
-            return Response(
-                message=AssistantMessage(content=cast(str, choice.message.content)),
-                message_info=info,
+            assistant_msg = _attach_reasoning(
+                AssistantMessage(content=cast(str, choice.message.content)),
+                choice.message,
             )
+            return Response(message=assistant_msg, message_info=info)
 
         calls: List[ToolCall] = []
         for tc in choice.message.tool_calls or []:
@@ -819,8 +848,9 @@ class LiteLLMWrapper(ModelBase, ABC):
 
         # Keep any text the model returned alongside the tool calls (e.g. "I will
         # check the weather in London for you"), it is part of the answer.
-        assistant_msg = AssistantMessage(
-            content=ToolCalls(calls, text=choice.message.content)
+        assistant_msg = _attach_reasoning(
+            AssistantMessage(content=ToolCalls(calls, text=choice.message.content)),
+            choice.message,
         )
 
         # Preserve the raw litellm message so that provider-specific metadata

--- a/packages/railtracks/src/railtracks/llm/response.py
+++ b/packages/railtracks/src/railtracks/llm/response.py
@@ -125,6 +125,22 @@ class Response:
             )
         return content
 
+    @property
+    def reasoning(self) -> str | None:
+        """
+        The model's reasoning/"thinking" text for this response, if the provider
+        returned any.
+
+        This is a convenience accessor for the human-readable reasoning; it is None
+        when the message carries no reasoning (a non-reasoning model, or one that
+        was not asked to expose its thinking). The structured, signed form is on
+        `response.message.thinking_blocks`.
+
+        Returns:
+            str | None: The reasoning text, or None if there is none.
+        """
+        return getattr(self._message, "reasoning_content", None)
+
     def __str__(self):
         if self._message is not None:
             return str(self._message)

--- a/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
+++ b/packages/railtracks/tests/unit_tests/llm/models/test_litellm_wrapper.py
@@ -663,14 +663,27 @@ class TestAsyncStreaming:
 
 
 # ================= START streamed delta accumulation tests =========================
-def _delta_chunk(*, content=None, tool_calls=None, finish_reason=None, usage=None):
+def _delta_chunk(
+    *,
+    content=None,
+    tool_calls=None,
+    finish_reason=None,
+    usage=None,
+    reasoning_content=None,
+    thinking_blocks=None,
+):
     """A single `ModelResponseStream` shaped the way litellm hands them to the handler."""
     return ModelResponseStream(
         model="mock-model",
         choices=[
             StreamingChoices(
                 index=0,
-                delta=Delta(content=content, tool_calls=tool_calls),
+                delta=Delta(
+                    content=content,
+                    tool_calls=tool_calls,
+                    reasoning_content=reasoning_content,
+                    thinking_blocks=thinking_blocks,
+                ),
                 finish_reason=finish_reason,
             )
         ],
@@ -1165,6 +1178,121 @@ def test_common_hyperparameter_passed_to_litellm_completion(
 
 
 # ================= END common hyperparameter support tests =========================
+
+# ================= START #1431 reasoning/thinking surfacing tests ===================
+
+_THINKING_BLOCKS = [{"type": "thinking", "thinking": "2 + 2", "signature": "sig-abc"}]
+
+
+def _model_response(*, content, finish_reason="stop", reasoning=False, tool_calls=None):
+    """A non-streamed `ModelResponse`, optionally carrying reasoning on its message."""
+    message = {
+        "role": "assistant",
+        "content": content,
+        "tool_calls": tool_calls,
+    }
+    if reasoning:
+        message["reasoning_content"] = "2 + 2 is 4"
+        message["thinking_blocks"] = _THINKING_BLOCKS
+    return ModelResponse(choices=[{"message": message, "finish_reason": finish_reason}])
+
+
+class TestReasoningSurfacing:
+    """#1431: reasoning/thinking the provider returns must surface on the assistant
+    message (so it rides along in history and the run graph) and via `Response.reasoning`,
+    across every response-building path, and stay None when the provider returns none."""
+
+    def test_chat_handle_base_surfaces_reasoning(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper()
+        raw = _model_response(content="4", reasoning=True)
+
+        response = wrapper._chat_handle_base(raw, MessageInfo())
+
+        assert response.reasoning == "2 + 2 is 4"
+        assert response.message.reasoning_content == "2 + 2 is 4"
+        assert response.message.thinking_blocks == _THINKING_BLOCKS
+
+    def test_chat_handle_base_without_reasoning_is_none(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper()
+        raw = _model_response(content="4", reasoning=False)
+
+        response = wrapper._chat_handle_base(raw, MessageInfo())
+
+        assert response.reasoning is None
+        assert response.message.reasoning_content is None
+        assert response.message.thinking_blocks is None
+
+    def test_structured_handle_base_surfaces_reasoning(self, mock_litellm_wrapper):
+        class Reply(BaseModel):
+            answer: int
+
+        wrapper = mock_litellm_wrapper()
+        raw = _model_response(content='{"answer": 4}', reasoning=True)
+
+        response = wrapper._structured_handle_base(raw, MessageInfo(), Reply)
+
+        assert isinstance(response.message.content, Reply)
+        assert response.message.reasoning_content == "2 + 2 is 4"
+        assert response.message.thinking_blocks == _THINKING_BLOCKS
+
+    def test_chat_with_tools_plain_reply_surfaces_reasoning(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper()
+        raw = _model_response(content="4", reasoning=True)
+
+        response = wrapper._chat_with_tools_handler_base(raw, MessageInfo())
+
+        assert response.reasoning == "2 + 2 is 4"
+        assert response.message.thinking_blocks == _THINKING_BLOCKS
+
+    def test_chat_with_tools_tool_call_surfaces_reasoning(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper()
+        raw = _model_response(
+            content=None,
+            finish_reason="tool_calls",
+            reasoning=True,
+            tool_calls=[
+                litellm.ChatCompletionMessageToolCall(
+                    function=litellm.Function(arguments="{}", name="tool_x"),
+                    id="id123",
+                    type="function",
+                )
+            ],
+        )
+
+        response = wrapper._chat_with_tools_handler_base(raw, MessageInfo())
+
+        assert isinstance(response.message.content, ToolCalls)
+        assert response.message.reasoning_content == "2 + 2 is 4"
+        assert response.message.thinking_blocks == _THINKING_BLOCKS
+
+    def test_streamed_reasoning_deltas_accumulate_onto_final_response(
+        self, mock_litellm_wrapper
+    ):
+        wrapper = mock_litellm_wrapper()
+        chunks = [
+            _delta_chunk(reasoning_content="2 + 2 ", thinking_blocks=_THINKING_BLOCKS),
+            _delta_chunk(reasoning_content="is 4"),
+            _delta_chunk(content="4"),
+            _delta_chunk(finish_reason="stop"),
+        ]
+
+        text, final = _drain(wrapper, chunks)
+
+        assert "".join(text) == "4"
+        assert final.reasoning == "2 + 2 is 4"
+        assert final.message.thinking_blocks == _THINKING_BLOCKS
+
+    def test_streamed_without_reasoning_is_none(self, mock_litellm_wrapper):
+        wrapper = mock_litellm_wrapper()
+        chunks = [_delta_chunk(content="4"), _delta_chunk(finish_reason="stop")]
+
+        _text, final = _drain(wrapper, chunks)
+
+        assert final.reasoning is None
+        assert final.message.thinking_blocks is None
+
+
+# ================= END #1431 reasoning/thinking surfacing tests =====================
 
 # ================= START #1394 reasoning_effort-default-for-tools tests =============
 

--- a/packages/railtracks/tests/unit_tests/llm/test_message.py
+++ b/packages/railtracks/tests/unit_tests/llm/test_message.py
@@ -56,6 +56,27 @@ def test_assistant_message():
     assert repr(message) == "assistant: Assistant response"
 
 
+def test_assistant_message_reasoning_defaults_none_and_absent_from_encode():
+    message = AssistantMessage("Assistant response")
+    assert message.reasoning_content is None
+    assert message.thinking_blocks is None
+    encoded = message.encode()
+    assert "reasoning_content" not in encoded
+    assert "thinking_blocks" not in encoded
+
+
+def test_assistant_message_encode_surfaces_reasoning():
+    blocks = [{"type": "thinking", "thinking": "2 + 2", "signature": "sig"}]
+    message = AssistantMessage("4")
+    message.reasoning_content = "2 + 2 is 4"
+    message.thinking_blocks = blocks
+
+    encoded = message.encode()
+
+    assert encoded["reasoning_content"] == "2 + 2 is 4"
+    assert encoded["thinking_blocks"] == blocks
+
+
 def test_tool_message():
     tool_response = ToolResponse(name="tool1", result="result", identifier="123")
     message = ToolMessage(tool_response)

--- a/packages/railtracks/tests/unit_tests/llm/test_response.py
+++ b/packages/railtracks/tests/unit_tests/llm/test_response.py
@@ -106,4 +106,16 @@ def test_response_message_info_is_same_object_when_passed():
     assert resp.message_info is mi
 
 
+def test_response_reasoning_forwards_from_message():
+    message = AssistantMessage("4")
+    message.reasoning_content = "2 + 2 is 4"
+    resp = Response(message=message)
+    assert resp.reasoning == "2 + 2 is 4"
+
+
+def test_response_reasoning_is_none_when_message_has_none():
+    resp = Response(message=AssistantMessage("4"))
+    assert resp.reasoning is None
+
+
 # ================ END response tests ===============


### PR DESCRIPTION
## Summary

Surface reasoning/"thinking" tokens that providers (Anthropic, DeepSeek, Gemini,
OpenAI in part) return, instead of dropping them. Reasoning now lives on the
`AssistantMessage`, so it rides along in history and serialization, and is reachable via
`Response.reasoning`. Covers chat, structured, tool-calling, and streaming paths.

closes #1431

## Type of change

- [x] Feature
- [x] Docs

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [x] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes (n/a — additive, defaults to `None`)

## Notes

New surface: `AssistantMessage.reasoning_content: str | None`,
`AssistantMessage.thinking_blocks: list[dict] | None` (signed blocks), and a
`Response.reasoning` convenience accessor. All default to `None` when the provider
returns no reasoning. Round-tripping thinking back to the provider is a follow-up.

Providers differ in what they surface, which is why both fields exist. Anthropic returns
structured `thinking_blocks` carrying a cryptographic `signature` (in addition to the
`reasoning_content` text) — the signed blocks are what a later turn must send back for
thinking to stay valid, so we keep them verbatim. DeepSeek returns `reasoning_content`
text only (no signed blocks); Gemini surfaces its thinking similarly; OpenAI exposes only
partial/summarized reasoning. So `reasoning_content` (and `Response.reasoning`) is the
portable, human-readable view that works everywhere, while `thinking_blocks` is populated
mainly for Anthropic and is the piece the round-trip follow-up will rely on.

Buffered:

```python
model = rt.llm.AnthropicLLM("claude-sonnet-4-5", reasoning_effort="low")
resp = await model.achat(rt.llm.MessageHistory([rt.llm.UserMessage("Why is the sky blue?")]))
print(resp.reasoning)                    # reasoning text, or None
print(resp.message.thinking_blocks)      # signed blocks, or None
```

Streaming (reasoning is attached to the final `Response`, not emitted as chunks):

```python
async for item in model.astream_chat(history):
    if isinstance(item, str):
        print(item, end="")              # answer chunks
    else:
        print(item.reasoning)            # final Response carries the reasoning
```