### PR TITLE
fix(retrieval): scope the staleness check and delete-before-write to the ingesting tenant

### DIFF
--- a/packages/railtracks/src/railtracks/retrieval/runtime.py
+++ b/packages/railtracks/src/railtracks/retrieval/runtime.py
@@ -259,7 +259,7 @@ class RetrievalRuntime:
 
         await self._ensure_captured_model_seeded()
 
-        if await self._is_complete_duplicate(doc):
+        if await self._is_complete_duplicate(doc, scope):
             stats.documents_skipped += 1
             yield DocumentSkipped(document_id=doc.id, source=doc.source)
             return
@@ -297,7 +297,9 @@ class RetrievalRuntime:
         if doc_errors:
             yield self._record_document_failed(doc, doc_errors, stats)
 
-    async def _is_complete_duplicate(self, doc: Document) -> bool:
+    async def _is_complete_duplicate(
+        self, doc: Document, scope: StoreScope | None
+    ) -> bool:
         """Whether the store already holds a *complete* copy of ``doc``.
 
         Skip re-embedding only when as many chunks are present as the last
@@ -313,6 +315,7 @@ class RetrievalRuntime:
         stale_filters = {
             "source_path": doc.source,
             "content_hash": doc.content_hash,
+            **(scope.to_payload_filters() if scope is not None else {}),
         }
         existing = await self._store.find(stale_filters, limit=1)
         if not existing:
@@ -383,7 +386,12 @@ class RetrievalRuntime:
                 # must not corrupt the store by clearing prior chunks first.
                 self._check_model(batch.metrics.model)
                 if not delete_done:
-                    await self._store.delete_where({"document_id": str(doc.id)})
+                    await self._store.delete_where(
+                        {
+                            "document_id": str(doc.id),
+                            **(scope.to_payload_filters() if scope is not None else {}),
+                        }
+                    )
                     delete_done = True
                 for embedded in batch.chunks:
                     self._capture_model(embedded)

--- a/packages/railtracks/tests/unit_tests/retrieval/test_runtime.py
+++ b/packages/railtracks/tests/unit_tests/retrieval/test_runtime.py
@@ -344,6 +344,56 @@ async def test_ingest_writes_entries_with_call_scope():
     assert {e.content for e in bob_entries} == {"gamma", "delta"}
 
 
+async def test_duplicate_check_is_scoped_per_tenant():
+    """The staleness/duplicate check must not let one tenant's ingest mark
+    another tenant's identical source+content as already present. Same
+    source and content, different scope, must both actually land."""
+    store = _store()
+    runtime, _, _ = _runtime(store=store)
+    alice = StoreScope(labels={"user_id": "alice"})
+    bob = StoreScope(labels={"user_id": "bob"})
+
+    await runtime.ingest_all(
+        _ListLoader([Document(source="shared", content="alpha beta")]),
+        scope=alice,
+    )
+    events = [
+        e
+        async for e in runtime.ingest(
+            _ListLoader([Document(source="shared", content="alpha beta")]),
+            scope=bob,
+        )
+    ]
+
+    assert not any(isinstance(e, DocumentSkipped) for e in events)
+    bob_entries = await store.find({"scope_user_id": "bob"}, limit=10)
+    assert {e.content for e in bob_entries} == {"alpha", "beta"}
+
+
+async def test_reingest_does_not_clobber_other_tenants_entries():
+    """Document.id is derived from source alone, so two tenants ingesting
+    the same source (with different content, so the duplicate check does
+    not short-circuit) share one document_id. The delete-before-write step
+    must scope its delete_where to the calling tenant, or it wipes the
+    other tenant's already-written rows for that same document_id."""
+    store = _store()
+    runtime, _, _ = _runtime(store=store)
+    alice = StoreScope(labels={"user_id": "alice"})
+    bob = StoreScope(labels={"user_id": "bob"})
+
+    await runtime.ingest_all(
+        _ListLoader([Document(source="shared", content="alpha beta")]),
+        scope=alice,
+    )
+    await runtime.ingest_all(
+        _ListLoader([Document(source="shared", content="gamma delta epsilon")]),
+        scope=bob,
+    )
+
+    alice_entries = await store.find({"scope_user_id": "alice"}, limit=10)
+    assert {e.content for e in alice_entries} == {"alpha", "beta"}
+
+
 async def test_retrieve_raises_on_model_mismatch():
     embedder_v1 = _FakeEmbedder(model="model-v1")
     runtime, store, _ = _runtime(embedder=embedder_v1)


### PR DESCRIPTION
## Summary

Fixes #1183. Merges `scope.to_payload_filters()` into `_is_complete_duplicate`'s `stale_filters` and into `_embed_and_store`'s `delete_where`, the same way `VectorStore.read`/`nearest_neighbors` already scope reads in `stores/vector/base.py`.

## Type of change

- [x] Bug fix

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)
- [x] Tests added/updated and pass locally (`pytest tests`)
- [ ] Docs updated if user-facing behavior changed
- [ ] Breaking changes include migration notes

## Notes

Two new tests in `test_runtime.py`, one per failure mode from the issue. Both fail on main (`test_duplicate_check_is_scoped_per_tenant` on the skip-as-duplicate case, `test_reingest_does_not_clobber_other_tenants_entries` on the clobber) and pass with the fix. Full `tests/unit_tests/retrieval/` suite (578 tests) green on the branch.

`delete_document(document_id)` has the same unscoped `delete_where` shape but its own signature takes no scope at all, so it's a separate public API surface, not the automatic ingest-path leak the issue reports. Left it alone; happy to fold it in if you'd rather it moved too.
