### PR TITLE
docs: define and cross-link Railtracks keywords (#1179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ docs/api_reference/railtracks/
 docs/api_reference/index.html
 docs/api_reference/railtracks.html
 
+# Generated from docs/glossary.md by scripts/mkdocs_hooks.py
+docs/includes/glossary_tooltips.md
+
 # Documentation build output
 site/
 

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -448,3 +448,14 @@
   color: var(--md-default-fg-color--light);
   margin-top: 1.5rem;
 }
+
+/* Glossary terms are headings as well as tooltipped keywords, and a tooltip on a
+   heading only repeats the text directly beneath it. Keep the definition available
+   without the dotted underline that invites a hover. */
+.md-typeset h1 abbr,
+.md-typeset h2 abbr,
+.md-typeset h3 abbr,
+.md-typeset h4 abbr {
+  text-decoration: none;
+  cursor: inherit;
+}

--- a/docs/documentation/advanced/context.md
+++ b/docs/documentation/advanced/context.md
@@ -1,10 +1,10 @@
 # Global Context
 
-Railtracks includes a concept of global context, letting you store and retrieve shared information across the lifecycle of a run. This makes it easy to coordinate data like config settings, environment flags, or shared resources.
+Railtracks includes a concept of global context, letting you store and retrieve shared information across the lifecycle of a [run](../invocation/flows.md#run). This makes it easy to coordinate data like config settings, environment flags, or shared resources.
 
 ## What is Global Context?
 
-The context system gives you a simple and clear API for interacting with shared values. It's scoped to the duration of a run, so everything is neatly contained within that execution lifecycle. One of the key features of the context system is that it can be accessed from within any node in your workflow, making it ideal for sharing data between different parts of your application.
+The context system gives you a simple and clear API for interacting with shared values. It's scoped to the duration of a run, so everything is neatly contained within that execution lifecycle. One of the key features of the context system is that it can be accessed from within any [node](../agent_design/overview.md#node) in your workflow, making it ideal for sharing data between different parts of your application.
 
 ## Core Functions
 

--- a/docs/documentation/agent_design/middleware/custom.md
+++ b/docs/documentation/agent_design/middleware/custom.md
@@ -1,6 +1,6 @@
 # Custom Middleware
 
-The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object. Node-level decorators can be passed to `middleware=` on either `rt.agent_node` or `rt.function_node`. Model-level decorators can only be passed to `model_middleware=` on `rt.agent_node`. A `function_node` never calls a model, so it has no `model_middleware=` slot (the parameter doesn't exist on `function_node`, so passing one is a type/argument error, not a silent no-op).
+The middleware system is designed to support the custom creation of middleware to fit your needs. Each decorator below wraps a plain function into a `Middleware` object. Node-level decorators can be passed to `middleware=` on either an [agent node](../overview.md#agent-node) or a [function node](../tools/function_tools.md#what-a-function-node-is). Model-level decorators can only be passed to `model_middleware=` on `rt.agent_node`. A `function_node` never calls a model, so it has no `model_middleware=` slot (the parameter doesn't exist on `function_node`, so passing one is a type/argument error, not a silent no-op).
 
 | Decorator | Scope | Runs
 |---|---|---|

--- a/docs/documentation/agent_design/middleware/guardrails/overview.md
+++ b/docs/documentation/agent_design/middleware/guardrails/overview.md
@@ -1,6 +1,6 @@
 # Guardrails Overview
 
-Guardrails are a policy layer around agent execution. They inspect requests before they reach a model and responses before they are returned, letting you enforce rules for safety, reliability, and product behavior.
+Guardrails are a policy layer around agent execution, implemented as [model middleware](../overview.md#model-middleware). They inspect requests before they reach a model and responses before they are returned, letting you enforce rules for safety, reliability, and product behavior.
 
 Guardrails aren't just about blocking unsafe content. They can also:
 

--- a/docs/documentation/agent_design/middleware/overview.md
+++ b/docs/documentation/agent_design/middleware/overview.md
@@ -1,6 +1,6 @@
 # Middleware
 
-Middleware in Railtracks is a function that wraps a node's call, letting you add behavior around it without touching the node itself. Concretely, middleware can do things like:
+Middleware in Railtracks is a function that wraps a [node](../overview.md#node)'s call, letting you add behavior around it without touching the node itself. Concretely, middleware can do things like:
 
 - Log inputs and outputs
 - Handle automatic retries

--- a/docs/documentation/agent_design/middleware/verifiers/overview.md
+++ b/docs/documentation/agent_design/middleware/verifiers/overview.md
@@ -1,6 +1,6 @@
 # Verifiers
 
-Human-in-the-loop (HIL) isn't a separate feature in Railtracks — it's `pre_verifier` and `post_verifier`, two node middleware that gate a call with any callable you provide. Where the human (or policy, or second model call) actually sits is entirely up to that callable; Railtracks only handles the gating.
+Human-in-the-loop (HIL) isn't a separate feature in Railtracks — it's `pre_verifier` and `post_verifier`, two [node middleware](../overview.md#node-middleware) that gate a call with any callable you provide. Where the human (or policy, or second model call) actually sits is entirely up to that callable; Railtracks only handles the gating.
 
 ```python
 from railtracks.prebuilt.middleware import pre_verifier, post_verifier

--- a/docs/documentation/agent_design/overview.md
+++ b/docs/documentation/agent_design/overview.md
@@ -7,10 +7,29 @@ At its core, the design is two pronged:
 1. Agent Level Design
 2. Agent Interaction Design
 
+## Building Blocks
+
+Railtracks has a single execution primitive, the node, and two builders that produce one. These terms are used throughout the rest of the documentation, so they are worth reading once here.
+
+### Node
+
+A **node** is the unit Railtracks executes. It accepts inputs, runs, and returns an output, and Railtracks records every invocation of it in the [run](../invocation/flows.md#run) graph and exposes it to [middleware](middleware/overview.md). Agents, tools, and plain Python functions are all nodes, and that is what lets Railtracks treat them interchangeably: anything that is a node can be given to an agent as a tool, used as a [Flow](../invocation/flows.md) entry point, or called from inside another node with [`rt.call`](../invocation/call.md).
+
+You do not subclass anything to make one. Two builders cover it: `rt.agent_node()` when the step needs a model to decide something, and `@rt.function_node` when the step is deterministic Python.
+
+### Agent Node
+
+An **agent node** is a node whose work is a call to an LLM. It is built with `rt.agent_node()` and holds the model, the system message, and the tools the model is allowed to call; at runtime it drives the tool-calling loop for you until the model produces a final answer.
+
+Reach for an agent node when the step needs judgement, such as interpreting a vague request, choosing between tools, or writing prose. If the step has one correct implementation, like a calculation or an API call, write a [function node](tools/function_tools.md#what-a-function-node-is) instead and let an agent call it as a tool. Note that `rt.agent_node()` returns a class rather than an instance, which is why agents are named in PascalCase throughout these docs. [Agent Level Design](#agent-level-design) covers the choices you make when configuring one.
+
+### Function Node
+
+The other kind of node, built from one of your own Python functions, has a page of its own: [Function Tools](tools/function_tools.md#what-a-function-node-is).
 
 ## Agent Level Design
 
-This is where what we'd like to "intra-agent" decisions come into play. Things such as choice of _LLM_, _System Message_, and _Tools_. Snippet below provides the most fundamental LLM-powered agent in Railtracks with no tool calling capabilities.
+This is where what we'd like to "intra-agent" decisions come into play. Things such as choice of [_LLM_](../../integrations/llms/providers.md), _System Message_, [_Tools_](tools/function_tools.md), and [_Middleware_](middleware/overview.md). Snippet below provides the most fundamental LLM-powered agent in Railtracks with no tool calling capabilities.
 
 ```python
 --8<-- "docs/scripts/documentation/agent_design.py"

--- a/docs/documentation/agent_design/structured_extraction.md
+++ b/docs/documentation/agent_design/structured_extraction.md
@@ -1,5 +1,5 @@
 ## Adding a Structured Output
-Now that you've seen how to add tools. Let's look at your agent can respond with reliable typed outputs. Schemas give you reliable, machine-checked outputs you can safely consume in code, rather than brittle strings.
+Now that you've seen how to add tools. Let's look at how an [agent node](overview.md#agent-node) can respond with reliable typed outputs. Schemas give you reliable, machine-checked outputs you can safely consume in code, rather than brittle strings.
 
 
 ```python 

--- a/docs/documentation/agent_design/tools/agents_as_tools.md
+++ b/docs/documentation/agent_design/tools/agents_as_tools.md
@@ -1,7 +1,7 @@
 We support using agents as tools in the following two ways:
 
 ## 1. Python Function
-By using a python function to call your agent, you can have the flexibility of your agent being invoked in different ways in different contexts. You will then simply [pass this function as a tool]() to your Orchestrator.
+By using a python function to call your agent, you can have the flexibility of your agent being invoked in different ways in different contexts. You will then simply [pass this function as a tool](function_tools.md) to your Orchestrator.
 ```python
 import railtracks as rt
 from my_agents import SomeAgent
@@ -17,8 +17,8 @@ def some_way(arg1: arg1_type, arg2: arg2_type) -> return_type
     ...
 ```
 
-## 2. Agent Manifest
-In this way, at agent definition time, you also define how this agent can be used by other agents.
+## 2. Tool Manifest
+A **tool manifest** is the description an agent carries of how other agents may call it: a description of what it does and the parameters it expects. Passing `manifest=` at agent definition time means any other agent can take this one as a tool without a wrapper function.
 ```python
 import railtracks as rt
 
@@ -37,4 +37,4 @@ WorkerAgent = rt.agent_node(
 )
 ```
 
-You can refer to [API Reference](../../../api_reference/railtracks.html) for more information. Or take a look at our [Tutorials]() section.
+You can refer to [API Reference](../../../api_reference/railtracks.html) for more information. Or take a look at the [Agents as Tools](../../../tutorials/walkthroughs/agents_as_tools.md) walkthrough.

--- a/docs/documentation/agent_design/tools/function_tools.md
+++ b/docs/documentation/agent_design/tools/function_tools.md
@@ -1,3 +1,11 @@
+## What a Function Node Is
+
+A **function node** is one of your own Python functions turned into a [node](../overview.md#node) by the `@rt.function_node` decorator. Railtracks reads the function's type hints to build its parameter schema and its docstring to describe it, so one decorated function serves two purposes at once: a step you can invoke yourself with [`rt.call`](../../invocation/call.md), and a tool an agent is allowed to choose.
+
+Use a function node wherever the work has one correct implementation, such as a calculation, a database query, or an API call. That keeps deterministic work out of the model's hands and leaves the [agent node](../overview.md#agent-node) responsible only for deciding *when* the work should happen.
+
+## Defining a Function Node
+
 Allowing your agents to use your `python` functions as tools for your agents is quite straight forward. You can choose one of the following ways:
 !!! warning "Docstrings"
     Your Python functions need to contain **_typehints_** for parameters and **_docstrings_** formatted in [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#:~:text=one%2Dline%20docstring.-,Args%3A,-List%20each%20parameter) as that is what Railtracks automatically parses to inform your LLM about the capability of the tool
@@ -25,7 +33,7 @@ Allowing your agents to use your `python` functions as tools for your agents is 
     )
     ```
 
-    1. Simply add the `railtracks.function_node` decorator before the definition of your function. This transforms your function into a node type usable upon passing to any agent.
+    1. Simply add the `railtracks.function_node` decorator before the definition of your function.
 
 === "Agent Specific"
 

--- a/docs/documentation/agent_design/tools/mcp.md
+++ b/docs/documentation/agent_design/tools/mcp.md
@@ -108,7 +108,7 @@ For detailed setup and usage instructions for specific MCP tools:
 
 ### Overview
 
-You can expose any Railtrack Node as an MCP-compatible tool, making it accessible to any MCP client or LLM agent that supports the [Model Context Protocol (MCP)](mcp.md). This allows you to share your custom RT logic with other frameworks, agents, or applications that use MCP.
+You can expose any Railtracks [node](../overview.md#node) as an MCP-compatible tool, making it accessible to any MCP client or LLM agent that supports the [Model Context Protocol (MCP)](mcp.md). This allows you to share your custom RT logic with other frameworks, agents, or applications that use MCP.
 
 RC provides utilities to convert your Nodes into MCP tools and run a FastMCP server, so your tools are discoverable and callable via standard MCP transports (HTTP, SSE, stdio).
 
@@ -120,7 +120,7 @@ RC provides utilities to convert your Nodes into MCP tools and run a FastMCP ser
 
 #### 1. Convert RT Nodes to MCP Tools
 
-Use the `create_mcp_server` utility to expose your RT nodes as MCP tools:
+Use the `create_mcp_server` utility to expose your nodes as MCP tools:
 
 ```python
 --8<-- "docs/scripts/RTtoMCP.py:simple_mcp_creation"

--- a/docs/documentation/getting_started/contributing_docs.md
+++ b/docs/documentation/getting_started/contributing_docs.md
@@ -70,6 +70,16 @@ Use admonitions sparingly, and match the existing tone:
 - External links must be full `https://` URLs.
 - Do not link to `main`-branch file paths for pages that are also in the nav;
   link to the rendered page instead.
+- Link to the **anchor that holds the definition**, not to the top of the page that contains it: `../invocation/flows.md#entry-point`, not `../invocation/flows.md`. Broken anchors fail `mkdocs build --strict`.
+
+## Keywords and the glossary
+
+Railtracks vocabulary (node, agent node, Flow, entry point, run, middleware and so on) is defined in exactly one place, and every other page links to it.
+
+- **One canonical home per term.** The page that owns a subject owns the full description of its terms, with the reasons and an example. Do not restate a definition on a second page, link to it.
+- **Link the first mention on a page**, not every mention. A reader who already followed the link does not need it again three paragraphs later.
+- **Add an entry to [the glossary](../../glossary.md)** when you introduce a term. Entries there are pointers rather than documentation: at most two sentences, always ending in a link to the canonical section, and never any code.
+- Glossary entries also become **hover definitions** site-wide. The `abbr` definitions behind them are generated from `docs/glossary.md` by `scripts/mkdocs_hooks.py`, so a tooltip and its glossary entry cannot drift apart. A term whose capitalized form also appears in an unrelated sense (Run, Tool, Context) is listed in that script's denylist and stays out of the tooltips.
 
 ## Building and previewing locally
 

--- a/docs/documentation/getting_started/quickstart.md
+++ b/docs/documentation/getting_started/quickstart.md
@@ -12,7 +12,7 @@ pip install 'railtracks[visual]'
 
 ## 2. Running your Agent
 
-Define an agent with a model and system message, then call it with a prompt:
+Define an [agent](../agent_design/overview.md#agent-node) with a model and system message, wrap it in a [Flow](../invocation/flows.md), then invoke it with a prompt:
 
 ```python
 --8<-- "docs/scripts/documentation/quickstart.py:setup"

--- a/docs/documentation/invocation/call.md
+++ b/docs/documentation/invocation/call.md
@@ -1,9 +1,15 @@
-If you are familiar and comfortable with the `async/await` syntax and you do not require any configurations, you can simply use the `railtracks.call` API to invoke your agent:
+# Direct Invocation
+
+**Direct invocation** is calling a node yourself with `await rt.call(...)` instead of letting an agent decide to call it. It is how the steps inside a [Flow](flows.md) are composed: the Flow's [entry point](flows.md#entry-point) is your own `async` function, and each step in it is an `rt.call` whose result you use like any other awaited value.
+
 ```python
 import railtracks as rt
 
 resp = await rt.call(AgentName, "user message to the agent")
 ```
+
+Because these are ordinary `await` expressions, the control flow stays yours. Await them one after another to fix an order (see [Sequential Flows](../../tutorials/concepts/architectures/sequential.md)), gather them with `asyncio.gather` to run steps concurrently, or branch on a result before deciding what to call next.
+
 !!! warning "async context"
     The above code snippet will work in an `async` context such as Jupyter notebooks. In a python script, it needs to be wrapped as follows:
     ```python
@@ -16,6 +22,7 @@ resp = await rt.call(AgentName, "user message to the agent")
     run(outer_func(...))
     ```
 
-The `call` API is also useful when you want to use agents as tools by having them wrapped within another a function (see [Agents as Tools](../agent_design/tools/agents_as_tools.md)). 
+The `call` API is also useful when you want to use agents as tools by having them wrapped within another a function (see [Agents as Tools](../agent_design/tools/agents_as_tools.md)).
 
-For configuration management such as context, observability through invocations, and other settings we recommend using [Flows](../invocation/flows.md).
+!!! tip "Start from a Flow"
+    `rt.call` does work as the top level of a script, where Railtracks builds the surrounding machinery for you with default settings. What you give up is everything that is configured on the Flow: context shared across runs, `timeout`, `end_on_error`, broadcast and payload callbacks, and the `flow.connect()` handle for inspecting a [run](flows.md#run) after it finishes. Past a quick experiment, wrap your entry point in a [Flow](flows.md) and keep `rt.call` for the steps inside it.

--- a/docs/documentation/invocation/flows.md
+++ b/docs/documentation/invocation/flows.md
@@ -1,12 +1,30 @@
-# Flows (Session Management)
-In Railtracks, flows are the primary way to organize your agent runs. Think of a Flow as a blueprint that you invoke to start a run. A single Flow can be invoked multiple times to execute the same agentic process. This guide provides concrete examples to help you get started with Flows.
+# Flows
+
+A **Flow** is a named, reusable entry point for an agent graph. It binds one [entry point](#entry-point) node to a fixed set of runtime options, such as context, a timeout, an error policy and callbacks, so the same agentic process can be invoked as many times as you like with each [run](#run) isolated from the others.
+
+A Flow is the intended top level of a Railtracks program, because everything it provides is scoped to the Flow rather than to a single call: context shared across runs, a timeout over the whole graph, and a connection you can inspect once a run has finished. Inside a Flow, nodes reach one another through [direct invocation](call.md). This guide provides concrete examples to help you get started with Flows.
+
+!!! note "Two senses of the word 'flow'"
+    Capital-F **Flow** always means the `rt.Flow` object described on this page. Lowercase "flow" appears elsewhere in these docs for the *shape* of an agent graph, as in "keep your flows linear", which describes an architecture rather than an object.
 
 ## Quickstart
-To get started with Flows, you simply need to provide an entry point and a name.
+To get started with Flows, you simply need to provide an [entry point](#entry-point) and a name.
 
 ```python
 --8<-- "docs/scripts/flows_sessions.py:quickstart"
 ```
+
+### Entry Point
+
+The **entry point** is the node a Flow starts from, given as `entry_point=`. It is the only node the Flow invokes itself; every other node in the graph is reached from it, either because an agent chose it as a tool or because your code called it with [`rt.call`](call.md).
+
+Any node can be an entry point. An [agent node](../agent_design/overview.md#agent-node) makes the Flow a single agent, while a [function node](../agent_design/tools/function_tools.md#what-a-function-node-is) makes it a multi-step process whose order your own Python controls, as in [Sequential Flows](../../tutorials/concepts/architectures/sequential.md).
+
+## Run
+
+A **run** is one execution of a Flow, started by `invoke` or `ainvoke`. It is the scope Railtracks uses for nearly everything that is not part of an agent's own definition: [context](../advanced/context.md) lives for the length of a run, a Flow's `timeout` applies to the whole run, and per-run budgets such as [`MaxCalls`](../agent_design/middleware/prebuilt/list/max_calls.md) start fresh at the beginning of each one.
+
+Runs of the same Flow never share state. Invoking a Flow twice, or invoking it concurrently, gives each run its own context and its own graph of node invocations.
 
 ## Passing Configuration
 If you want to apply configurations scoped to a specific Flow, you can pass them in during the Flow's creation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,148 @@
+# Glossary
+
+Railtracks uses a handful of ordinary words in a specific way. Each entry below says what a term means in one or two sentences, then links to the page that describes it in full.
+
+!!! note "Contributing to this page"
+    Entries here are pointers, not documentation: at most two sentences, always ending in a link, and no code or examples. If a term needs more than that to make sense, the linked section is too thin, so expand that section rather than this page.
+
+## Building Blocks
+
+### Agent
+
+A system that pursues a goal on its own, deciding what to do next rather than following a fixed script. In Railtracks an agent is built as an [agent node](#agent-node). [What is an Agent?](tutorials/concepts/agents.md)
+
+### Node
+
+The unit Railtracks executes: it accepts inputs, runs, and returns an output. Agents, tools, and plain Python functions are all nodes, which is what lets Railtracks treat them interchangeably. [Building Blocks](documentation/agent_design/overview.md#node)
+
+### Agent Node
+
+A node whose work is a call to an LLM, built with `rt.agent_node()` and holding the model, system message and available tools. Reach for one when the step needs judgement rather than a fixed implementation. [Building Blocks](documentation/agent_design/overview.md#agent-node)
+
+### Function Node
+
+One of your own Python functions turned into a node by the `@rt.function_node` decorator. It is how deterministic work enters a graph, and how a function becomes a tool an agent can call. [Function Tools](documentation/agent_design/tools/function_tools.md#what-a-function-node-is)
+
+### Tool
+
+A capability an agent may choose to invoke, letting it act on the world instead of only producing text. In Railtracks a tool is any node passed to an agent as `tool_nodes=`. [What Is a Tool?](tutorials/concepts/tools.md#what-is-a-tool)
+
+### Tool Manifest
+
+The description an agent carries of how other agents may call it, given as `manifest=rt.ToolManifest(...)`. It is what lets an agent be used as a tool without a wrapper function. [Agents as Tools](documentation/agent_design/tools/agents_as_tools.md#2-tool-manifest)
+
+### LLM
+
+The language model an agent calls, configured through `rt.llm.*` and chosen per agent with `llm=`. See [LLMs as Agents](tutorials/concepts/agents.md#llms-as-agents) for the concept and [Providers](integrations/llms/providers.md) for the models Railtracks can reach.
+
+### Structured Output
+
+A response validated against a schema you supply as `output_schema=`, so an agent returns typed data rather than a string you have to parse. [Structured Output](documentation/agent_design/structured_extraction.md)
+
+### Middleware
+
+A layer that wraps a call to add behaviour around it, such as retries, logging or redaction, without changing the thing being called. Several can be attached to the same target, where they run as nested layers. [Middleware](documentation/agent_design/middleware/overview.md)
+
+### Node Middleware
+
+Middleware that wraps an entire node invocation, attached with `middleware=` on any node. [Node Middleware](documentation/agent_design/middleware/overview.md#node-middleware)
+
+### Model Middleware
+
+Middleware that wraps a single model call rather than the whole node, attached with `model_middleware=`. It applies only to agent nodes, since a function node never calls a model. [Model Middleware](documentation/agent_design/middleware/overview.md#model-middleware)
+
+### Guardrail
+
+Model middleware that inspects what goes into or comes out of a model call and decides whether to allow, change or reject it. Also referred to as a *guard* or a *rail*. [Guardrails](documentation/agent_design/middleware/guardrails/overview.md)
+
+### Verifier
+
+Node middleware that gates a call on a decision made outside the graph, which is how human-in-the-loop (**HIL**) review is built in Railtracks. [Verifiers](documentation/agent_design/middleware/verifiers/overview.md)
+
+### Coupling
+
+Attaching middleware to an existing node with `rt.couple()`, which returns a new node class rather than modifying the original. [Attaching Middleware](documentation/agent_design/middleware/overview.md#attaching-middleware)
+
+### MCP
+
+The Model Context Protocol, an open standard for exposing tools to models. Railtracks can both consume MCP tools and expose its own nodes as an MCP server. [Model Context Protocol](tutorials/concepts/mcp.md#what-is-model-context-protocol-mcp)
+
+## Running Agents
+
+### Flow
+
+A named, reusable entry point for an agent graph, binding one entry point node to a fixed set of runtime options. It is the intended top level of a Railtracks program. [Flows](documentation/invocation/flows.md)
+
+### Entry Point
+
+The node a Flow starts from, given as `entry_point=`; every other node in the graph is reached from it. [Entry Point](documentation/invocation/flows.md#entry-point)
+
+### Run
+
+One execution of a Flow, started by `invoke` or `ainvoke`. It is the scope for context, timeouts and per-run budgets, and no two runs share state. [Run](documentation/invocation/flows.md#run)
+
+### Direct Invocation
+
+Calling a node yourself with `await rt.call(...)` instead of letting an agent decide to call it. It is how the steps inside a Flow are composed. [Direct Invocation](documentation/invocation/call.md)
+
+### Context
+
+Key-value state that any node in a run can read and write, used to pass data between agents without threading it through their messages. It lives only for the length of the run. [Global Context](documentation/advanced/context.md#what-is-global-context)
+
+### Session
+
+The record Railtracks writes for a run, stored under `.railtracks/data/sessions/` and read back by the visualizer and the evaluation tools. Prefer [run](#run) when referring to the execution itself. [Local Visualization](observability/agenthub/local_v2.md)
+
+### Broadcasting
+
+Sending live updates out of a running graph to a callback, so progress can be surfaced while the run is still going. [Broadcasting](observability/tracking/broadcasting.md)
+
+### Streaming
+
+Receiving a model's tokens as they are produced rather than waiting for the finished response, via `rt.astream`. [Streaming](integrations/llms/streaming.md#what-is-streaming)
+
+## Architectures
+
+### Sequential Flow
+
+A Flow whose steps run in the order your Python code awaits them, rather than in an order a model chooses. [Sequential Flows](tutorials/concepts/architectures/sequential.md)
+
+### Validation Loop
+
+An architecture in which an agent evaluates its own output, applies the feedback and tries again until the result meets a bar. [Validation Loops](tutorials/concepts/architectures/validation_loop.md)
+
+### Agent as Tool
+
+Giving one agent another agent as a tool, so the caller delegates a sub-task instead of handling it itself. [Agents as Tools](documentation/agent_design/tools/agents_as_tools.md)
+
+## Evaluation
+
+### Evaluator
+
+The component that runs an evaluation over a dataset and produces structured results. [Evaluators](evaluations/evaluators/evaluators.md)
+
+### Metric
+
+What an evaluation measures, either a category or a number, supplied to or fixed by an evaluator. [Metrics](evaluations/metrics/metrics.md)
+
+## Retrieval
+
+### Document
+
+A loaded source file together with its metadata, before it has been split. [The Document object](retrieval/components/ingestion/base.md#the-document-object)
+
+### Chunk
+
+A slice of a Document sized for embedding and retrieval. [The Chunk object](retrieval/components/chunking/base.md#the-chunk-object)
+
+### EmbeddedChunk
+
+A Chunk together with the vector produced for it. [The EmbeddedChunk object](retrieval/components/embeddings/overview.md#the-embeddedchunk-object)
+
+### Store
+
+The backend that holds embedded chunks and answers similarity queries against them. [Data models](retrieval/components/stores/base.md#data-models)
+
+### Retrieval Runtime
+
+The object that ties loading, chunking, embedding and storage into one pipeline you can ingest into and query. [Retrieval Quickstart](retrieval/runtime/quickstart.md)

--- a/docs/integrations/llms/streaming.md
+++ b/docs/integrations/llms/streaming.md
@@ -11,7 +11,7 @@ Streaming is requested at the call site rather than baked into the agent, so the
 - `rt.call(agent, ...)` runs buffered, with no streaming overhead and no chunks.
 - `rt.astream(agent, ...)` streams the agent's LLM response chunk by chunk as it runs.
 
-`rt.astream` targets **agent nodes only**. Passing a `@function_node` (or any non-agent node) raises an error; run those with `rt.call` and reach for `rt.astream` on the agent inside them.
+`rt.astream` targets **[agent nodes](../../documentation/agent_design/overview.md#agent-node) only**. Passing a [`function_node`](../../documentation/agent_design/tools/function_tools.md#what-a-function-node-is) (or any non-agent node) raises an error; run those with `rt.call` and reach for `rt.astream` on the agent inside them.
 
 `rt.astream` returns a `Stream`, an async iterator that yields only the `str` chunks. The final result is kept separate and read from `.result` once the stream is exhausted, so a chunk is never confused with the final value:
 

--- a/docs/observability/tracking/error_handling.md
+++ b/docs/observability/tracking/error_handling.md
@@ -20,7 +20,7 @@ RTError (base)
 └── FatalError
 ```
 
-`NodeInvocationError` tells you *that* a node terminated; its subclasses tell you *why*. Every level is a plain `except` clause, so you handle only as much detail as you care about:
+`NodeInvocationError` tells you *that* a [node](../../documentation/agent_design/overview.md#node) terminated; its subclasses tell you *why*. Every level is a plain `except` clause, so you handle only as much detail as you care about:
 
 ```python
 --8<-- "docs/scripts/error_handling.py:llm_dispatch"

--- a/docs/observability/tracking/logging.md
+++ b/docs/observability/tracking/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Railtracks emits log records for execution (node creation, completion, failures) but **does not configure logging by default**. To see logs in the terminal or a file, call `enable_logging()` from your application entry point (e.g. `main`, CLI, or server startup). This keeps the library from overriding your—or your host environment’s—logging setup.
+Railtracks emits log records for execution ([node](../../documentation/agent_design/overview.md#node) creation, completion, failures) but **does not configure logging by default**. To see logs in the terminal or a file, call `enable_logging()` from your application entry point (e.g. `main`, CLI, or server startup). This keeps the library from overriding your—or your host environment’s—logging setup.
 
 !!! note "Session/Flow logging parameters removed"
     Per-session and global-config logging options (`logging_setting`, `log_file` on `Session`, `Flow`, and `set_config()`) were removed. Use `enable_logging(level=..., log_file=...)` at startup (or `RT_LOG_LEVEL` / `RT_LOG_FILE` environment variables) as the single way to configure logging.

--- a/docs/scripts/documentation/quickstart.py
+++ b/docs/scripts/documentation/quickstart.py
@@ -8,8 +8,8 @@ Agent = rt.agent_node(
 )
 
 
-# Create your flow and set the entry point to the function we just created. 
-# Then we can invoke the flow with a the input to the function node. 
+# Create your flow and set the entry point to the agent we just created.
+# Then we can invoke the flow with the input to that agent.
 flow = rt.Flow("Quickstart Example", entry_point=Agent)
 
 result = flow.invoke("Hello, what can you do?")

--- a/docs/scripts/documentation/sequential.py
+++ b/docs/scripts/documentation/sequential.py
@@ -1,0 +1,37 @@
+# --8<-- [start: sequential]
+import railtracks as rt
+
+llm = rt.llm.OpenAILLM("gpt-4o")
+
+Researcher = rt.agent_node(
+    name="Researcher",
+    system_message="Collect the key facts about the topic the user gives you. Answer in bullet points.",
+    llm=llm,
+)
+
+Writer = rt.agent_node(
+    name="Writer",
+    system_message="Turn the notes you are given into a single tight paragraph.",
+    llm=llm,
+)
+
+
+@rt.function_node
+async def research_then_write(topic: str) -> str:
+    """Research a topic, then write the findings up as a paragraph.
+
+    Args:
+        topic: The subject to research.
+
+    Returns:
+        A one paragraph write-up of the topic.
+    """
+    notes = await rt.call(Researcher, topic)
+    write_up = await rt.call(Writer, notes.text)
+    return write_up.text
+
+
+flow = rt.Flow(name="Research then Write", entry_point=research_then_write)
+result = flow.invoke("How do heat pumps work?")
+# --8<-- [end: sequential]
+print(result)

--- a/docs/tutorials/concepts/agents.md
+++ b/docs/tutorials/concepts/agents.md
@@ -21,6 +21,8 @@ for a while now, but LLMs have changed the game and made it much easier to use t
 accomplish complex tasks and goals. This ability makes them uniquely suited to operate as the **brain** for your agentic
 system.
 
+In Railtracks, an agent built on an LLM is an [agent node](../../documentation/agent_design/overview.md#agent-node).
+
 ```mermaid
 graph TB
     User[User]

--- a/docs/tutorials/concepts/architectures/overview.md
+++ b/docs/tutorials/concepts/architectures/overview.md
@@ -21,9 +21,9 @@ The same flow model supports multiple agent architectures without introducing ne
   </a>
 
   <a class="card" href="../sequential/">
-    <h3>Sequential Agent</h3>
+    <h3>Sequential Flows</h3>
     <p>
-      Linear flows and branching logic between agents, tools, and functions defined programmatically in Python.
+      A fixed order of agents, tools, and functions, defined programmatically in Python rather than chosen by a model.
     </p>
   </a>
 </div>

--- a/docs/tutorials/concepts/architectures/sequential.md
+++ b/docs/tutorials/concepts/architectures/sequential.md
@@ -1,8 +1,24 @@
 # Sequential Flows
-In many cases you just want things to happen in a specific order. Instead of letting the LLM decide the order you chain tasks programmatically. 
 
-In the below colab notebook, we will explore how to built a simple sequential flow. Connecting an agent in a sequence
+A **sequential flow** is a [Flow](../../../documentation/invocation/flows.md) whose [entry point](../../../documentation/invocation/flows.md#entry-point) is your own `async` function, so its steps run in the order your Python code awaits them. The order lives in the code rather than in a model's judgement: the second step cannot begin before the first returns, because it is a plain `await`.
 
+Reach for one whenever the order is a property of the problem rather than a decision to be made: research before drafting, validate before writing to disk, fetch before summarizing. Leaving that ordering to an LLM adds a decision that can go wrong, spends a round trip on it, and makes a run harder to reproduce. Keep the model for the steps that genuinely need judgement and let the sequence around them stay deterministic.
+
+The tradeoff is flexibility. A sequential flow takes the same path every time, so when the right next step depends on what the last one turned up, either branch in Python once the condition is something you can express in code, or give an [agent node](../../../documentation/agent_design/overview.md#agent-node) the tools and let it choose.
+
+## Example
+
+Two agents composed in order inside a [function node](../../../documentation/agent_design/tools/function_tools.md#what-a-function-node-is), which the Flow then uses as its entry point:
+
+```python
+--8<-- "docs/scripts/documentation/sequential.py:sequential"
+```
+
+`Writer` cannot start until the `await` on `Researcher` returns, so the dependency between the two steps is explicit, and every `invoke` of the Flow runs the same two steps in the same order. Steps that do *not* depend on each other need not wait at all: gather those concurrently instead, as described in [Direct Invocation](../../../documentation/invocation/call.md).
+
+## Try it in Colab
+
+The notebook below builds a sequential flow interactively.
 
 <div class="colab-card">
 

--- a/docs/tutorials/concepts/tools.md
+++ b/docs/tutorials/concepts/tools.md
@@ -6,7 +6,7 @@ One of the most important parts of any agentic system is the **set of tools** th
 
 A **tool** provides the agent with the ability to interact with external systems, perform actions, or access information that is not contained within the LLM's training data. Tools can be anything from APIs, databases, or even simple functions that perform specific tasks.
 
-At a technical level, tools are often defined as **functions** that the agent can call. Large Language Models (LLMs) like OpenAI’s or Anthropic’s support something called `tool_calls` or `function_calls`. These allow the LLM to output structured `JSON`.
+At a technical level, tools are often defined as **functions** that the agent can call. Large Language Models (LLMs) like OpenAI’s or Anthropic’s support something called `tool_calls` or `function_calls`. These allow the LLM to output structured `JSON`. In Railtracks a tool is any node given to an agent, most often a [function node](../../documentation/agent_design/tools/function_tools.md#what-a-function-node-is).
 
 !!! info "Common Tools"
     * Search the web

--- a/docs/tutorials/notebooks/architectures.md
+++ b/docs/tutorials/notebooks/architectures.md
@@ -1,7 +1,5 @@
 ## Sequential Flows
-In many cases you just want things to happen in a specific order. Instead of letting the LLM decide the order you chain tasks programmatically. 
-
-In the below colab notebook, we will explore how to built a simple sequential flow. Connecting an agent in a sequence
+A [sequential flow](../concepts/architectures/sequential.md) runs its steps in the order your Python code awaits them, rather than letting the LLM decide. The concept page covers when to reach for one and why; the notebook below builds one interactively.
 
 
 <div class="colab-card">
@@ -30,9 +28,7 @@ In the below colab notebook, we will explore how to built a simple sequential fl
 </div>
 
 ## Validation Loops
-Anyone who has spent time building agentic systems has likely run into the limits of one-shot LLM responses, especially as tasks grow more complex where precision is at a premium. This is where validation loops become useful.
-
-A validation loop allows an agent to iteratively evaluate its own output, apply feedback, and try again until a desired bar is met. In this tutorial, we’ll walk through a simple example of building a validation loop in Railtracks. While the example uses an LLM to perform validation, the same pattern can be applied with fully programmatic checks such as schema validation, static analysis, code execution, or other custom logic.
+A [validation loop](../concepts/architectures/validation_loop.md) has an agent evaluate its own output, apply the feedback, and try again until a desired bar is met. The concept page covers the pattern and its variations; the notebook below builds one interactively.
 
 
 

--- a/docs/tutorials/walkthroughs/byfa.md
+++ b/docs/tutorials/walkthroughs/byfa.md
@@ -16,7 +16,7 @@ Start with minimal ingredients: a model + a system message
 What if your agent needs real-world data? You will need to give it _tools_. This allows your agent to go beyond static responses and actually interact with the real world.
 
 ??? tip "Creating a Tool"
-    All you need is a Python function with docstring and the `rt.function_node` decorator
+    All you need is a Python function with docstring and the `rt.function_node` decorator, which turns it into a [function node](../../documentation/agent_design/tools/function_tools.md#what-a-function-node-is).
     ```python 
     --8<-- "docs/scripts/first_agent.py:general_tool"
     ```

--- a/docs/tutorials/walkthroughs/flows.md
+++ b/docs/tutorials/walkthroughs/flows.md
@@ -2,6 +2,9 @@
 
 Railtracks makes it easy to create custom agents with access to tools they can call to complete tasks. But what if you want to use agents themselves as tools? In this section, we’ll explore more complex flows and how Railtracks gives you control over them.
 
+!!! note
+    “Flow” is used here in its informal sense, meaning the shape of an agent graph. For the `rt.Flow` object that wraps a graph as a reusable entry point, see [Flows](../../documentation/invocation/flows.md).
+
 To start, let’s look at the simplest case: an agent that uses another agent as a tool.
 
 ### Example

--- a/docs/tutorials/walkthroughs/ryfa.md
+++ b/docs/tutorials/walkthroughs/ryfa.md
@@ -3,7 +3,7 @@
 ## Calling the Agent directly
 Once you have defined your agent class ([Build Your First Agent](byfa.md)) you can then run your workflow and see results!
 
-To begin you just have to use **`call`** method from Railtracks. This is an asynchronous method so you will need to run it in an async context.
+To begin you just have to use the **`call`** method from Railtracks, which is called [direct invocation](../../documentation/invocation/call.md). This is an asynchronous method so you will need to run it in an async context. Once you are past a first run, wrap your agent in a [Flow](../../documentation/invocation/flows.md) instead: that is where context, timeouts and run inspection are configured.
 
 === "Asynchronous"
     ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ theme:
     - content.code.copy
     - content.code.highlight
     - content.code.annotate
+    - content.tooltips
 
 plugins:
   - search
@@ -61,8 +62,14 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:mermaid2.fence_mermaid_custom
+  - abbr
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  # Glossary terms are appended to every page so `abbr` can turn them into
+  # hover definitions. The appended file is generated from docs/glossary.md
+  # by scripts/mkdocs_hooks.py.
+  - pymdownx.snippets:
+      auto_append:
+        - docs/includes/glossary_tooltips.md
   - pymdownx.highlight:
       anchor_linenums: true
       pygments_lang_class: true
@@ -74,11 +81,19 @@ extra_css:
 extra:
   generator: false
 
+# Generated include, appended to every page rather than published as one.
+exclude_docs: |
+  includes/
+
 # Per-middleware prebuilt pages are intentionally kept out of the sidebar (they are
 # reached from the prebuilt Overview catalog) so the nav stays clean as the
 # catalog grows. Listing them here silences the "not in nav" build warning.
 not_in_nav: |
   /documentation/agent_design/middleware/prebuilt/list/*.md
+
+validation:
+  links:
+    anchors: warn
 
 nav:
   - Home: index.md
@@ -228,5 +243,7 @@ nav:
               - Overview: tutorials/concepts/architectures/overview.md
               - Validation Loops: tutorials/concepts/architectures/validation_loop.md
               - Sequential Flows: tutorials/concepts/architectures/sequential.md
+
+  - Glossary: glossary.md
 
   - API Reference: api_reference.md

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -2,10 +2,91 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+# Terms whose capitalized form still shows up in unrelated senses across the docs
+# ("a Run", "the Store", "this Document"). `abbr` rewrites every whole-word match on
+# every page, so tooltipping these would litter ordinary prose with dotted
+# underlines. They stay in the glossary; they just do not become tooltips.
+_TOOLTIP_DENYLIST = frozenset(
+    {
+        "Agent",
+        "Context",
+        "Document",
+        "LLM",
+        "Metric",
+        "Run",
+        "Session",
+        "Store",
+        "Tool",
+    }
+)
+
+_GLOSSARY_TERM = re.compile(r"^### (?P<term>.+?)\s*$", re.MULTILINE)
+
+
+def _plain_text(markdown: str) -> str:
+    """Strip the inline markup `abbr` definitions cannot carry.
+
+    Abbreviation definitions render as a plain `title` attribute, so links, emphasis
+    and code spans have to be flattened to their text.
+    """
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", markdown)  # links -> link text
+    text = text.replace("`", "")
+    text = re.sub(r"\*{1,2}([^*]+)\*{1,2}", r"\1", text)  # bold / emphasis
+    return " ".join(text.split())
+
+
+def _first_sentence(paragraph: str) -> str:
+    """Return the paragraph's opening sentence, keeping its terminating period."""
+    match = re.search(r"^.*?[.!?](?=\s|$)", paragraph)
+    return (match.group(0) if match else paragraph).strip()
+
+
+def _glossary_tooltips(glossary: Path) -> str:
+    """Build the `abbr` definition list that gives every glossary term a tooltip.
+
+    Generated rather than hand-written so the tooltip a reader hovers and the entry
+    on the glossary page cannot drift apart.
+    """
+    text = glossary.read_text(encoding="utf-8").replace("\r\n", "\n")
+    matches = list(_GLOSSARY_TERM.finditer(text))
+
+    lines = [
+        "<!-- Generated from docs/glossary.md by scripts/mkdocs_hooks.py. Do not edit. -->",
+        "",
+    ]
+    for current, following in zip(matches, matches[1:] + [None]):
+        term = current.group("term")
+        if term in _TOOLTIP_DENYLIST:
+            continue
+
+        end = following.start() if following is not None else len(text)
+        body = text[current.end() : end].strip()
+        if not body:
+            continue
+
+        definition = _first_sentence(_plain_text(body.split("\n\n")[0]))
+        if definition:
+            lines.append(f"*[{term}]: {definition}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _write_if_changed(path: Path, content: str) -> None:
+    """Write only on a real change, so the file's mtime stays put.
+
+    `mkdocs serve` watches the docs directory. Rewriting a file there on every build
+    would register as a change and kick off another build, looping forever.
+    """
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
 
 
 def _api_reference_is_fresh(src_dir: Path, output_dir: Path) -> bool:
@@ -52,7 +133,7 @@ def _generate_api_reference(repo_root: Path, output_dir: Path) -> None:
 
 
 def on_pre_build(config, **kwargs):
-    """Regenerate API docs before each build.
+    """Regenerate the derived documentation files before each build.
 
     Skips pdoc entirely when output is already newer than all source files,
     which prevents MkDocs' watcher from detecting a spurious change and
@@ -61,6 +142,13 @@ def on_pre_build(config, **kwargs):
     repo_root = Path(__file__).resolve().parent.parent
     src_dir = repo_root / "packages" / "railtracks" / "src" / "railtracks"
     output_dir = repo_root / "docs" / "api_reference"
+
+    glossary = repo_root / "docs" / "glossary.md"
+    if glossary.exists():
+        _write_if_changed(
+            repo_root / "docs" / "includes" / "glossary_tooltips.md",
+            _glossary_tooltips(glossary),
+        )
 
     if _api_reference_is_fresh(src_dir, output_dir):
         return


### PR DESCRIPTION
Resolves #1179. Written from scratch rather than continuing #1420, with that PR's review used as the specification.

## The problem

Framework vocabulary is used throughout the docs without being defined anywhere. `node` appears on 25 pages with no definition on any of them. "Direct Invocation" exists only as a nav label in `mkdocs.yml` and appears in no page. "entry point" and "run" carry real scoping rules (context lifetime, timeouts, per-run budgets) that a reader has no way to look up. Several concepts are also named two ways: a `Sequential Agent` card pointing at a `# Sequential Flows` page, an `## Agent Manifest` heading over `rt.ToolManifest` code, and a `Flows (Session Management)` title resting on a term the docs never define.

## Approach

**One canonical home per term.** The full description, with the reasons and an example, lives on the page that already owns the subject. The glossary is an index that points at those sections. No definition is written twice; a grep for each definition sentence returns exactly one file.

## What changed

**Definitions written where they were missing** (each with a stable anchor):

| Term | Home |
|---|---|
| Node, Agent Node | new `## Building Blocks` in `documentation/agent_design/overview.md` |
| Function Node | new lead section in `agent_design/tools/function_tools.md` (promoted out of a code annotation) |
| Flow, Entry Point, Run | `documentation/invocation/flows.md` |
| Direct Invocation | `documentation/invocation/call.md`, which previously had no H1 and never used its own nav name |
| Sequential Flow | `tutorials/concepts/architectures/sequential.md`, with a worked example |

**New glossary** at `docs/glossary.md`, a top-level nav entry before API Reference. 31 terms, grouped. Every entry is at most two sentences and ends in a link to the canonical section; no code, no examples. The page states that contract in a note so it stays an index rather than growing into a second set of docs.

**Definitions on hover.** Glossary entries become site-wide tooltips through `abbr`. The definition list is *generated* from `docs/glossary.md` by `scripts/mkdocs_hooks.py` (which already generates the API reference), so a tooltip and its glossary entry cannot drift apart. Two safeguards: the file is written only when its content actually changes, so `mkdocs serve`'s watcher cannot enter a rebuild loop; and a denylist keeps generic words (`Run`, `Tool`, `Context`, `Agent`, `Store`, `Document`, `LLM`, `Metric`, `Session`) out of the tooltips, since `abbr` rewrites every whole-word match on every page. Case sensitivity does useful work here too: `Flow` is tooltipped, the informal lowercase "flow" is left alone. A small CSS rule stops headings from being tooltipped, where the definition would only repeat the text directly beneath it.

**Keyword links at first mention** on the 18 pages that lean hardest on undefined vocabulary (quickstart, byfa, ryfa, the middleware pages, mcp, streaming, context, logging, error handling, the concept pages). First mention only, not every occurrence.

**Terminology reconciled:**
- `Sequential Agent` card renamed to `Sequential Flows` to match the page it links to.
- `## 2. Agent Manifest` renamed to `Tool Manifest` to match `rt.ToolManifest`, and given an actual definition.
- `(Session Management)` dropped from the Flows title.
- `tutorials/notebooks/architectures.md` carried prose byte-identical to two concept pages, so a glossary link had two equally valid targets. It now links to the canonical page instead of restating it.
- The informal-flow walkthrough gets one note distinguishing it from `rt.Flow`.
- Fixed two empty link targets (`[pass this function as a tool]()`, `[Tutorials]()`).
- Fixed a comment in `quickstart.py` calling an agent node a function node.

**From the #1420 review specifically:**
- Every definition link lands on an anchor, not a page top.
- `rt.call` is framed as composition *inside* a Flow, with a tip stating exactly what a top-level call gives up: Flow-scoped context, `timeout`, `end_on_error`, broadcast and payload callbacks, and the `flow.connect()` handle. Verified against `interaction/_call.py`, where a top-level call wraps itself in an implicit session with default config.
- The italicised *LLM*, *Tools* and *Middleware* on the agent-design page are now links.
- The Sequential Flow example lives in `docs/scripts/documentation/sequential.py` and is type-checked by `scripts/docs_validation.sh`, per the convention comments on that PR.
- `contributing_docs.md` gains a **Keywords and the glossary** section, so the convention is written down rather than relearned.

**Broken anchors now fail the build.** mkdocs reports unknown anchors at `info` level by default, which is how #1420 could ship links that landed on page tops. `validation.links.anchors: warn` plus `--strict` turns that into a build failure. Smoke-tested with a deliberately bad anchor: the build aborts. No pre-existing backlog surfaced.

## Verification

- `mkdocs build --strict` — clean, zero warnings, with anchor validation active.
- `scripts/docs_validation.sh` — passes, including the new `sequential.py`.
- `ruff check` / `ruff format --check` — clean on `scripts/mkdocs_hooks.py` (`docs/` is excluded from ruff in `pyproject.toml`).
- Confirmed `<abbr title=...>` renders, and that heading anchors survive the abbr pass.

## Deliberately out of scope

`Session` as an object and `Request` have no definition anywhere today, and the review of #1420 called `Session` a framework internal needing careful treatment of its own. So this PR defines the user-facing **Run** instead, and gives **Session** only its narrow verifiable meaning: the record written under `.railtracks/data/sessions/`.

Follow-ups worth their own tickets, all skipped here rather than given invented glosses:

- `Request` — appears in `request_id` and log output with nothing to point at.
- `LLMResponse` / `MessageHistory` — `.text` / `.structured` / `.message_history` are explained inside an admonition in `ryfa.md`, which produces no anchor to link.
- `AgentHub` — a nav group name that no page defines.
- `system_message` is left unlinked: its page is still unmerged, and linking it would break a strict build on a clean checkout.
