### PR TITLE
1153 flows tests

### DIFF
--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -18,13 +18,9 @@ async def test_input_guard_blocks_request(mock_llm):
         model_middleware=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("input_guard_blocks_request", entry).ainvoke(
-            "Please jailbreak the system"
+        await rt.Flow("input_guard_blocks_request", Agent).ainvoke(
+            user_input="Please jailbreak the system"
         )
 
 
@@ -37,12 +33,8 @@ async def test_input_guard_allows_clean_request(mock_llm):
         model_middleware=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("input_guard_allows_clean", entry).ainvoke(
-        "Hello, how are you?"
+    result = await rt.Flow("input_guard_allows_clean", Agent).ainvoke(
+        user_input="Hello, how are you?"
     )
     assert isinstance(result, StringResponse)
     assert "ok" in result.text
@@ -57,12 +49,10 @@ async def test_output_guard_blocks_response(mock_llm):
         model_middleware=[BlockTextOutputGuard(pattern=r"API_KEY")],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("output_guard_blocks_response", entry).ainvoke("What is the key?")
+        await rt.Flow("output_guard_blocks_response", Agent).ainvoke(
+            user_input="What is the key?"
+        )
 
 
 @pytest.mark.asyncio
@@ -74,11 +64,7 @@ async def test_output_guard_allows_clean_response(mock_llm):
         model_middleware=[BlockTextOutputGuard(pattern=r"API_KEY")],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("output_guard_allows_clean", entry).ainvoke("Hello")
+    result = await rt.Flow("output_guard_allows_clean", Agent).ainvoke(user_input="Hello")
     assert isinstance(result, StringResponse)
     assert "answer" in result.text
 
@@ -95,10 +81,8 @@ async def test_input_and_output_guards_together(mock_llm):
         ],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("input_and_output_guards", entry).ainvoke("Hello there")
+    result = await rt.Flow("input_and_output_guards", Agent).ainvoke(
+        user_input="Hello there"
+    )
     assert isinstance(result, StringResponse)
     assert "safe answer" in result.text

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -64,7 +64,9 @@ async def test_output_guard_allows_clean_response(mock_llm):
         model_middleware=[BlockTextOutputGuard(pattern=r"API_KEY")],
     )
 
-    result = await rt.Flow("output_guard_allows_clean", Agent).ainvoke(user_input="Hello")
+    result = await rt.Flow("output_guard_allows_clean", Agent).ainvoke(
+        user_input="Hello"
+    )
     assert isinstance(result, StringResponse)
     assert "answer" in result.text
 

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -17,9 +17,15 @@ async def test_input_guard_blocks_request(mock_llm):
         llm=llm,
         model_middleware=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="Please jailbreak the system")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("input_guard_blocks_request", entry).ainvoke(
+            "Please jailbreak the system"
+        )
 
 
 @pytest.mark.asyncio
@@ -30,8 +36,14 @@ async def test_input_guard_allows_clean_request(mock_llm):
         llm=llm,
         model_middleware=[BlockTextInputGuard(pattern=r"\bjailbreak\b")],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="Hello, how are you?")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("input_guard_allows_clean", entry).ainvoke(
+        "Hello, how are you?"
+    )
     assert isinstance(result, StringResponse)
     assert "ok" in result.text
 
@@ -44,9 +56,15 @@ async def test_output_guard_blocks_response(mock_llm):
         llm=llm,
         model_middleware=[BlockTextOutputGuard(pattern=r"API_KEY")],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="What is the key?")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("output_guard_blocks_response", entry).ainvoke(
+            "What is the key?"
+        )
 
 
 @pytest.mark.asyncio
@@ -57,8 +75,12 @@ async def test_output_guard_allows_clean_response(mock_llm):
         llm=llm,
         model_middleware=[BlockTextOutputGuard(pattern=r"API_KEY")],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="Hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("output_guard_allows_clean", entry).ainvoke("Hello")
     assert isinstance(result, StringResponse)
     assert "answer" in result.text
 
@@ -74,7 +96,11 @@ async def test_input_and_output_guards_together(mock_llm):
             BlockTextOutputGuard(pattern=r"SECRET"),
         ],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="Hello there")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("input_and_output_guards", entry).ainvoke("Hello there")
     assert isinstance(result, StringResponse)
     assert "safe answer" in result.text

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_block_text.py
@@ -62,9 +62,7 @@ async def test_output_guard_blocks_response(mock_llm):
         return await rt.call(Agent, user_input=user_input)
 
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("output_guard_blocks_response", entry).ainvoke(
-            "What is the key?"
-        )
+        await rt.Flow("output_guard_blocks_response", entry).ainvoke("What is the key?")
 
 
 @pytest.mark.asyncio

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -86,9 +86,13 @@ async def test_terminal_input_block_skips_llm(mock_llm, block_input):
         llm=llm,
         model_middleware=[block_input],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("terminal_input_block", entry).ainvoke("hello")
     assert counts["n"] == 0
 
 
@@ -101,8 +105,12 @@ async def test_terminal_input_allow_calls_llm(mock_llm, allow_input):
         llm=llm,
         model_middleware=[allow_input],
     )
-    with rt.Session():
-        out = await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    out = await rt.Flow("terminal_input_allow", entry).ainvoke("hello")
     assert counts["n"] == 1
     assert isinstance(out, StringResponse)
     assert "ok" in out.text
@@ -118,8 +126,11 @@ async def test_terminal_guardrails_allow(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    with rt.Session():
-        result = await rt.call(Agent, user_input="hi")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("terminal_guardrails_allow", entry).ainvoke("hi")
 
     assert counts["n"] == 1
     assert isinstance(result, StringResponse)
@@ -140,9 +151,13 @@ async def test_structured_input_block_skips_llm(mock_llm, block_input):
         llm=llm,
         model_middleware=[block_input],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="q")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("structured_input_block", entry).ainvoke("q")
     assert counts["n"] == 0
 
 
@@ -159,9 +174,13 @@ async def test_structured_output_block_after_llm(mock_llm, allow_input):
             FnOutputGuard(lambda _e: GuardrailDecision.block(reason="output policy")),
         ],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="q")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("structured_output_block", entry).ainvoke("q")
 
 
 @pytest.mark.asyncio
@@ -175,8 +194,11 @@ async def test_structured_guardrails_allow(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    with rt.Session():
-        result = await rt.call(Agent, user_input="hi")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("structured_guardrails_allow", entry).ainvoke("hi")
 
     assert counts["n"] == 1
     assert isinstance(result, StructuredResponse)
@@ -195,9 +217,13 @@ async def test_terminal_output_block(mock_llm, allow_input):
             FnOutputGuard(lambda _e: GuardrailDecision.block(reason="no")),
         ],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="q")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("terminal_output_block", entry).ainvoke("q")
 
 
 # ============================================================
@@ -218,9 +244,13 @@ async def test_tool_call_input_block_skips_llm(mock_llm, block_input):
         llm=llm,
         model_middleware=[block_input],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("tool_call_input_block", entry).ainvoke("hello")
     assert counts["n"] == 0
 
 
@@ -237,8 +267,12 @@ async def test_tool_call_input_allow_calls_llm(mock_llm, allow_input):
         llm=llm,
         model_middleware=[allow_input],
     )
-    with rt.Session():
-        out = await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    out = await rt.Flow("tool_call_input_allow", entry).ainvoke("hello")
     assert counts["n"] >= 1
     assert isinstance(out, StringResponse)
 
@@ -257,9 +291,13 @@ async def test_tool_call_output_block(mock_llm, allow_input):
             FnOutputGuard(lambda _e: GuardrailDecision.block(reason="blocked output")),
         ],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("tool_call_output_block", entry).ainvoke("hello")
 
 
 @pytest.mark.asyncio
@@ -286,8 +324,12 @@ async def test_tool_call_output_transform_updates_response_and_history(
             ),
         ],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="hello")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("tool_call_output_transform", entry).ainvoke("hello")
     assert isinstance(result, StringResponse)
     assert result.content == transformed
     assert result.message_history[-1].content == transformed
@@ -327,8 +369,12 @@ async def test_tool_call_output_guard_fires_only_on_final_reply(mock_llm, allow_
         llm=llm,
         model_middleware=[allow_input, FnOutputGuard(_counting_guard)],
     )
-    with rt.Session():
-        await rt.call(Agent, user_input="weather?")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    await rt.Flow("tool_call_output_fires_once", entry).ainvoke("weather?")
 
     assert fire_count["n"] == 1
 

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -174,7 +174,9 @@ async def test_structured_guardrails_allow(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    result = await rt.Flow("structured_guardrails_allow", Agent).ainvoke(user_input="hi")
+    result = await rt.Flow("structured_guardrails_allow", Agent).ainvoke(
+        user_input="hi"
+    )
 
     assert counts["n"] == 1
     assert isinstance(result, StructuredResponse)

--- a/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_agent_node_guardrails.py
@@ -87,12 +87,8 @@ async def test_terminal_input_block_skips_llm(mock_llm, block_input):
         model_middleware=[block_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("terminal_input_block", entry).ainvoke("hello")
+        await rt.Flow("terminal_input_block", Agent).ainvoke(user_input="hello")
     assert counts["n"] == 0
 
 
@@ -106,11 +102,7 @@ async def test_terminal_input_allow_calls_llm(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    out = await rt.Flow("terminal_input_allow", entry).ainvoke("hello")
+    out = await rt.Flow("terminal_input_allow", Agent).ainvoke(user_input="hello")
     assert counts["n"] == 1
     assert isinstance(out, StringResponse)
     assert "ok" in out.text
@@ -126,11 +118,7 @@ async def test_terminal_guardrails_allow(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("terminal_guardrails_allow", entry).ainvoke("hi")
+    result = await rt.Flow("terminal_guardrails_allow", Agent).ainvoke(user_input="hi")
 
     assert counts["n"] == 1
     assert isinstance(result, StringResponse)
@@ -152,12 +140,8 @@ async def test_structured_input_block_skips_llm(mock_llm, block_input):
         model_middleware=[block_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("structured_input_block", entry).ainvoke("q")
+        await rt.Flow("structured_input_block", Agent).ainvoke(user_input="q")
     assert counts["n"] == 0
 
 
@@ -175,12 +159,8 @@ async def test_structured_output_block_after_llm(mock_llm, allow_input):
         ],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("structured_output_block", entry).ainvoke("q")
+        await rt.Flow("structured_output_block", Agent).ainvoke(user_input="q")
 
 
 @pytest.mark.asyncio
@@ -194,11 +174,7 @@ async def test_structured_guardrails_allow(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("structured_guardrails_allow", entry).ainvoke("hi")
+    result = await rt.Flow("structured_guardrails_allow", Agent).ainvoke(user_input="hi")
 
     assert counts["n"] == 1
     assert isinstance(result, StructuredResponse)
@@ -218,12 +194,8 @@ async def test_terminal_output_block(mock_llm, allow_input):
         ],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("terminal_output_block", entry).ainvoke("q")
+        await rt.Flow("terminal_output_block", Agent).ainvoke(user_input="q")
 
 
 # ============================================================
@@ -245,12 +217,8 @@ async def test_tool_call_input_block_skips_llm(mock_llm, block_input):
         model_middleware=[block_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("tool_call_input_block", entry).ainvoke("hello")
+        await rt.Flow("tool_call_input_block", Agent).ainvoke(user_input="hello")
     assert counts["n"] == 0
 
 
@@ -268,11 +236,7 @@ async def test_tool_call_input_allow_calls_llm(mock_llm, allow_input):
         model_middleware=[allow_input],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    out = await rt.Flow("tool_call_input_allow", entry).ainvoke("hello")
+    out = await rt.Flow("tool_call_input_allow", Agent).ainvoke(user_input="hello")
     assert counts["n"] >= 1
     assert isinstance(out, StringResponse)
 
@@ -292,12 +256,8 @@ async def test_tool_call_output_block(mock_llm, allow_input):
         ],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("tool_call_output_block", entry).ainvoke("hello")
+        await rt.Flow("tool_call_output_block", Agent).ainvoke(user_input="hello")
 
 
 @pytest.mark.asyncio
@@ -325,11 +285,9 @@ async def test_tool_call_output_transform_updates_response_and_history(
         ],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("tool_call_output_transform", entry).ainvoke("hello")
+    result = await rt.Flow("tool_call_output_transform", Agent).ainvoke(
+        user_input="hello"
+    )
     assert isinstance(result, StringResponse)
     assert result.content == transformed
     assert result.message_history[-1].content == transformed
@@ -370,11 +328,7 @@ async def test_tool_call_output_guard_fires_only_on_final_reply(mock_llm, allow_
         model_middleware=[allow_input, FnOutputGuard(_counting_guard)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    await rt.Flow("tool_call_output_fires_once", entry).ainvoke("weather?")
+    await rt.Flow("tool_call_output_fires_once", Agent).ainvoke(user_input="weather?")
 
     assert fire_count["n"] == 1
 

--- a/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
@@ -49,12 +49,10 @@ async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
     counts = _counting_chat(guarded_llm)
     agent = rt.agent_node(name="guarded", llm=guarded_llm, model_middleware=[llm_judge])
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError) as exc:
-        await rt.Flow("async_input_guard_blocks", entry).ainvoke("something sketchy")
+        await rt.Flow("async_input_guard_blocks", agent).ainvoke(
+            user_input="something sketchy"
+        )
 
     assert counts["n"] == 0
     assert "UNSAFE" in seen["verdict"]
@@ -82,11 +80,9 @@ async def test_async_input_guard_allows_using_a_judge_agent(mock_llm):
         name="guarded-ok", llm=guarded_llm, model_middleware=[llm_judge]
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
-    out = await rt.Flow("async_input_guard_allows", entry).ainvoke("a normal question")
+    out = await rt.Flow("async_input_guard_allows", agent).ainvoke(
+        user_input="a normal question"
+    )
 
     assert counts["n"] == 1
     assert isinstance(out, StringResponse)
@@ -113,12 +109,10 @@ async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
         model_middleware=[llm_judge],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError) as exc:
-        await rt.Flow("async_output_guard_blocks", entry).ainvoke("tell me a secret")
+        await rt.Flow("async_output_guard_blocks", agent).ainvoke(
+            user_input="tell me a secret"
+        )
 
     assert exc.value.reason == "judge flagged output"
 
@@ -154,11 +148,9 @@ async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
         name="guarded-transform", llm=guarded_llm, model_middleware=[rewrite]
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
-    await rt.Flow("async_guard_transform", entry).ainvoke("the original question")
+    await rt.Flow("async_guard_transform", agent).ainvoke(
+        user_input="the original question"
+    )
 
     assert any("sanitized question" in m for m in seen["messages"])
     assert not any("the original question" in m for m in seen["messages"])

--- a/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_async_guardrail_agent_call.py
@@ -49,9 +49,12 @@ async def test_async_input_guard_blocks_using_a_judge_agent(mock_llm):
     counts = _counting_chat(guarded_llm)
     agent = rt.agent_node(name="guarded", llm=guarded_llm, model_middleware=[llm_judge])
 
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError) as exc:
-            await rt.call(agent, user_input="something sketchy")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError) as exc:
+        await rt.Flow("async_input_guard_blocks", entry).ainvoke("something sketchy")
 
     assert counts["n"] == 0
     assert "UNSAFE" in seen["verdict"]
@@ -79,8 +82,11 @@ async def test_async_input_guard_allows_using_a_judge_agent(mock_llm):
         name="guarded-ok", llm=guarded_llm, model_middleware=[llm_judge]
     )
 
-    with rt.Session():
-        out = await rt.call(agent, user_input="a normal question")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    out = await rt.Flow("async_input_guard_allows", entry).ainvoke("a normal question")
 
     assert counts["n"] == 1
     assert isinstance(out, StringResponse)
@@ -107,9 +113,12 @@ async def test_async_output_guard_blocks_using_a_judge_agent(mock_llm):
         model_middleware=[llm_judge],
     )
 
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError) as exc:
-            await rt.call(agent, user_input="tell me a secret")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError) as exc:
+        await rt.Flow("async_output_guard_blocks", entry).ainvoke("tell me a secret")
 
     assert exc.value.reason == "judge flagged output"
 
@@ -145,8 +154,11 @@ async def test_async_guard_transform_via_agent_rewrites_history(mock_llm):
         name="guarded-transform", llm=guarded_llm, model_middleware=[rewrite]
     )
 
-    with rt.Session():
-        await rt.call(agent, user_input="the original question")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    await rt.Flow("async_guard_transform", entry).ainvoke("the original question")
 
     assert any("sanitized question" in m for m in seen["messages"])
     assert not any("the original question" in m for m in seen["messages"])

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
@@ -35,9 +35,13 @@ async def test_input_guard_exception_blocks_the_call_by_default(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[RaisingInputGuard(fail_open=False)],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("fail_closed_input", entry).ainvoke("hi")
 
 
 @pytest.mark.asyncio
@@ -47,8 +51,12 @@ async def test_input_guard_exception_does_not_block_the_call_when_fail_open(mock
         llm=mock_llm(custom_response="ok"),
         model_middleware=[RaisingInputGuard(fail_open=True)],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("fail_open_input", entry).ainvoke("hi")
 
     assert isinstance(result, StringResponse)
     assert "ok" in result.text
@@ -61,9 +69,13 @@ async def test_output_guard_exception_blocks_the_call_by_default(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[RaisingOutputGuard(fail_open=False)],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("fail_closed_output", entry).ainvoke("hi")
 
 
 @pytest.mark.asyncio
@@ -73,8 +85,12 @@ async def test_output_guard_exception_does_not_block_the_call_when_fail_open(moc
         llm=mock_llm(custom_response="ok"),
         model_middleware=[RaisingOutputGuard(fail_open=True)],
     )
-    with rt.Session():
-        result = await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    result = await rt.Flow("fail_open_output", entry).ainvoke("hi")
 
     assert isinstance(result, StringResponse)
     assert "ok" in result.text

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_fail_open.py
@@ -36,12 +36,8 @@ async def test_input_guard_exception_blocks_the_call_by_default(mock_llm):
         model_middleware=[RaisingInputGuard(fail_open=False)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("fail_closed_input", entry).ainvoke("hi")
+        await rt.Flow("fail_closed_input", Agent).ainvoke(user_input="hi")
 
 
 @pytest.mark.asyncio
@@ -52,11 +48,7 @@ async def test_input_guard_exception_does_not_block_the_call_when_fail_open(mock
         model_middleware=[RaisingInputGuard(fail_open=True)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("fail_open_input", entry).ainvoke("hi")
+    result = await rt.Flow("fail_open_input", Agent).ainvoke(user_input="hi")
 
     assert isinstance(result, StringResponse)
     assert "ok" in result.text
@@ -70,12 +62,8 @@ async def test_output_guard_exception_blocks_the_call_by_default(mock_llm):
         model_middleware=[RaisingOutputGuard(fail_open=False)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("fail_closed_output", entry).ainvoke("hi")
+        await rt.Flow("fail_closed_output", Agent).ainvoke(user_input="hi")
 
 
 @pytest.mark.asyncio
@@ -86,11 +74,7 @@ async def test_output_guard_exception_does_not_block_the_call_when_fail_open(moc
         model_middleware=[RaisingOutputGuard(fail_open=True)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    result = await rt.Flow("fail_open_output", entry).ainvoke("hi")
+    result = await rt.Flow("fail_open_output", Agent).ainvoke(user_input="hi")
 
     assert isinstance(result, StringResponse)
     assert "ok" in result.text

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
@@ -55,11 +55,7 @@ async def test_input_guards_fire_in_list_order(mock_llm):
         model_middleware=[guard_a, guard_b],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    await rt.Flow("input_guards_fire_in_list_order", entry).ainvoke("hi")
+    await rt.Flow("input_guards_fire_in_list_order", Agent).ainvoke(user_input="hi")
 
     assert trace == ["A", "B"]
 
@@ -87,11 +83,9 @@ async def test_input_guard_transform_is_seen_by_the_next_guard_in_the_chain(mock
         model_middleware=[FnInputGuard(redact), FnInputGuard(record)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    await rt.Flow("input_guard_transform_chain", entry).ainvoke("my secret is X")
+    await rt.Flow("input_guard_transform_chain", Agent).ainvoke(
+        user_input="my secret is X"
+    )
 
     assert seen["last_content"] == "my [REDACTED] is X"
 
@@ -114,12 +108,8 @@ async def test_input_guard_block_short_circuits_later_guards_in_the_list(mock_ll
         model_middleware=[block, counter],
     )
 
-    @rt.function_node
-    async def entry1(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("block_first", entry1).ainvoke("hi")
+        await rt.Flow("block_first", Agent).ainvoke(user_input="hi")
     assert counts["n"] == 0
 
     # counter listed first: it runs before the later guard blocks
@@ -129,12 +119,8 @@ async def test_input_guard_block_short_circuits_later_guards_in_the_list(mock_ll
         model_middleware=[counter, block],
     )
 
-    @rt.function_node
-    async def entry2(user_input):
-        return await rt.call(Agent2, user_input=user_input)
-
     with pytest.raises(GuardrailBlockedError):
-        await rt.Flow("block_second", entry2).ainvoke("hi")
+        await rt.Flow("block_second", Agent2).ainvoke(user_input="hi")
     assert counts["n"] == 1
 
 
@@ -162,11 +148,7 @@ async def test_output_guards_fire_in_reverse_list_order(mock_llm):
         model_middleware=[guard_a, guard_b],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    await rt.Flow("output_guards_reverse_order", entry).ainvoke("hi")
+    await rt.Flow("output_guards_reverse_order", Agent).ainvoke(user_input="hi")
 
     # guard_b is closest to the raw model call (innermost), so it observes the
     # response and fires before guard_a, which wraps around it.
@@ -198,11 +180,7 @@ async def test_guard_and_plain_middleware_interleave_by_position(mock_llm):
         model_middleware=[plain_tracer, guard],
     )
 
-    @rt.function_node
-    async def entry1(user_input):
-        return await rt.call(Agent, user_input=user_input)
-
-    await rt.Flow("interleave_plain_first", entry1).ainvoke("hi")
+    await rt.Flow("interleave_plain_first", Agent).ainvoke(user_input="hi")
     assert trace == ["plain", "guard"]
 
     trace.clear()
@@ -212,9 +190,5 @@ async def test_guard_and_plain_middleware_interleave_by_position(mock_llm):
         model_middleware=[guard, plain_tracer],
     )
 
-    @rt.function_node
-    async def entry2(user_input):
-        return await rt.call(Agent2, user_input=user_input)
-
-    await rt.Flow("interleave_guard_first", entry2).ainvoke("hi")
+    await rt.Flow("interleave_guard_first", Agent2).ainvoke(user_input="hi")
     assert trace == ["guard", "plain"]

--- a/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
+++ b/packages/railtracks/tests/integration_tests/guardrails/test_guardrail_ordering.py
@@ -54,8 +54,12 @@ async def test_input_guards_fire_in_list_order(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[guard_a, guard_b],
     )
-    with rt.Session():
-        await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    await rt.Flow("input_guards_fire_in_list_order", entry).ainvoke("hi")
 
     assert trace == ["A", "B"]
 
@@ -82,8 +86,12 @@ async def test_input_guard_transform_is_seen_by_the_next_guard_in_the_chain(mock
         llm=mock_llm(custom_response="ok"),
         model_middleware=[FnInputGuard(redact), FnInputGuard(record)],
     )
-    with rt.Session():
-        await rt.call(Agent, user_input="my secret is X")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    await rt.Flow("input_guard_transform_chain", entry).ainvoke("my secret is X")
 
     assert seen["last_content"] == "my [REDACTED] is X"
 
@@ -105,9 +113,13 @@ async def test_input_guard_block_short_circuits_later_guards_in_the_list(mock_ll
         llm=mock_llm(),
         model_middleware=[block, counter],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry1(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("block_first", entry1).ainvoke("hi")
     assert counts["n"] == 0
 
     # counter listed first: it runs before the later guard blocks
@@ -116,9 +128,13 @@ async def test_input_guard_block_short_circuits_later_guards_in_the_list(mock_ll
         llm=mock_llm(),
         model_middleware=[counter, block],
     )
-    with rt.Session():
-        with pytest.raises(GuardrailBlockedError):
-            await rt.call(Agent2, user_input="hi")
+
+    @rt.function_node
+    async def entry2(user_input):
+        return await rt.call(Agent2, user_input=user_input)
+
+    with pytest.raises(GuardrailBlockedError):
+        await rt.Flow("block_second", entry2).ainvoke("hi")
     assert counts["n"] == 1
 
 
@@ -145,8 +161,12 @@ async def test_output_guards_fire_in_reverse_list_order(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[guard_a, guard_b],
     )
-    with rt.Session():
-        await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    await rt.Flow("output_guards_reverse_order", entry).ainvoke("hi")
 
     # guard_b is closest to the raw model call (innermost), so it observes the
     # response and fires before guard_a, which wraps around it.
@@ -177,8 +197,12 @@ async def test_guard_and_plain_middleware_interleave_by_position(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[plain_tracer, guard],
     )
-    with rt.Session():
-        await rt.call(Agent, user_input="hi")
+
+    @rt.function_node
+    async def entry1(user_input):
+        return await rt.call(Agent, user_input=user_input)
+
+    await rt.Flow("interleave_plain_first", entry1).ainvoke("hi")
     assert trace == ["plain", "guard"]
 
     trace.clear()
@@ -187,6 +211,10 @@ async def test_guard_and_plain_middleware_interleave_by_position(mock_llm):
         llm=mock_llm(custom_response="ok"),
         model_middleware=[guard, plain_tracer],
     )
-    with rt.Session():
-        await rt.call(Agent2, user_input="hi")
+
+    @rt.function_node
+    async def entry2(user_input):
+        return await rt.call(Agent2, user_input=user_input)
+
+    await rt.Flow("interleave_guard_first", entry2).ainvoke("hi")
     assert trace == ["guard", "plain"]

--- a/packages/railtracks/tests/integration_tests/interaction/test_batch.py
+++ b/packages/railtracks/tests/integration_tests/interaction/test_batch.py
@@ -16,11 +16,10 @@ import railtracks as rt
     ],
 )
 async def test_parallel_calls(parallel_node, timeout_config, expected, buffer):
-    with rt.Session():
-        start_time = time.time()
-        results = await rt.call(parallel_node, timeout_config)
-        assert abs(time.time() - start_time - expected) < buffer
-        assert results == timeout_config
+    start_time = time.time()
+    results = await rt.Flow("test_parallel_calls", parallel_node).ainvoke(timeout_config)
+    assert abs(time.time() - start_time - expected) < buffer
+    assert results == timeout_config
 
 
 exc = ValueError("This is a test exception")
@@ -85,8 +84,9 @@ async def test_batch_error_handling_default_error_prop(num_times):
     """
     Test that batch execution handles errors correctly.
     """
-    with rt.Session():
-        await rt.call(ErrorThrowerTopLevel, num_times=num_times)
+    await rt.Flow(
+        "test_batch_error_handling_default_error_prop", ErrorThrowerTopLevel
+    ).ainvoke(num_times=num_times)
 
 
 @pytest.mark.parametrize(
@@ -97,8 +97,9 @@ async def test_batch_error_handling_true_error_prop(num_times):
     """
     Test that batch execution handles errors correctly.
     """
-    with rt.Session():
-        await rt.call(ErrorThrowerTopLevel, num_times=num_times, return_exceptions=True)
+    await rt.Flow(
+        "test_batch_error_handling_true_error_prop", ErrorThrowerTopLevel
+    ).ainvoke(num_times=num_times, return_exceptions=True)
 
 
 @pytest.mark.parametrize(
@@ -109,8 +110,7 @@ async def test_batch_error_handling_false_error_prop(num_times):
     """
     Test that batch execution handles errors correctly.
     """
-    with rt.Session():
-        with pytest.raises(type(exc)):
-            await rt.call(
-                ErrorThrowerTopLevel, num_times=num_times, return_exceptions=False
-            )
+    with pytest.raises(type(exc)):
+        await rt.Flow(
+            "test_batch_error_handling_false_error_prop", ErrorThrowerTopLevel
+        ).ainvoke(num_times=num_times, return_exceptions=False)

--- a/packages/railtracks/tests/integration_tests/interaction/test_batch.py
+++ b/packages/railtracks/tests/integration_tests/interaction/test_batch.py
@@ -17,7 +17,9 @@ import railtracks as rt
 )
 async def test_parallel_calls(parallel_node, timeout_config, expected, buffer):
     start_time = time.time()
-    results = await rt.Flow("test_parallel_calls", parallel_node).ainvoke(timeout_config)
+    results = await rt.Flow("test_parallel_calls", parallel_node).ainvoke(
+        timeout_config
+    )
     assert abs(time.time() - start_time - expected) < buffer
     assert results == timeout_config
 

--- a/packages/railtracks/tests/integration_tests/interaction/test_call.py
+++ b/packages/railtracks/tests/integration_tests/interaction/test_call.py
@@ -69,16 +69,17 @@ async def test_message_history_not_mutated_terminal_llm(terminal_nodes):
 
     MathGameNode = rt.function_node(make_math_game_node)  # noqa: N806
 
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("You can start the game")]
-        )
-        original_message_history = deepcopy(message_history)
-        _ = await rt.call(MathGameNode, message_history=message_history)
-        assert all(
-            orig.content == new.content
-            for orig, new in zip(original_message_history, message_history)
-        ), "Message history modified after runner run"
+    message_history = rt.llm.MessageHistory(
+        [rt.llm.UserMessage("You can start the game")]
+    )
+    original_message_history = deepcopy(message_history)
+    _ = await rt.Flow(
+        "test_message_history_not_mutated_terminal_llm", MathGameNode
+    ).ainvoke(message_history=message_history)
+    assert all(
+        orig.content == new.content
+        for orig, new in zip(original_message_history, message_history)
+    ), "Message history modified after runner run"
 
 
 @pytest.mark.asyncio
@@ -138,20 +139,21 @@ async def test_message_history_not_mutated_structured_llm(structured_nodes):
 
     MathProofNode = rt.function_node(math_proof_node)  # noqa: N806
 
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [
-                rt.llm.UserMessage(
-                    "Prove that the sum of all numbers until infinity is -1/12"
-                )
-            ]
-        )
-        original_message_history = deepcopy(message_history)
-        _ = await rt.call(MathProofNode, message_history=message_history)
-        assert all(
-            orig.content == new.content
-            for orig, new in zip(original_message_history, message_history)
-        ), "Message history modified after runner run"
+    message_history = rt.llm.MessageHistory(
+        [
+            rt.llm.UserMessage(
+                "Prove that the sum of all numbers until infinity is -1/12"
+            )
+        ]
+    )
+    original_message_history = deepcopy(message_history)
+    _ = await rt.Flow(
+        "test_message_history_not_mutated_structured_llm", MathProofNode
+    ).ainvoke(message_history=message_history)
+    assert all(
+        orig.content == new.content
+        for orig, new in zip(original_message_history, message_history)
+    ), "Message history modified after runner run"
 
 
 @pytest.mark.timeout(34)
@@ -194,20 +196,21 @@ async def test_message_history_not_mutated_tool_call_llm(tool_calling_nodes):
         return response
 
     TravelSummarizerNode = rt.function_node(travel_summarizer_node)  # noqa: N806
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [
-                rt.llm.UserMessage(
-                    "I want to plan a trip to from Delhi to New York for a week. Please provide me with a budget summary for the trip."
-                )
-            ]
-        )
-        original_message_history = deepcopy(message_history)
-        _ = await rt.call(TravelSummarizerNode, message_history=message_history)
-        assert all(
-            orig.content == new.content
-            for orig, new in zip(original_message_history, message_history)
-        ), "Message history modified after runner run"
+    message_history = rt.llm.MessageHistory(
+        [
+            rt.llm.UserMessage(
+                "I want to plan a trip to from Delhi to New York for a week. Please provide me with a budget summary for the trip."
+            )
+        ]
+    )
+    original_message_history = deepcopy(message_history)
+    _ = await rt.Flow(
+        "test_message_history_not_mutated_tool_call_llm", TravelSummarizerNode
+    ).ainvoke(message_history=message_history)
+    assert all(
+        orig.content == new.content
+        for orig, new in zip(original_message_history, message_history)
+    ), "Message history modified after runner run"
 
 
 async def test_no_context_call():
@@ -257,9 +260,9 @@ ManyCalls = rt.function_node(many_calls)
 
 @pytest.mark.asyncio
 async def many_calls_tester(num_calls: int, parallel_calls: int):
-    with rt.Session() as run:
-        finished_result = await rt.call(ManyCalls, num_calls, parallel_calls)
-        info = run.info
+    conn = rt.Flow("many_calls_tester", ManyCalls).connect()
+    finished_result = await conn.ainvoke(num_calls, parallel_calls)
+    info = conn.session.info
 
     ans = finished_result
 
@@ -300,8 +303,7 @@ async def test_large_no_deadlock():
 
 @pytest.mark.asyncio
 async def test_simple_rng():
-    with rt.Session():
-        result = await rt.call(RNGNode)
+    result = await rt.Flow("test_simple_rng", RNGNode).ainvoke()
 
     assert 0 < result < 1
 
@@ -347,10 +349,10 @@ class NestedManyCalls(Node):
 
 @pytest.mark.asyncio
 async def nested_many_calls_tester(num_calls: int, parallel_calls: int, depth: int):
-    with rt.Session() as run:
-        await rt.call(NestedManyCalls, num_calls, parallel_calls, depth)
+    conn = rt.Flow("nested_many_calls_tester", NestedManyCalls).connect()
+    await conn.ainvoke(num_calls, parallel_calls, depth)
 
-    ans = run.info
+    ans = conn.session.info
 
     assert isinstance(ans.answer, list)
     assert len(ans.answer) == (parallel_calls * num_calls) ** (depth + 1)
@@ -397,54 +399,55 @@ async def test_nested_no_deadlock_harder_2():
 
 @pytest.mark.asyncio
 async def test_multiple_runs():
-    with rt.Session() as run:
-        result = await rt.call(RNGNode)
-        assert 0 < result < 1
+    @rt.function_node
+    async def entry():
+        r1 = await rt.call(RNGNode)
+        assert 0 < r1 < 1
+        r2 = await rt.call(RNGNode)
+        return [r1, r2]
 
-        result = await rt.call(RNGNode)
+    conn = rt.Flow("test_multiple_runs", entry).connect()
+    result = await conn.ainvoke()
+    assert isinstance(result, List)
+    assert 0 < result[0] < 1
+    assert 0 < result[1] < 1
 
-        info = run.info
-        assert isinstance(info.answer, List)
-        assert 0 < info.answer[0] < 1
-        assert 0 < info.answer[1] < 1
+    info = conn.session.info
+    insertion_requests = info.request_forest.insertion_request
+    assert isinstance(insertion_requests, List)
+    assert len(insertion_requests) == 1
 
-        insertion_requests = info.request_forest.insertion_request
-
-        assert isinstance(insertion_requests, List)
-        assert len(insertion_requests) == 2
-        for i_r in insertion_requests:
-            i_r_id = i_r.identifier
-
-            subset_info = info._get_info(i_r_id)
-            assert 0 < subset_info.answer < 1
-            assert len(subset_info.node_forest.heap()) == 1
+    # entry generated two child rt.call requests; each returned a float in (0, 1)
+    entry_children = info.request_forest.children(insertion_requests[0].sink_id)
+    assert len(entry_children) == 2
+    for r in entry_children:
+        assert 0 < r.output < 1
 
 
 @pytest.mark.asyncio
 async def test_multiple_runs_async():
-    with rt.Session() as run:
-        result = await rt.call(RNGNode)
-        assert 0 < result < 1
+    @rt.function_node
+    async def entry():
+        r1 = await rt.call(RNGNode)
+        assert 0 < r1 < 1
+        r2 = await rt.call(RNGNode)
+        return [r1, r2]
 
-        result = await rt.call(RNGNode)
+    conn = rt.Flow("test_multiple_runs_async", entry).connect()
+    result = await conn.ainvoke()
+    assert isinstance(result, List)
+    assert 0 < result[0] < 1
+    assert 0 < result[1] < 1
 
-        result = run.info.answer
-        assert isinstance(result, List)
-        assert 0 < result[0] < 1
-        assert 0 < result[1] < 1
+    info = conn.session.info
+    insertion_requests = info.request_forest.insertion_request
+    assert isinstance(insertion_requests, List)
+    assert len(insertion_requests) == 1
 
-        info = run.info
-
-        insertion_requests = info.request_forest.insertion_request
-
-        assert isinstance(insertion_requests, List)
-        assert len(insertion_requests) == 2
-        for i_r in insertion_requests:
-            i_r_id = i_r.identifier
-
-            subset_info = info._get_info(i_r_id)
-            assert 0 < subset_info.answer < 1
-            assert len(subset_info.node_forest.heap()) == 1
+    entry_children = info.request_forest.children(insertion_requests[0].sink_id)
+    assert len(entry_children) == 2
+    for r in entry_children:
+        assert 0 < r.output < 1
 
 
 def level_3(message: str):
@@ -469,13 +472,15 @@ async def test_multi_level_calls(level_2_node):
 
     ALevel1 = rt.function_node(level_1_async)  # noqa: N806
 
-    with rt.Session():
-        result = await rt.call(ALevel1, "Hello from Level 1 (async)")
-        assert result == "Hello from Level 1 (async)"
+    result = await rt.Flow("test_multi_level_calls_1", ALevel1).ainvoke(
+        "Hello from Level 1 (async)"
+    )
+    assert result == "Hello from Level 1 (async)"
 
-    with rt.Session():
-        result = await rt.call(ALevel1, "Hello from Level 1 (async)")
-        assert result == "Hello from Level 1 (async)"
+    result = await rt.Flow("test_multi_level_calls_2", ALevel1).ainvoke(
+        "Hello from Level 1 (async)"
+    )
+    assert result == "Hello from Level 1 (async)"
 
 
 async def timeout_node(timeout_len: float):
@@ -491,9 +496,8 @@ TimeoutNode = rt.function_node(timeout_node)
 
 @pytest.mark.asyncio
 async def test_timeout():
-    with rt.Session(timeout=0.1):
-        with pytest.raises(GlobalTimeOutError):
-            await rt.call(TimeoutNode, 0.3)
+    with pytest.raises(GlobalTimeOutError):
+        await rt.Flow("test_timeout", TimeoutNode, timeout=0.1).ainvoke(0.3)
 
 
 async def timeout_thrower():
@@ -505,11 +509,10 @@ TimeoutThrower = rt.function_node(timeout_thrower)
 
 @pytest.mark.asyncio
 async def test_timeout_thrower():
-    with rt.Session():
-        try:
-            await rt.call(TimeoutThrower)
-        except Exception as e:
-            assert isinstance(e, asyncio.TimeoutError)
+    try:
+        await rt.Flow("test_timeout_thrower", TimeoutThrower).ainvoke()
+    except Exception as e:
+        assert isinstance(e, asyncio.TimeoutError)
 
 
 # ============================================ END Many calls and Timeout tests ============================================

--- a/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
@@ -59,10 +59,15 @@ async def test_structured_llm_run_with_different_inputs(
         output_schema=simple_output_model,
     )
 
-    with rt.Session():
-        user_input = user_input_factory()
-        response = await rt.call(simple_agent, user_input=user_input)
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(simple_agent, user_input=user_input)
 
-        assert isinstance(response.content, simple_output_model)
-        assert isinstance(response.content.text, str)
-        assert isinstance(response.content.number, int)
+    user_input = user_input_factory()
+    response = await rt.Flow(
+        "test_structured_llm_run_with_different_inputs", entry
+    ).ainvoke(user_input)
+
+    assert isinstance(response.content, simple_output_model)
+    assert isinstance(response.content.text, str)
+    assert isinstance(response.content.number, int)

--- a/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_basic_llms.py
@@ -59,13 +59,9 @@ async def test_structured_llm_run_with_different_inputs(
         output_schema=simple_output_model,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(simple_agent, user_input=user_input)
-
     user_input = user_input_factory()
     response = await rt.Flow(
-        "test_structured_llm_run_with_different_inputs", entry
+        "test_structured_llm_run_with_different_inputs", simple_agent
     ).ainvoke(user_input)
 
     assert isinstance(response.content, simple_output_model)

--- a/packages/railtracks/tests/integration_tests/library/test_function.py
+++ b/packages/railtracks/tests/integration_tests/library/test_function.py
@@ -388,11 +388,7 @@ class TestSequenceInputTypes:
             llm,
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(agent, user_input)
-
-        response = await rt.Flow("test_lists", entry).ainvoke(
+        response = await rt.Flow("test_lists", agent).ainvoke(
             "What is the magic result for [1, 2] and [5.5, 10]? Only return the result, no other text.",
         )
 
@@ -418,11 +414,7 @@ class TestDictionaryInputTypes:
         with pytest.raises(Exception):
             agent = _agent_node_factory(dict_func, mock_llm())
 
-            @rt.function_node
-            async def entry(user_input):
-                return await rt.call(agent, user_input)
-
-            await rt.Flow("test_dict_input_raises_error", entry).ainvoke(
+            await rt.Flow("test_dict_input_raises_error", agent).ainvoke(
                 rt.llm.MessageHistory(
                     [rt.llm.UserMessage("What is the result for {'key': 'value'}?")]
                 ),

--- a/packages/railtracks/tests/integration_tests/library/test_function.py
+++ b/packages/railtracks/tests/integration_tests/library/test_function.py
@@ -42,13 +42,16 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "What is the secret phrase? Only return the secret phrase, no other text.",
-            )
-            assert "Constantinople" in response.content
-            assert rt.context.get("secret_phrase_called")
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("secret_phrase_called")
+
+        response, secret_called = await rt.Flow("test_empty_function", entry).ainvoke(
+            "What is the secret phrase? Only return the secret phrase, no other text."
+        )
+        assert "Constantinople" in response.content
+        assert secret_called
 
     async def test_single_int_input(self, _agent_node_factory, mock_llm):
         """Test that a function with a single int parameter works correctly."""
@@ -81,13 +84,16 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "Find what the magic function output is for 6? Only return the magic number, no other text.",
-            )
-            assert rt.context.get("magic_number_called")
-            assert "666666" in response.content
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_number_called")
+
+        response, called = await rt.Flow("test_single_int_input", entry).ainvoke(
+            "Find what the magic function output is for 6? Only return the magic number, no other text.",
+        )
+        assert called
+        assert "666666" in response.content
 
     async def test_single_str_input(self, _agent_node_factory, mock_llm):
         """Test that a function with a single str parameter works correctly."""
@@ -120,13 +126,16 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "What is the magic phrase for the word 'hello'? Only return the magic phrase, no other text.",
-            )
-            assert rt.context.get("magic_phrase_called")
-            assert "h$e$l$l$o" in response.content
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_phrase_called")
+
+        response, called = await rt.Flow("test_single_str_input", entry).ainvoke(
+            "What is the magic phrase for the word 'hello'? Only return the magic phrase, no other text.",
+        )
+        assert called
+        assert "h$e$l$l$o" in response.content
 
     async def test_single_float_input(self, _agent_node_factory, mock_llm):
         """Test that a function with a single float parameter works correctly."""
@@ -159,14 +168,17 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "Does 5 pass the magic test? Only return the result, no other text.",
-            )
-            assert rt.context.get("magic_test_called")
-            resp: str = response.content
-            assert "True" in resp
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_test_called")
+
+        response, called = await rt.Flow("test_single_float_input", entry).ainvoke(
+            "Does 5 pass the magic test? Only return the result, no other text.",
+        )
+        assert called
+        resp: str = response.content
+        assert "True" in resp
 
     async def test_single_bool_input(self, _agent_node_factory, mock_llm):
         """Test that a function with a single bool parameter works correctly."""
@@ -199,12 +211,16 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent, "Is the magic test true? Only return the result, no other text."
-            )
-            assert rt.context.get("magic_test_called")
-            assert "Wish Granted" in response.content
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_test_called")
+
+        response, called = await rt.Flow("test_single_bool_input", entry).ainvoke(
+            "Is the magic test true? Only return the result, no other text."
+        )
+        assert called
+        assert "Wish Granted" in response.content
 
     # TODO: think carefully about how we can test the graceful error handling. This test is temporary.
     async def test_function_error_handling(self, _agent_node_factory, mock_llm):
@@ -238,14 +254,17 @@ class TestPrimitiveInputTypes:
             llm,
         )
 
-        with rt.Session():
-            output = await rt.call(
-                agent,
-                "What does the tool return for an input of 0? Only return the result, no other text.",
-            )
+        @rt.function_node
+        async def entry(user_input):
+            output = await rt.call(agent, user_input)
+            return output, rt.context.get("magic_test_called")
 
-            assert "There was an error" in output.content  # graceful error handling
-            assert rt.context.get("magic_test_called")
+        output, called = await rt.Flow("test_function_error_handling", entry).ainvoke(
+            "What does the tool return for an input of 0? Only return the result, no other text.",
+        )
+
+        assert "There was an error" in output.content  # graceful error handling
+        assert called
 
 
 class TestSequenceInputTypes:
@@ -282,13 +301,16 @@ class TestSequenceInputTypes:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "What is the magic list for ['1', '2', '3']? Only return the result, no other text.",
-            )
-            assert "3 2 1" in response.content
-            assert rt.context.get("magic_list_called")
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_list_called")
+
+        response, called = await rt.Flow("test_single_list_input", entry).ainvoke(
+            "What is the magic list for ['1', '2', '3']? Only return the result, no other text.",
+        )
+        assert "3 2 1" in response.content
+        assert called
 
     async def test_single_tuple_input(self, _agent_node_factory, mock_llm):
         """Test that a function with a single tuple parameter works correctly."""
@@ -320,14 +342,18 @@ class TestSequenceInputTypes:
             magic_tuple,
             llm,
         )
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "What is the magic tuple for ('1', '2', '3')? Only return the result, no other text.",
-            )
 
-            assert "3 2 1" in response.content
-            assert rt.context.get("magic_tuple_called")
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_tuple_called")
+
+        response, called = await rt.Flow("test_single_tuple_input", entry).ainvoke(
+            "What is the magic tuple for ('1', '2', '3')? Only return the result, no other text.",
+        )
+
+        assert "3 2 1" in response.content
+        assert called
 
     async def test_lists(self, _agent_node_factory, mock_llm):
         """Test that a function with a list parameter works correctly."""
@@ -361,11 +387,14 @@ class TestSequenceInputTypes:
             magic_result,
             llm,
         )
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "What is the magic result for [1, 2] and [5.5, 10]? Only return the result, no other text.",
-            )
+
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(agent, user_input)
+
+        response = await rt.Flow("test_lists", entry).ainvoke(
+            "What is the magic result for [1, 2] and [5.5, 10]? Only return the result, no other text.",
+        )
 
         assert "25.5" in response.content
 
@@ -388,13 +417,16 @@ class TestDictionaryInputTypes:
 
         with pytest.raises(Exception):
             agent = _agent_node_factory(dict_func, mock_llm())
-            with rt.Session():
-                await rt.call(
-                    agent,
-                    rt.llm.MessageHistory(
-                        [rt.llm.UserMessage("What is the result for {'key': 'value'}?")]
-                    ),
-                )
+
+            @rt.function_node
+            async def entry(user_input):
+                return await rt.call(agent, user_input)
+
+            await rt.Flow("test_dict_input_raises_error", entry).ainvoke(
+                rt.llm.MessageHistory(
+                    [rt.llm.UserMessage("What is the result for {'key': 'value'}?")]
+                ),
+            )
 
 
 class TestUnionAndOptionalParameter:
@@ -441,13 +473,16 @@ class TestUnionAndOptionalParameter:
             llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "Calculate the magic number for 5. Then calculate the magic number for 'fox'.",
-            )
-            assert rt.context.get("magic_number_called")
-            assert len(re.findall(r"21", response.content)) == 2  # 21 appears twice
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_number_called")
+
+        response, called = await rt.Flow("test_union_parameter", entry).ainvoke(
+            "Calculate the magic number for 5. Then calculate the magic number for 'fox'.",
+        )
+        assert called
+        assert len(re.findall(r"21", response.content)) == 2  # 21 appears twice
 
     @pytest.mark.parametrize(
         "default_value, expected",
@@ -487,20 +522,21 @@ class TestUnionAndOptionalParameter:
 
         agent = _agent_node_factory(magic_number, llm)
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                "Calculate the magic number for 21. Then calculate the magic number with no args.",
-            )
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input)
+            return response, rt.context.get("magic_number_called")
 
-            # verify each expected number appears in the response
-            for val in expected:
-                assert str(val) in response.content
+        response, called = await rt.Flow("test_optional_parameter", entry).ainvoke(
+            "Calculate the magic number for 21. Then calculate the magic number with no args.",
+        )
 
-            # also check counts if you want stricter validation
-            for val in set(expected):
-                assert len(re.findall(str(val), response.content)) == expected.count(
-                    val
-                )
+        # verify each expected number appears in the response
+        for val in expected:
+            assert str(val) in response.content
 
-            assert rt.context.get("magic_number_called")
+        # also check counts if you want stricter validation
+        for val in set(expected):
+            assert len(re.findall(str(val), response.content)) == expected.count(val)
+
+        assert called

--- a/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
@@ -41,14 +41,17 @@ class TestSimpleToolCalling:
             llm=llm,
         )
 
-        with rt.Session():
-            response = await rt.call(
-                agent,
-                user_input="What is the secret phrase? Only return the secret phrase, no other text.",
-            )
-            assert response is not None
-            assert "Constantinople" in response.text
-            assert rt.context.get("secret_phrase_called")
+        @rt.function_node
+        async def entry(user_input):
+            response = await rt.call(agent, user_input=user_input)
+            return response, rt.context.get("secret_phrase_called")
+
+        response, secret_called = await rt.Flow("test_simple_tool", entry).ainvoke(
+            "What is the secret phrase? Only return the secret phrase, no other text."
+        )
+        assert response is not None
+        assert "Constantinople" in response.text
+        assert secret_called
 
     @pytest.mark.asyncio
     async def test_text_returned_with_tool_call_is_kept(self, mock_llm):
@@ -90,8 +93,13 @@ class TestSimpleToolCalling:
             llm=llm,
         )
 
-        with rt.Session():
-            response = await rt.call(agent, user_input="What is the secret phrase?")
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(agent, user_input=user_input)
+
+        response = await rt.Flow(
+            "test_text_returned_with_tool_call_is_kept", entry
+        ).ainvoke("What is the secret phrase?")
 
         tool_call_messages = [
             m for m in response.message_history if isinstance(m.content, ToolCalls)
@@ -135,13 +143,22 @@ class TestLimitedToolCalling:
         )
 
         message = "Get the magic number and divide it by 2."
-        with rt.Session():
+
+        @rt.function_node
+        async def entry(user_input):
             _reset_tools_called()
-            _ = await rt.call(agent, user_input=message)
-            assert rt.context.get("tools_called") == 1
+            _ = await rt.call(agent, user_input=user_input)
+            count1 = rt.context.get("tools_called")
             _reset_tools_called()
-            _ = await rt.call(agent, user_input=message)
-            assert rt.context.get("tools_called") == 1
+            _ = await rt.call(agent, user_input=user_input)
+            count2 = rt.context.get("tools_called")
+            return count1, count2
+
+        count1, count2 = await rt.Flow(
+            "test_context_reset_between_runs", entry
+        ).ainvoke(message)
+        assert count1 == 1
+        assert count2 == 1
 
 
 class TestFunctionNodeCallWithFunctionList:
@@ -180,14 +197,18 @@ class TestFunctionNodeCallWithFunctionList:
             ),
         )
 
-        with rt.Session(name="AgentHandlerNode"):
-            result = await rt.call(
-                AgentHandler,
-                rt.llm.MessageHistory(
-                    [
-                        rt.llm.UserMessage("Give me a number and add 50 to it please"),
-                    ]
-                ),
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(AgentHandler, user_input)
+
+        result = await rt.Flow(
+            "test_function_node_call_with_function_list_parameter", entry
+        ).ainvoke(
+            rt.llm.MessageHistory(
+                [
+                    rt.llm.UserMessage("Give me a number and add 50 to it please"),
+                ]
             )
+        )
 
         assert "92" in result.content

--- a/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_calling_llms.py
@@ -93,12 +93,8 @@ class TestSimpleToolCalling:
             llm=llm,
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(agent, user_input=user_input)
-
         response = await rt.Flow(
-            "test_text_returned_with_tool_call_is_kept", entry
+            "test_text_returned_with_tool_call_is_kept", agent
         ).ainvoke("What is the secret phrase?")
 
         tool_call_messages = [
@@ -197,12 +193,8 @@ class TestFunctionNodeCallWithFunctionList:
             ),
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(AgentHandler, user_input)
-
         result = await rt.Flow(
-            "test_function_node_call_with_function_list_parameter", entry
+            "test_function_node_call_with_function_list_parameter", AgentHandler
         ).ainvoke(
             rt.llm.MessageHistory(
                 [

--- a/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
@@ -158,9 +158,9 @@ async def test_agent_as_tool_result_is_not_wrapped(mock_llm, encoder_system_mess
         system_message="You are a helpful assistant that uses the encoder tool.",
     )
 
-    response = await rt.Flow("test_agent_as_tool_result_is_not_wrapped", caller).ainvoke(
-        "Encode 'hello world'"
-    )
+    response = await rt.Flow(
+        "test_agent_as_tool_result_is_not_wrapped", caller
+    ).ainvoke("Encode 'hello world'")
     tool_results = [
         message.content.result
         for message in response.message_history

--- a/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
@@ -170,9 +170,9 @@ async def test_agent_as_tool_result_is_not_wrapped(mock_llm, encoder_system_mess
     async def entry(user_input):
         return await rt.call(caller, user_input=user_input)
 
-    response = await rt.Flow(
-        "test_agent_as_tool_result_is_not_wrapped", entry
-    ).ainvoke("Encode 'hello world'")
+    response = await rt.Flow("test_agent_as_tool_result_is_not_wrapped", entry).ainvoke(
+        "Encode 'hello world'"
+    )
     tool_results = [
         message.content.result
         for message in response.message_history

--- a/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
@@ -81,13 +81,18 @@ async def test_terminal_llm_as_tool_correct_initialization(
         system_message=system_randomizer,
     )
 
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("The input string is 'hello world'")]
-        )
-        response = await rt.call(randomizer, user_input=message_history)
-        assert "encoder check" in response.content
-        assert "decoder check" in response.content
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(randomizer, user_input=user_input)
+
+    message_history = rt.llm.MessageHistory(
+        [rt.llm.UserMessage("The input string is 'hello world'")]
+    )
+    response = await rt.Flow(
+        "test_terminal_llm_as_tool_correct_initialization", entry
+    ).ainvoke(message_history)
+    assert "encoder check" in response.content
+    assert "decoder check" in response.content
 
 
 @pytest.mark.asyncio
@@ -123,13 +128,18 @@ async def test_terminal_llm_as_tool_correct_initialization_no_params(mock_llm):
         llm=math_llm,
     )
 
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("Start the Math node.")]
-        )
-        response = await rt.call(math_node, user_input=message_history)
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(math_node, user_input=user_input)
 
-        assert "[42, 42, 42, 42, 42]" in response.content
+    message_history = rt.llm.MessageHistory(
+        [rt.llm.UserMessage("Start the Math node.")]
+    )
+    response = await rt.Flow(
+        "test_terminal_llm_as_tool_correct_initialization_no_params", entry
+    ).ainvoke(message_history)
+
+    assert "[42, 42, 42, 42, 42]" in response.content
 
 
 @pytest.mark.timeout(30)
@@ -156,14 +166,19 @@ async def test_agent_as_tool_result_is_not_wrapped(mock_llm, encoder_system_mess
         system_message="You are a helpful assistant that uses the encoder tool.",
     )
 
-    with rt.Session():
-        response = await rt.call(caller, user_input="Encode 'hello world'")
-        tool_results = [
-            message.content.result
-            for message in response.message_history
-            if message.role == "tool"
-        ]
-        assert tool_results == ["encoder check"]
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(caller, user_input=user_input)
+
+    response = await rt.Flow(
+        "test_agent_as_tool_result_is_not_wrapped", entry
+    ).ainvoke("Encode 'hello world'")
+    tool_results = [
+        message.content.result
+        for message in response.message_history
+        if message.role == "tool"
+    ]
+    assert tool_results == ["encoder check"]
 
 
 @pytest.mark.timeout(30)
@@ -203,17 +218,22 @@ async def test_terminal_llm_tool_with_invalid_parameters(
         system_message=system_message,
     )
 
-    with rt.Session():
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("Encode this text but use an invalid parameter name.")]
-        )
-        response = await rt.call(tool_call_llm, user_input=message_history)
-        # Check that there was an error running the tool
-        assert any(
-            message.role == "assistant"
-            and "There was an error during tool execution" in message.content
-            for message in response.message_history
-        )
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(tool_call_llm, user_input=user_input)
+
+    message_history = rt.llm.MessageHistory(
+        [rt.llm.UserMessage("Encode this text but use an invalid parameter name.")]
+    )
+    response = await rt.Flow(
+        "test_terminal_llm_tool_with_invalid_parameters", entry
+    ).ainvoke(message_history)
+    # Check that there was an error running the tool
+    assert any(
+        message.role == "assistant"
+        and "There was an error during tool execution" in message.content
+        for message in response.message_history
+    )
 
 
 def test_no_manifest(mock_llm):

--- a/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
+++ b/packages/railtracks/tests/integration_tests/library/test_tool_manifestation.py
@@ -81,15 +81,11 @@ async def test_terminal_llm_as_tool_correct_initialization(
         system_message=system_randomizer,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(randomizer, user_input=user_input)
-
     message_history = rt.llm.MessageHistory(
         [rt.llm.UserMessage("The input string is 'hello world'")]
     )
     response = await rt.Flow(
-        "test_terminal_llm_as_tool_correct_initialization", entry
+        "test_terminal_llm_as_tool_correct_initialization", randomizer
     ).ainvoke(message_history)
     assert "encoder check" in response.content
     assert "decoder check" in response.content
@@ -128,15 +124,11 @@ async def test_terminal_llm_as_tool_correct_initialization_no_params(mock_llm):
         llm=math_llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(math_node, user_input=user_input)
-
     message_history = rt.llm.MessageHistory(
         [rt.llm.UserMessage("Start the Math node.")]
     )
     response = await rt.Flow(
-        "test_terminal_llm_as_tool_correct_initialization_no_params", entry
+        "test_terminal_llm_as_tool_correct_initialization_no_params", math_node
     ).ainvoke(message_history)
 
     assert "[42, 42, 42, 42, 42]" in response.content
@@ -166,11 +158,7 @@ async def test_agent_as_tool_result_is_not_wrapped(mock_llm, encoder_system_mess
         system_message="You are a helpful assistant that uses the encoder tool.",
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(caller, user_input=user_input)
-
-    response = await rt.Flow("test_agent_as_tool_result_is_not_wrapped", entry).ainvoke(
+    response = await rt.Flow("test_agent_as_tool_result_is_not_wrapped", caller).ainvoke(
         "Encode 'hello world'"
     )
     tool_results = [
@@ -218,15 +206,11 @@ async def test_terminal_llm_tool_with_invalid_parameters(
         system_message=system_message,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(tool_call_llm, user_input=user_input)
-
     message_history = rt.llm.MessageHistory(
         [rt.llm.UserMessage("Encode this text but use an invalid parameter name.")]
     )
     response = await rt.Flow(
-        "test_terminal_llm_tool_with_invalid_parameters", entry
+        "test_terminal_llm_tool_with_invalid_parameters", tool_call_llm
     ).ainvoke(message_history)
     # Check that there was an error running the tool
     assert any(

--- a/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
+++ b/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
@@ -62,12 +62,8 @@ class TestWebSearchToolCalling:
             llm=llm,
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(agent, user_input=user_input)
-
         response = await rt.Flow(
-            "test_search_tool_round_trips_through_agent", entry
+            "test_search_tool_round_trips_through_agent", agent
         ).ainvoke("What is railtracks?")
         assert "An agentic framework" in response.text
         assert _contains_url(response.text, "https://railtracks.org")
@@ -100,11 +96,7 @@ class TestWebSearchToolCalling:
             llm=llm,
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(agent, user_input=user_input)
-
         response = await rt.Flow(
-            "test_fetch_tool_round_trips_through_agent", entry
+            "test_fetch_tool_round_trips_through_agent", agent
         ).ainvoke("Read https://railtracks.org")
         assert "Full page content here" in response.text

--- a/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
+++ b/packages/railtracks/tests/integration_tests/library/test_websearch_agent.py
@@ -62,10 +62,15 @@ class TestWebSearchToolCalling:
             llm=llm,
         )
 
-        with rt.Session():
-            response = await rt.call(agent, user_input="What is railtracks?")
-            assert "An agentic framework" in response.text
-            assert _contains_url(response.text, "https://railtracks.org")
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(agent, user_input=user_input)
+
+        response = await rt.Flow(
+            "test_search_tool_round_trips_through_agent", entry
+        ).ainvoke("What is railtracks?")
+        assert "An agentic framework" in response.text
+        assert _contains_url(response.text, "https://railtracks.org")
 
     @pytest.mark.asyncio
     async def test_fetch_tool_round_trips_through_agent(self, mock_llm):
@@ -95,6 +100,11 @@ class TestWebSearchToolCalling:
             llm=llm,
         )
 
-        with rt.Session():
-            response = await rt.call(agent, user_input="Read https://railtracks.org")
-            assert "Full page content here" in response.text
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(agent, user_input=user_input)
+
+        response = await rt.Flow(
+            "test_fetch_tool_round_trips_through_agent", entry
+        ).ainvoke("Read https://railtracks.org")
+        assert "Full page content here" in response.text

--- a/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
@@ -1090,11 +1090,16 @@ class TestConcurrencyAndRetryInterplay:
             await asyncio.sleep(0.01 if tag == 0 else 0)
             return tag
 
-        with rt.Session():
-            results = await asyncio.gather(
+        @rt.function_node
+        async def entry():
+            return await asyncio.gather(
                 rt.call(slow_identity, 0),
                 rt.call(slow_identity, 1),
             )
+
+        results = await rt.Flow(
+            "test_concurrent_invocations_do_not_leak_state", entry
+        ).ainvoke()
 
         assert sorted(results) == [0, 1]
         assert order.count("start-0") == 1
@@ -1154,7 +1159,12 @@ class TestSessionPersistence:
             "PersistAgent", llm=mock_llm(custom_response="ok"), middleware=[tracer]
         )
 
-        with rt.Session() as session:
-            await rt.call(agent, user_input="hi")
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(agent, user_input=user_input)
 
-        validate(session.payload(), json_state_schema)
+        flow = rt.Flow("PersistAgent", entry)
+        conn = flow.connect()
+        await conn.ainvoke("hi")
+
+        validate(conn.session.payload(), json_state_schema)

--- a/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_middleware_integration.py
@@ -1159,11 +1159,7 @@ class TestSessionPersistence:
             "PersistAgent", llm=mock_llm(custom_response="ok"), middleware=[tracer]
         )
 
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(agent, user_input=user_input)
-
-        flow = rt.Flow("PersistAgent", entry)
+        flow = rt.Flow("PersistAgent", agent)
         conn = flow.connect()
         await conn.ainvoke("hi")
 

--- a/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
@@ -94,6 +94,6 @@ async def test_retry_exhaustion_surfaces_after_max_tries(mock_llm):
         return await rt.call(agent, user_input=user_input)
 
     with pytest.raises(Exception):
-        await rt.Flow(
-            "test_retry_exhaustion_surfaces_after_max_tries", entry
-        ).ainvoke("hi")
+        await rt.Flow("test_retry_exhaustion_surfaces_after_max_tries", entry).ainvoke(
+            "hi"
+        )

--- a/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
@@ -37,12 +37,8 @@ async def test_retry_in_model_middleware_recovers_from_transient_llm_error(mock_
         model_middleware=[_fast_retry()],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
     out = await rt.Flow(
-        "test_retry_in_model_middleware_recovers_from_transient_llm_error", entry
+        "test_retry_in_model_middleware_recovers_from_transient_llm_error", agent
     ).ainvoke("hi")
 
     assert isinstance(out, StringResponse)
@@ -64,12 +60,8 @@ async def test_retry_in_node_middleware_retries_a_flaky_function():
         middleware=[_fast_retry(retry_on=(Exception,))],
     )
 
-    @rt.function_node
-    async def entry():
-        return await rt.call(node)
-
     out = await rt.Flow(
-        "test_retry_in_node_middleware_retries_a_flaky_function", entry
+        "test_retry_in_node_middleware_retries_a_flaky_function", node
     ).ainvoke()
 
     assert out == "done"
@@ -89,11 +81,7 @@ async def test_retry_exhaustion_surfaces_after_max_tries(mock_llm):
         model_middleware=[_fast_retry(max_tries=2)],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
     with pytest.raises(Exception):
-        await rt.Flow("test_retry_exhaustion_surfaces_after_max_tries", entry).ainvoke(
+        await rt.Flow("test_retry_exhaustion_surfaces_after_max_tries", agent).ainvoke(
             "hi"
         )

--- a/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
+++ b/packages/railtracks/tests/integration_tests/middlewares/test_prebuilt_addons.py
@@ -37,8 +37,13 @@ async def test_retry_in_model_middleware_recovers_from_transient_llm_error(mock_
         model_middleware=[_fast_retry()],
     )
 
-    with rt.Session():
-        out = await rt.call(agent, user_input="hi")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    out = await rt.Flow(
+        "test_retry_in_model_middleware_recovers_from_transient_llm_error", entry
+    ).ainvoke("hi")
 
     assert isinstance(out, StringResponse)
     assert "recovered" in out.text
@@ -59,8 +64,13 @@ async def test_retry_in_node_middleware_retries_a_flaky_function():
         middleware=[_fast_retry(retry_on=(Exception,))],
     )
 
-    with rt.Session():
-        out = await rt.call(node)
+    @rt.function_node
+    async def entry():
+        return await rt.call(node)
+
+    out = await rt.Flow(
+        "test_retry_in_node_middleware_retries_a_flaky_function", entry
+    ).ainvoke()
 
     assert out == "done"
     assert calls["n"] == 3
@@ -79,6 +89,11 @@ async def test_retry_exhaustion_surfaces_after_max_tries(mock_llm):
         model_middleware=[_fast_retry(max_tries=2)],
     )
 
-    with rt.Session():
-        with pytest.raises(Exception):
-            await rt.call(agent, user_input="hi")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
+
+    with pytest.raises(Exception):
+        await rt.Flow(
+            "test_retry_exhaustion_surfaces_after_max_tries", entry
+        ).ainvoke("hi")

--- a/packages/railtracks/tests/integration_tests/rt_mcp/test_node_to_mcp.py
+++ b/packages/railtracks/tests/integration_tests/rt_mcp/test_node_to_mcp.py
@@ -78,8 +78,9 @@ async def test_add_nums_tool(mcp_server):
     server = connect_mcp(MCPHttpParams(url=f"http://127.0.0.1:{FAST_MCP_PORT}/mcp"))
     assert len(server.tools) == 1
 
-    with rt.Session(timeout=1000):
-        response = await rt.call(server.tools[0], num1=1, num2=3, print_s="Hello")
+    response = await rt.Flow(
+        "test_add_nums_tool", server.tools[0], timeout=1000
+    ).ainvoke(num1=1, num2=3, print_s="Hello")
 
     print(response.content)
     assert response.content[0].text == "14", (

--- a/packages/railtracks/tests/integration_tests/run/test_astream.py
+++ b/packages/railtracks/tests/integration_tests/run/test_astream.py
@@ -333,6 +333,4 @@ async def test_astream_timeout_raises_global_timeout_error(mock_llm):
             with pytest.raises(GlobalTimeOutError):
                 _ = stream.result
 
-    await rt.Flow(
-        "test_astream_timeout_raises_global_timeout_error", entry
-    ).ainvoke()
+    await rt.Flow("test_astream_timeout_raises_global_timeout_error", entry).ainvoke()

--- a/packages/railtracks/tests/integration_tests/run/test_astream.py
+++ b/packages/railtracks/tests/integration_tests/run/test_astream.py
@@ -86,15 +86,25 @@ async def test_astream_two_concurrent_streams_are_isolated(mock_llm):
     async def drain(stream):
         return [chunk async for chunk in stream]
 
-    with rt.Session():
+    captured = {}
+
+    @rt.function_node
+    async def entry():
         a = rt.astream(agent_a, user_input="go")
         b = rt.astream(agent_b, user_input="go")
         a_chunks, b_chunks = await asyncio.gather(drain(a), drain(b))
+        captured["a"] = a
+        captured["b"] = b
+        return a_chunks, b_chunks
+
+    a_chunks, b_chunks = await rt.Flow(
+        "test_astream_two_concurrent_streams_are_isolated", entry
+    ).ainvoke()
 
     assert a_chunks == ["A", "A", "A", "A"]
     assert b_chunks == ["B", "B", "B", "B"]
-    assert a.result.text == "AAAA"
-    assert b.result.text == "BBBB"
+    assert captured["a"].result.text == "AAAA"
+    assert captured["b"].result.text == "BBBB"
 
 
 @pytest.mark.asyncio
@@ -224,8 +234,12 @@ async def test_astream_mid_stream_node_failure_propagates_and_cleans_up(mock_llm
 
     agent = rt.agent_node(name="Failer", system_message="stream", llm=_FailingLLM())
 
-    with rt.Session():
+    captured = {}
+
+    @rt.function_node
+    async def entry():
         stream = rt.astream(agent, user_input="go")
+        captured["stream"] = stream
         seen = []
         # the model's raw error is wrapped as LLMError by the tool-calling loop
         # (llm_helpers.llm_invoke), same as a non-streamed rt.call would see.
@@ -236,9 +250,13 @@ async def test_astream_mid_stream_node_failure_propagates_and_cleans_up(mock_llm
         assert seen == ["a", "b"]
         assert stream._sub_id is None
 
+    await rt.Flow(
+        "test_astream_mid_stream_node_failure_propagates_and_cleans_up", entry
+    ).ainvoke()
+
     # .result re-raises the same error rather than hanging or resetting state
     with pytest.raises(LLMError, match="boom mid-stream"):
-        _ = stream.result
+        _ = captured["stream"].result
 
 
 @pytest.mark.asyncio
@@ -246,10 +264,15 @@ async def test_astream_result_before_finished_raises_runtime_error(mock_llm):
     """Accessing `.result` before the stream has been consumed raises RuntimeError."""
     agent = _agent(mock_llm, "abc")
 
-    with rt.Session():
+    @rt.function_node
+    async def entry():
         stream = rt.astream(agent, user_input="go")
         with pytest.raises(RuntimeError, match="has not finished"):
             _ = stream.result
+
+    await rt.Flow(
+        "test_astream_result_before_finished_raises_runtime_error", entry
+    ).ainvoke()
 
 
 @pytest.mark.asyncio
@@ -298,12 +321,18 @@ async def test_astream_timeout_raises_global_timeout_error(mock_llm):
 
     agent = rt.agent_node(name="Slow", system_message="stream", llm=_SlowLLM())
 
-    with rt.Session(timeout=0.05):
-        stream = rt.astream(agent, user_input="go")
-        with pytest.raises(GlobalTimeOutError):
-            async for _ in stream:
-                pass
+    @rt.function_node
+    async def entry():
+        with rt.Session(timeout=0.05):
+            stream = rt.astream(agent, user_input="go")
+            with pytest.raises(GlobalTimeOutError):
+                async for _ in stream:
+                    pass
 
-        # re-accessing .result re-raises the same timeout rather than hanging
-        with pytest.raises(GlobalTimeOutError):
-            _ = stream.result
+            # re-accessing .result re-raises the same timeout rather than hanging
+            with pytest.raises(GlobalTimeOutError):
+                _ = stream.result
+
+    await rt.Flow(
+        "test_astream_timeout_raises_global_timeout_error", entry
+    ).ainvoke()

--- a/packages/railtracks/tests/integration_tests/run/test_broadcast.py
+++ b/packages/railtracks/tests/integration_tests/run/test_broadcast.py
@@ -25,10 +25,9 @@ async def test_simple_streamer():
             self.finished_message = item
 
     sub = SubObject()
-    with rt.Session(
-        broadcast_callback=sub.handle,
-    ):
-        finished_result = await rt.call(StreamingRNGNode)
+    finished_result = await rt.Flow(
+        "test_simple_streamer", StreamingRNGNode, broadcast_callback=sub.handle
+    ).ainvoke()
 
     # force close streams flag must be set to false to allow the slow streaming to finish.
 
@@ -50,8 +49,9 @@ async def test_slow_streamer():
             self.finished_message = item
 
     sub = Sub()
-    with rt.Session(broadcast_callback=sub.handle):
-        finished_result = await rt.call(StreamingRNGNode)
+    finished_result = await rt.Flow(
+        "test_slow_streamer", StreamingRNGNode, broadcast_callback=sub.handle
+    ).ainvoke()
 
     assert isinstance(finished_result, float)
     assert sub.finished_message is not None
@@ -89,10 +89,9 @@ async def rng_stream_tester(
                 self.total_streams.append(item)
 
     sub = Sub()
-    with rt.Session(broadcast_callback=sub.handle):
-        finished_result = await rt.call(
-            RNGTreeStreamer, num_calls, parallel_call_nums, multiplier
-        )
+    finished_result = await rt.Flow(
+        "rng_stream_tester", RNGTreeStreamer, broadcast_callback=sub.handle
+    ).ainvoke(num_calls, parallel_call_nums, multiplier)
 
     assert isinstance(finished_result, list)
     assert len(finished_result) == num_calls * parallel_call_nums

--- a/packages/railtracks/tests/integration_tests/run/test_error_handler.py
+++ b/packages/railtracks/tests/integration_tests/run/test_error_handler.py
@@ -73,9 +73,7 @@ ErrorHandlerWithRetry = rt.function_node(error_handler_with_retry)
 @pytest.mark.timeout(5)
 async def test_error_handler_with_retry():
     for num_retries in range(5, 15):
-        conn = rt.Flow(
-            "test_error_handler_with_retry", ErrorHandlerWithRetry
-        ).connect()
+        conn = rt.Flow("test_error_handler_with_retry", ErrorHandlerWithRetry).connect()
         await conn.ainvoke(num_retries)
         result = conn.session.info
 

--- a/packages/railtracks/tests/integration_tests/run/test_error_handler.py
+++ b/packages/railtracks/tests/integration_tests/run/test_error_handler.py
@@ -12,8 +12,7 @@ RNGNode = rt.function_node(random.random)
 
 @pytest.mark.timeout(1)
 async def test_simple_request():
-    with rt.Session():
-        result = await rt.call(RNGNode)
+    result = await rt.Flow("test_simple_request", RNGNode).ainvoke()
 
     assert isinstance(result, float)
     assert 0 < result < 1
@@ -31,9 +30,8 @@ ErrorThrower = rt.function_node(error_thrower)
 
 
 async def test_error():
-    with rt.Session():
-        with pytest.raises(CustomTestError):
-            await rt.call(ErrorThrower)
+    with pytest.raises(CustomTestError):
+        await rt.Flow("test_error", ErrorThrower).ainvoke()
 
 
 async def error_handler():
@@ -48,15 +46,15 @@ ErrorHandler = rt.function_node(error_handler)
 
 @pytest.mark.timeout(1)
 async def test_error_handler():
-    with rt.Session():
-        result = await rt.call(ErrorHandler)
+    result = await rt.Flow("test_error_handler", ErrorHandler).ainvoke()
     assert result == "Caught the error"
 
 
 async def test_error_handler_wo_retry():
     with pytest.raises(CustomTestError):
-        with rt.Session(end_on_error=True):
-            await rt.call(ErrorHandler)
+        await rt.Flow(
+            "test_error_handler_wo_retry", ErrorHandler, end_on_error=True
+        ).ainvoke()
 
 
 async def error_handler_with_retry(retries: int):
@@ -75,9 +73,11 @@ ErrorHandlerWithRetry = rt.function_node(error_handler_with_retry)
 @pytest.mark.timeout(5)
 async def test_error_handler_with_retry():
     for num_retries in range(5, 15):
-        with rt.Session() as run:
-            result = await rt.call(ErrorHandlerWithRetry, num_retries)
-            result = run.info
+        conn = rt.Flow(
+            "test_error_handler_with_retry", ErrorHandlerWithRetry
+        ).connect()
+        await conn.ainvoke(num_retries)
+        result = conn.session.info
 
         assert result.answer == "Caught the error"
         i_r = result.request_forest.insertion_request[0]
@@ -107,8 +107,9 @@ ParallelErrorHandler = rt.function_node(parallel_error_handler)
 
 async def test_parallel_error_tester():
     for n_c, p_c in [(10, 10), (3, 20), (1, 10), (60, 10)]:
-        with rt.Session():
-            result = await rt.call(ParallelErrorHandler, n_c, p_c)
+        result = await rt.Flow(
+            "test_parallel_error_tester", ParallelErrorHandler
+        ).ainvoke(n_c, p_c)
 
         assert isinstance(result, list)
         assert len(result) == n_c * p_c
@@ -128,16 +129,16 @@ ErrorHandlerWrapper = rt.function_node(error_handler_wrapper)
 
 async def test_parallel_error_wrapper():
     for n_c, p_c in [(10, 10), (3, 20), (1, 10), (60, 10)]:
-        with rt.Session() as run:
-            result = await rt.call(ErrorHandlerWrapper, n_c, p_c)
+        conn = rt.Flow("test_parallel_error_wrapper", ErrorHandlerWrapper).connect()
+        result = await conn.ainvoke(n_c, p_c)
 
         assert len(result) == n_c * p_c
         assert all(isinstance(x, CustomTestError) for x in result)
-        i_r = run.info.request_forest.insertion_request[0]
+        i_r = conn.session.info.request_forest.insertion_request[0]
 
-        children = run.info.request_forest.children(i_r.sink_id)
+        children = conn.session.info.request_forest.children(i_r.sink_id)
         assert len(children) == 1
-        full_children = run.info.request_forest.children(children[0].sink_id)
+        full_children = conn.session.info.request_forest.children(children[0].sink_id)
         for r in children:
             assert r.output == result
 

--- a/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
+++ b/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
@@ -37,9 +37,7 @@ async def test_runner_call_with_context():
     response = await conn.ainvoke()
     assert isinstance(response, float), "Expected a float result from RNGNode"
     info = conn.session.info
-    assert info.answer == response, (
-        "Expected the answer to be the same as the response"
-    )
+    assert info.answer == response, "Expected the answer to be the same as the response"
 
 
 async def config_test_async():
@@ -144,9 +142,7 @@ def test_back_to_defaults():
     def entry():
         return None
 
-    conn = rt.Flow(
-        "test_back_to_defaults_explicit", entry, end_on_error=True
-    ).connect()
+    conn = rt.Flow("test_back_to_defaults_explicit", entry, end_on_error=True).connect()
     conn.invoke()
     assert conn.session.rt_state.executor_config.end_on_error
 

--- a/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
+++ b/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
@@ -51,12 +51,7 @@ async def config_test_async():
     async def run_with_config_w_context():
         railtracks.context.central.set_config(end_on_error=False)
 
-        @rt.function_node
-        async def entry():
-            info = await rt.call(RNGNode)
-            return info
-
-        conn = rt.Flow("config_test_async_w_context", entry).connect()
+        conn = rt.Flow("config_test_async_w_context", RNGNode).connect()
         info = await conn.ainvoke()
         assert not conn.session.rt_state.executor_config.end_on_error
         response = info
@@ -83,11 +78,7 @@ def config_test_threads():
     async def run_with_config_w_context():
         railtracks.context.central.set_config(end_on_error=False)
 
-        @rt.function_node
-        async def entry():
-            return await rt.call(RNGNode)
-
-        conn = rt.Flow("config_test_threads_w_context", entry).connect()
+        conn = rt.Flow("config_test_threads_w_context", RNGNode).connect()
         response = await conn.ainvoke()
         assert not conn.session.rt_state.executor_config.end_on_error
         assert isinstance(response, float), "Expected a float result from RNGNode"
@@ -109,11 +100,7 @@ async def test_sequence_of_changes():
     railtracks.context.central.set_config(end_on_error=False)
     railtracks.context.central.set_config(end_on_error=True)
 
-    @rt.function_node
-    async def entry():
-        return await rt.call(RNGNode)
-
-    conn = rt.Flow("test_sequence_of_changes", entry).connect()
+    conn = rt.Flow("test_sequence_of_changes", RNGNode).connect()
     response = await conn.ainvoke()
     assert conn.session.rt_state.executor_config.end_on_error
     assert response == conn.session.info.answer
@@ -123,19 +110,15 @@ async def test_sequence_of_changes_overwrite():
     railtracks.context.central.set_config(end_on_error=True)
     railtracks.context.central.set_config(end_on_error=False)
 
-    @rt.function_node
-    async def entry():
-        return await rt.call(RNGNode)
-
     conn = rt.Flow(
-        "test_sequence_of_changes_overwrite", entry, end_on_error=True
+        "test_sequence_of_changes_overwrite", RNGNode, end_on_error=True
     ).connect()
     response = await conn.ainvoke()
     assert conn.session.rt_state.executor_config.end_on_error
     assert response == conn.session.info.answer
 
 
-def test_back_to_defaults():
+async def test_back_to_defaults():
     rt.set_config(end_on_error=True)
 
     @rt.function_node
@@ -143,11 +126,11 @@ def test_back_to_defaults():
         return None
 
     conn = rt.Flow("test_back_to_defaults_explicit", entry, end_on_error=True).connect()
-    conn.invoke()
+    await conn.ainvoke()
     assert conn.session.rt_state.executor_config.end_on_error
 
     conn = rt.Flow("test_back_to_defaults_default", entry).connect()
-    conn.invoke()
+    await conn.ainvoke()
     assert conn.session.rt_state.executor_config.end_on_error
 
 

--- a/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
+++ b/packages/railtracks/tests/integration_tests/run/test_exterior_call.py
@@ -33,13 +33,13 @@ async def test_runner_call_basic():
 
 @pytest.mark.skip(reason="Skipping test for now, will be fixed in future release")
 async def test_runner_call_with_context():
-    with rt.Session() as run:
-        response = await rt.call(RNGNode)
-        assert isinstance(response, float), "Expected a float result from RNGNode"
-        info = run.info
-        assert info.answer == response, (
-            "Expected the answer to be the same as the response"
-        )
+    conn = rt.Flow("test_runner_call_with_context", RNGNode).connect()
+    response = await conn.ainvoke()
+    assert isinstance(response, float), "Expected a float result from RNGNode"
+    info = conn.session.info
+    assert info.answer == response, (
+        "Expected the answer to be the same as the response"
+    )
 
 
 async def config_test_async():
@@ -52,9 +52,15 @@ async def config_test_async():
 
     async def run_with_config_w_context():
         railtracks.context.central.set_config(end_on_error=False)
-        with rt.Session() as session:
+
+        @rt.function_node
+        async def entry():
             info = await rt.call(RNGNode)
-            assert not session.rt_state.executor_config.end_on_error
+            return info
+
+        conn = rt.Flow("config_test_async_w_context", entry).connect()
+        info = await conn.ainvoke()
+        assert not conn.session.rt_state.executor_config.end_on_error
         response = info
         assert isinstance(response, float), "Expected a float result from RNGNode"
         assert 0 < response < 1, "Expected a float result from RNGNode"
@@ -78,9 +84,14 @@ async def test_different_config_local_set_async():
 def config_test_threads():
     async def run_with_config_w_context():
         railtracks.context.central.set_config(end_on_error=False)
-        with rt.Session() as session:
-            response = await rt.call(RNGNode)
-            assert not session.rt_state.executor_config.end_on_error
+
+        @rt.function_node
+        async def entry():
+            return await rt.call(RNGNode)
+
+        conn = rt.Flow("config_test_threads_w_context", entry).connect()
+        response = await conn.ainvoke()
+        assert not conn.session.rt_state.executor_config.end_on_error
         assert isinstance(response, float), "Expected a float result from RNGNode"
         assert 0 < response < 1, "Expected a float result from RNGNode"
 
@@ -99,28 +110,49 @@ async def test_sequence_of_changes():
     railtracks.context.central.set_config(end_on_error=True)
     railtracks.context.central.set_config(end_on_error=False)
     railtracks.context.central.set_config(end_on_error=True)
-    with rt.Session() as session:
-        response = await rt.call(RNGNode)
-        assert session.rt_state.executor_config.end_on_error
-        assert response == session.info.answer
+
+    @rt.function_node
+    async def entry():
+        return await rt.call(RNGNode)
+
+    conn = rt.Flow("test_sequence_of_changes", entry).connect()
+    response = await conn.ainvoke()
+    assert conn.session.rt_state.executor_config.end_on_error
+    assert response == conn.session.info.answer
 
 
 async def test_sequence_of_changes_overwrite():
     railtracks.context.central.set_config(end_on_error=True)
     railtracks.context.central.set_config(end_on_error=False)
-    with rt.Session(end_on_error=True) as session:
-        response = await rt.call(RNGNode)
-        assert session.rt_state.executor_config.end_on_error
-        assert response == session.info.answer
+
+    @rt.function_node
+    async def entry():
+        return await rt.call(RNGNode)
+
+    conn = rt.Flow(
+        "test_sequence_of_changes_overwrite", entry, end_on_error=True
+    ).connect()
+    response = await conn.ainvoke()
+    assert conn.session.rt_state.executor_config.end_on_error
+    assert response == conn.session.info.answer
 
 
 def test_back_to_defaults():
     rt.set_config(end_on_error=True)
-    with rt.Session(end_on_error=True) as run:
-        assert run.rt_state.executor_config.end_on_error
 
-    with rt.Session() as run:
-        assert run.rt_state.executor_config.end_on_error
+    @rt.function_node
+    def entry():
+        return None
+
+    conn = rt.Flow(
+        "test_back_to_defaults_explicit", entry, end_on_error=True
+    ).connect()
+    conn.invoke()
+    assert conn.session.rt_state.executor_config.end_on_error
+
+    conn = rt.Flow("test_back_to_defaults_default", entry).connect()
+    conn.invoke()
+    assert conn.session.rt_state.executor_config.end_on_error
 
 
 message = "Hello, World!"
@@ -146,9 +178,8 @@ async def test_streaming_inserted_globally():
     handler = StreamHandler()
 
     railtracks.context.central.set_config(broadcast_callback=handler.handle)
-    with rt.Session():
-        result = await rt.call(StreamingNode)
-        assert result is None
+    result = await rt.Flow("test_streaming_inserted_globally", StreamingNode).ainvoke()
+    assert result is None
 
     sleep(0.1)
     assert len(handler.message) == 1
@@ -158,9 +189,12 @@ async def test_streaming_inserted_globally():
 async def test_streaming_inserted_locally():
     handler = StreamHandler()
 
-    with rt.Session(broadcast_callback=handler.handle):
-        result = await rt.call(StreamingNode)
-        assert result is None
+    result = await rt.Flow(
+        "test_streaming_inserted_locally",
+        StreamingNode,
+        broadcast_callback=handler.handle,
+    ).ainvoke()
+    assert result is None
 
     sleep(0.1)
     assert len(handler.message) == 1
@@ -175,9 +209,12 @@ async def test_streaming_overwrite():
     handler = StreamHandler()
 
     railtracks.context.central.set_config(broadcast_callback=fake_handler)
-    with rt.Session(broadcast_callback=handler.handle):
-        result = await rt.call(StreamingNode)
-        assert result is None
+    result = await rt.Flow(
+        "test_streaming_overwrite",
+        StreamingNode,
+        broadcast_callback=handler.handle,
+    ).ainvoke()
+    assert result is None
 
     sleep(0.1)
     assert len(handler.message) == 1

--- a/packages/railtracks/tests/integration_tests/run/test_multiple_runners.py
+++ b/packages/railtracks/tests/integration_tests/run/test_multiple_runners.py
@@ -18,9 +18,9 @@ SlowRNG = rt.function_node(slow_rng)
 @pytest.mark.asyncio
 async def test_async_runners_w_async():
     async def run_rng(timeout_len: float):
-        with rt.Session() as run:
-            await rt.call(SlowRNG, timeout_len)
-            return run.info
+        conn = rt.Flow("test_async_runners_w_async", SlowRNG).connect()
+        await conn.ainvoke(timeout_len)
+        return conn.session.info
 
     contracts = [run_rng(0.2) for _ in range(5)]
 
@@ -36,9 +36,9 @@ async def test_async_runners_w_executor():
     with concurrent.futures.ThreadPoolExecutor() as executor:
 
         async def run_rng(timeout_len: float):
-            with rt.Session() as run:
-                await rt.call(SlowRNG, timeout_len)
-                return run.info
+            conn = rt.Flow("test_async_runners_w_executor", SlowRNG).connect()
+            await conn.ainvoke(timeout_len)
+            return conn.session.info
 
         mapped_results = executor.map(lambda x: asyncio.run(run_rng(x)), [0.2] * 5)
 
@@ -48,9 +48,7 @@ async def test_async_runners_w_executor():
 
 @pytest.mark.asyncio
 async def nested_runner_call():
-    with rt.Session():
-        result = await rt.call(SlowRNG, 0.2)
-        return result
+    return await rt.Flow("nested_runner_call", SlowRNG).ainvoke(0.2)
 
 
 NestedRunner = rt.function_node(nested_runner_call)

--- a/packages/railtracks/tests/integration_tests/run/test_parallelization.py
+++ b/packages/railtracks/tests/integration_tests/run/test_parallelization.py
@@ -51,9 +51,5 @@ TopLevel = rt.function_node(top_level)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("node", [TopLevel, TopLevelAsync], ids=["sync", "async"])
 async def test_async_style_parallel(node):
-    @rt.function_node
-    async def entry():
-        return await rt.call(node)
-
-    result = await rt.Flow("test_async_style_parallel", entry).ainvoke()
+    result = await rt.Flow("test_async_style_parallel", node).ainvoke()
     assert result == [1, 2, 3, 2, 1]

--- a/packages/railtracks/tests/integration_tests/run/test_parallelization.py
+++ b/packages/railtracks/tests/integration_tests/run/test_parallelization.py
@@ -51,6 +51,9 @@ TopLevel = rt.function_node(top_level)
 @pytest.mark.asyncio
 @pytest.mark.parametrize("node", [TopLevel, TopLevelAsync], ids=["sync", "async"])
 async def test_async_style_parallel(node):
-    with rt.Session():
-        result = await rt.call(node)
-        assert result == [1, 2, 3, 2, 1]
+    @rt.function_node
+    async def entry():
+        return await rt.call(node)
+
+    result = await rt.Flow("test_async_style_parallel", entry).ainvoke()
+    assert result == [1, 2, 3, 2, 1]

--- a/packages/railtracks/tests/integration_tests/test_legacy_trace_compat.py
+++ b/packages/railtracks/tests/integration_tests/test_legacy_trace_compat.py
@@ -42,9 +42,9 @@ def tool_calling_payload(mock_llm):
     )
 
     async def run():
-        with rt.Session(flow_name="legacy-trace-compat") as session:
-            await rt.call(agent, "What is the secret phrase?")
-        return session.payload()
+        conn = rt.Flow("legacy-trace-compat", agent).connect()
+        await conn.ainvoke("What is the secret phrase?")
+        return conn.session.payload()
 
     return run
 

--- a/packages/railtracks/tests/llm_live_tests/test_basic.py
+++ b/packages/railtracks/tests/llm_live_tests/test_basic.py
@@ -57,11 +57,7 @@ async def test_terminal_llm(llm):
         llm=llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(terminal_node, user_input=user_input)
-
-    response = await rt.Flow("test_terminal_llm", entry).ainvoke(
+    response = await rt.Flow("test_terminal_llm", terminal_node).ainvoke(
         "Please reverse '12345'."
     )
     final_resp: StringResponse | None = response
@@ -84,11 +80,7 @@ async def test_structured_llm(llm, test_case):
         llm=llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(structured_node, user_input=user_input)
-
-    response = await rt.Flow("test_structured_llm", entry).ainvoke(
+    response = await rt.Flow("test_structured_llm", structured_node).ainvoke(
         test_case["user_input"]
     )
 

--- a/packages/railtracks/tests/llm_live_tests/test_basic.py
+++ b/packages/railtracks/tests/llm_live_tests/test_basic.py
@@ -57,11 +57,16 @@ async def test_terminal_llm(llm):
         llm=llm,
     )
 
-    with rt.Session():
-        response = await rt.call(terminal_node, user_input="Please reverse '12345'.")
-        final_resp: StringResponse | None = response
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(terminal_node, user_input=user_input)
 
-        assert final_resp is not None and "54321" in final_resp.content
+    response = await rt.Flow("test_terminal_llm", entry).ainvoke(
+        "Please reverse '12345'."
+    )
+    final_resp: StringResponse | None = response
+
+    assert final_resp is not None and "54321" in final_resp.content
 
 
 @pytest.mark.asyncio
@@ -79,16 +84,21 @@ async def test_structured_llm(llm, test_case):
         llm=llm,
     )
 
-    with rt.Session():
-        response = await rt.call(structured_node, user_input=test_case["user_input"])
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(structured_node, user_input=user_input)
 
-        final_resp = response
+    response = await rt.Flow("test_structured_llm", entry).ainvoke(
+        test_case["user_input"]
+    )
 
-        # Basic type check
-        assert final_resp is not None
-        assert isinstance(final_resp.structured, test_case["schema"])
+    final_resp = response
 
-        # Custom validation
-        assert test_case["validator"](final_resp), (
-            f"Validation failed for {test_case['case_id']}"
-        )
+    # Basic type check
+    assert final_resp is not None
+    assert isinstance(final_resp.structured, test_case["schema"])
+
+    # Custom validation
+    assert test_case["validator"](final_resp), (
+        f"Validation failed for {test_case['case_id']}"
+    )

--- a/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
+++ b/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
@@ -6,7 +6,8 @@ from railtracks.rt_mcp.main import MCPHttpParams, MCPStdioParams
 
 
 @pytest.mark.skip(reason="Skipped due to LLM stochasticity")
-def test_from_mcp_server_with_llm():
+@pytest.mark.asyncio
+async def test_from_mcp_server_with_llm():
     time_server = rt.connect_mcp(
         MCPStdioParams(
             command=sys.executable,
@@ -23,22 +24,19 @@ def test_from_mcp_server_with_llm():
         llm=rt.llm.OpenAILLM("gpt-4o"),
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(parent_tool, user_input=user_input)
-
     # Run the parent tool
     message_history = rt.llm.MessageHistory([rt.llm.UserMessage("What time is it?")])
-    response = rt.Flow("test_from_mcp_server_with_llm", entry, timeout=1000).invoke(
-        message_history
-    )
+    response = await rt.Flow(
+        "test_from_mcp_server_with_llm", parent_tool, timeout=1000
+    ).ainvoke(message_history)
 
     assert response is not None
     assert response.content != "It didn't work!"
 
 
 @pytest.mark.skip(reason="Skipped due to LLM stochasticity")
-def test_from_mcp_server_with_http():
+@pytest.mark.asyncio
+async def test_from_mcp_server_with_http():
     time_server = rt.connect_mcp(MCPHttpParams(url="https://mcp.deepwiki.com/sse"))
     parent_tool = rt.agent_node(
         tool_nodes={*time_server.tools},
@@ -50,17 +48,13 @@ def test_from_mcp_server_with_http():
         llm=rt.llm.OpenAILLM("gpt-4o"),
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(parent_tool, user_input=user_input)
-
     # Run the parent tool
     message_history = rt.llm.MessageHistory(
         [rt.llm.UserMessage("Tell me about the website conductr.ai")]
     )
-    response = rt.Flow("test_from_mcp_server_with_http", entry, timeout=1000).invoke(
-        message_history
-    )
+    response = await rt.Flow(
+        "test_from_mcp_server_with_http", parent_tool, timeout=1000
+    ).ainvoke(message_history)
 
     assert response is not None
     assert response.content != "It didn't work!"

--- a/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
+++ b/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
@@ -29,9 +29,9 @@ def test_from_mcp_server_with_llm():
 
     # Run the parent tool
     message_history = rt.llm.MessageHistory([rt.llm.UserMessage("What time is it?")])
-    response = rt.Flow(
-        "test_from_mcp_server_with_llm", entry, timeout=1000
-    ).invoke(message_history)
+    response = rt.Flow("test_from_mcp_server_with_llm", entry, timeout=1000).invoke(
+        message_history
+    )
 
     assert response is not None
     assert response.content != "It didn't work!"
@@ -58,9 +58,9 @@ def test_from_mcp_server_with_http():
     message_history = rt.llm.MessageHistory(
         [rt.llm.UserMessage("Tell me about the website conductr.ai")]
     )
-    response = rt.Flow(
-        "test_from_mcp_server_with_http", entry, timeout=1000
-    ).invoke(message_history)
+    response = rt.Flow("test_from_mcp_server_with_http", entry, timeout=1000).invoke(
+        message_history
+    )
 
     assert response is not None
     assert response.content != "It didn't work!"

--- a/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
+++ b/packages/railtracks/tests/llm_live_tests/test_rt_mcp.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 
 import pytest
@@ -24,12 +23,15 @@ def test_from_mcp_server_with_llm():
         llm=rt.llm.OpenAILLM("gpt-4o"),
     )
 
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(parent_tool, user_input=user_input)
+
     # Run the parent tool
-    with rt.Session(timeout=1000):
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("What time is it?")]
-        )
-        response = asyncio.run(rt.call(parent_tool, user_input=message_history))
+    message_history = rt.llm.MessageHistory([rt.llm.UserMessage("What time is it?")])
+    response = rt.Flow(
+        "test_from_mcp_server_with_llm", entry, timeout=1000
+    ).invoke(message_history)
 
     assert response is not None
     assert response.content != "It didn't work!"
@@ -48,12 +50,17 @@ def test_from_mcp_server_with_http():
         llm=rt.llm.OpenAILLM("gpt-4o"),
     )
 
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(parent_tool, user_input=user_input)
+
     # Run the parent tool
-    with rt.Session(timeout=1000):
-        message_history = rt.llm.MessageHistory(
-            [rt.llm.UserMessage("Tell me about the website conductr.ai")]
-        )
-        response = asyncio.run(rt.call(parent_tool, user_input=message_history))
+    message_history = rt.llm.MessageHistory(
+        [rt.llm.UserMessage("Tell me about the website conductr.ai")]
+    )
+    response = rt.Flow(
+        "test_from_mcp_server_with_http", entry, timeout=1000
+    ).invoke(message_history)
 
     assert response is not None
     assert response.content != "It didn't work!"

--- a/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
+++ b/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
@@ -34,18 +34,21 @@ async def test_function_as_tool(llm):
         llm=llm,
     )
 
-    with rt.Session():
-        response = await rt.call(
-            agent,
-            user_input="First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.",
-        )
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input=user_input)
 
-        final_resp = response
+    conn = rt.Flow("test_function_as_tool", entry).connect()
+    response = await conn.ainvoke(
+        "First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.",
+    )
 
-        assert final_resp is not None
-        assert "15" in final_resp.content
-        assert rt.context.get("magic_number_called")
-        assert rt.context.get("magic_operator_called")
+    final_resp = response
+
+    assert final_resp is not None
+    assert "15" in final_resp.content
+    assert conn.context.get("magic_number_called")
+    assert conn.context.get("magic_operator_called")
 
 
 @pytest.mark.asyncio
@@ -88,9 +91,13 @@ async def test_realistic_scenario(llm):
         llm=llm,
     )
 
-    with rt.Session():
-        await rt.call(agent, rt.llm.MessageHistory([rt.llm.UserMessage(usr_prompt)]))
-        assert rt.context.get("staff_directory_updated")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(agent, user_input)
+
+    conn = rt.Flow("test_realistic_scenario", entry).connect()
+    await conn.ainvoke(rt.llm.MessageHistory([rt.llm.UserMessage(usr_prompt)]))
+    assert conn.context.get("staff_directory_updated")
 
     assert db["John"]["role"] == "Senior Manager"
     assert db["John"]["phone"] == "5555"
@@ -148,16 +155,18 @@ async def test_agents_as_tools(llm):
         llm=llm,
     )
 
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(parent_tool, user_input=user_input)
+
     # Run the parent tool
-    with rt.Session(timeout=100):
-        response = await rt.call(
-            parent_tool, user_input="Get me the secret phrase for id `1`."
-        )
+    conn = rt.Flow("test_agents_as_tools", entry, timeout=100).connect()
+    response = await conn.ainvoke("Get me the secret phrase for id `1`.")
 
-        final_resp = response
+    final_resp = response
 
-        assert final_resp is not None
-        assert rt.context.get("secret_phrase_called")
+    assert final_resp is not None
+    assert conn.context.get("secret_phrase_called")
 
     assert final_resp is not None
     assert "3 cats and a dog" in final_resp.content

--- a/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
+++ b/packages/railtracks/tests/llm_live_tests/test_tool_calling.py
@@ -34,11 +34,7 @@ async def test_function_as_tool(llm):
         llm=llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input=user_input)
-
-    conn = rt.Flow("test_function_as_tool", entry).connect()
+    conn = rt.Flow("test_function_as_tool", agent).connect()
     response = await conn.ainvoke(
         "First find the magic number for 4. Then use the magic_operator with `x` as the result from magic_number and `y` as 3. Return the result from the magic_operator.",
     )
@@ -91,11 +87,7 @@ async def test_realistic_scenario(llm):
         llm=llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(agent, user_input)
-
-    conn = rt.Flow("test_realistic_scenario", entry).connect()
+    conn = rt.Flow("test_realistic_scenario", agent).connect()
     await conn.ainvoke(rt.llm.MessageHistory([rt.llm.UserMessage(usr_prompt)]))
     assert conn.context.get("staff_directory_updated")
 
@@ -155,12 +147,8 @@ async def test_agents_as_tools(llm):
         llm=llm,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(parent_tool, user_input=user_input)
-
     # Run the parent tool
-    conn = rt.Flow("test_agents_as_tools", entry, timeout=100).connect()
+    conn = rt.Flow("test_agents_as_tools", parent_tool, timeout=100).connect()
     response = await conn.ainvoke("Get me the secret phrase for id `1`.")
 
     final_resp = response

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_model_source.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_model_source.py
@@ -1,8 +1,6 @@
 """Tests for the ModelSource contract: an agent accepts either a concrete model
 or a no-arg factory, resolved fresh on every model call (runtime model swap)."""
 
-import asyncio
-
 import railtracks as rt
 from railtracks.llm import Message, MessageHistory
 from railtracks.llm.message import Role
@@ -20,11 +18,13 @@ def test_agent_node_accepts_model_factory(mock_llm):
 
     node = rt.agent_node(system_message="hello", llm=lambda: model)
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(node, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    response = asyncio.run(top_level())
+    response = rt.Flow("test_agent_node_accepts_model_factory", entry).invoke(
+        MessageHistory()
+    )
     assert response.content == "hello"
 
 
@@ -43,13 +43,15 @@ def test_model_factory_resolved_per_call(mock_llm):
     current = {"model": model_a}
     node = rt.agent_node(system_message="hi", llm=lambda: current["model"])
 
-    async def run_once():
-        with rt.Session():
-            return await rt.call(node, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    assert asyncio.run(run_once()).content == "from-a"
+    flow = rt.Flow("test_model_factory_resolved_per_call", entry)
+
+    assert flow.invoke(MessageHistory()).content == "from-a"
     current["model"] = model_b
-    assert asyncio.run(run_once()).content == "from-b"
+    assert flow.invoke(MessageHistory()).content == "from-b"
 
 
 def test_model_middleware_list_mutation_after_build_does_not_affect_built_agent(
@@ -71,11 +73,14 @@ def test_model_middleware_list_mutation_after_build_does_not_affect_built_agent(
     )
     shared.append(tracer)  # mutate after build
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node, user_input="hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    asyncio.run(top())
+    rt.Flow(
+        "test_model_middleware_list_mutation_after_build_does_not_affect_built_agent",
+        entry,
+    ).invoke("hello")
     assert calls == [
         "ran"
     ]  # ran once, not twice -- build-time snapshot was independent
@@ -98,12 +103,16 @@ def test_two_agents_built_from_same_model_middleware_list_are_independent(mock_l
         "B", llm=mock_llm(custom_response="b"), model_middleware=shared
     )
 
-    async def run(node):
-        with rt.Session():
-            return await rt.call(node, user_input="hi")
+    @rt.function_node
+    async def entry_a(user_input):
+        return await rt.call(node_a, user_input=user_input)
 
-    asyncio.run(run(node_a))
-    asyncio.run(run(node_b))
+    @rt.function_node
+    async def entry_b(user_input):
+        return await rt.call(node_b, user_input=user_input)
+
+    rt.Flow("independent_agent_a", entry_a).invoke("hi")
+    rt.Flow("independent_agent_b", entry_b).invoke("hi")
     assert calls_a == [
         "ran"
     ]  # node_a still ran tracer_a despite the later `shared.clear()`

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_model_source.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_model_source.py
@@ -18,11 +18,7 @@ def test_agent_node_accepts_model_factory(mock_llm):
 
     node = rt.agent_node(system_message="hello", llm=lambda: model)
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
-    response = rt.Flow("test_agent_node_accepts_model_factory", entry).invoke(
+    response = rt.Flow("test_agent_node_accepts_model_factory", node).invoke(
         MessageHistory()
     )
     assert response.content == "hello"
@@ -43,11 +39,7 @@ def test_model_factory_resolved_per_call(mock_llm):
     current = {"model": model_a}
     node = rt.agent_node(system_message="hi", llm=lambda: current["model"])
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
-    flow = rt.Flow("test_model_factory_resolved_per_call", entry)
+    flow = rt.Flow("test_model_factory_resolved_per_call", node)
 
     assert flow.invoke(MessageHistory()).content == "from-a"
     current["model"] = model_b
@@ -73,13 +65,9 @@ def test_model_middleware_list_mutation_after_build_does_not_affect_built_agent(
     )
     shared.append(tracer)  # mutate after build
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
     rt.Flow(
         "test_model_middleware_list_mutation_after_build_does_not_affect_built_agent",
-        entry,
+        node,
     ).invoke("hello")
     assert calls == [
         "ran"
@@ -103,16 +91,8 @@ def test_two_agents_built_from_same_model_middleware_list_are_independent(mock_l
         "B", llm=mock_llm(custom_response="b"), model_middleware=shared
     )
 
-    @rt.function_node
-    async def entry_a(user_input):
-        return await rt.call(node_a, user_input=user_input)
-
-    @rt.function_node
-    async def entry_b(user_input):
-        return await rt.call(node_b, user_input=user_input)
-
-    rt.Flow("independent_agent_a", entry_a).invoke("hi")
-    rt.Flow("independent_agent_b", entry_b).invoke("hi")
+    rt.Flow("independent_agent_a", node_a).invoke("hi")
+    rt.Flow("independent_agent_b", node_b).invoke("hi")
     assert calls_a == [
         "ran"
     ]  # node_a still ran tracer_a despite the later `shared.clear()`

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -413,12 +413,8 @@ def test_nodebuilder_llm_middleware_sets_user_middleware(mock_llm):
         "TestNode", model=mock_llm(custom_response="hi"), middleware=[tag]
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input=user_input)
-
-    rt.Flow("test_nodebuilder_llm_middleware_sets_user_middleware", entry).invoke(
-        "hello"
+    rt.Flow("test_nodebuilder_llm_middleware_sets_user_middleware", node_cls).invoke(
+        user_input="hello"
     )
     assert fired["value"]
     assert len(node_cls._user_middleware) == 1
@@ -438,13 +434,9 @@ def test_nodebuilder_llm_model_middleware_wraps_model_call(mock_llm):
         "TestNode", model=mock_llm(custom_response="hi"), model_middleware=[tracer]
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input=user_input)
-
     result = rt.Flow(
-        "test_nodebuilder_llm_model_middleware_wraps_model_call", entry
-    ).invoke("hello")
+        "test_nodebuilder_llm_model_middleware_wraps_model_call", node_cls
+    ).invoke(user_input="hello")
     assert result.content == "hi"
     assert calls == ["in", "out"]
 
@@ -466,14 +458,10 @@ def test_nodebuilder_llm_context_injection_via_middleware(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input=user_input)
-
     assert (
         rt.Flow(
             "test_nodebuilder_llm_context_injection_via_middleware",
-            entry,
+            node_cls,
             context={"secret": "tomato"},
         )
         .invoke(MessageHistory())
@@ -493,14 +481,10 @@ def test_nodebuilder_llm_no_injection_by_default(mock_llm):
         system_message=SystemMessage(content="{secret}"),
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input=user_input)
-
     assert (
         rt.Flow(
             "test_nodebuilder_llm_no_injection_by_default",
-            entry,
+            node_cls,
             context={"secret": "tomato"},
         )
         .invoke(MessageHistory())
@@ -528,13 +512,9 @@ def test_nodebuilder_llm_guardrails_input_and_output_both_fire(mock_llm):
         model_middleware=[MarkInputGuard(), MarkOutputGuard()],
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input)
-
-    rt.Flow("test_nodebuilder_llm_guardrails_input_and_output_both_fire", entry).invoke(
-        "hello"
-    )
+    rt.Flow(
+        "test_nodebuilder_llm_guardrails_input_and_output_both_fire", node_cls
+    ).invoke("hello")
     assert fired == {"input": True, "output": True}
 
 
@@ -552,12 +532,8 @@ def test_nodebuilder_llm_guardrails_input_only_does_not_fire_output(mock_llm):
         model_middleware=[MarkInputGuard()],
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input)
-
     result = rt.Flow(
-        "test_nodebuilder_llm_guardrails_input_only_does_not_fire_output", entry
+        "test_nodebuilder_llm_guardrails_input_only_does_not_fire_output", node_cls
     ).invoke("hello")
     assert fired["input"]
     assert result.content == "hi"
@@ -568,12 +544,8 @@ def test_nodebuilder_llm_empty_model_middleware_is_a_no_op(mock_llm):
         "EmptyGuardNode", model=mock_llm(custom_response="hi"), model_middleware=[]
     ).build()
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input)
-
     assert (
-        rt.Flow("test_nodebuilder_llm_empty_model_middleware_is_a_no_op", entry)
+        rt.Flow("test_nodebuilder_llm_empty_model_middleware_is_a_no_op", node_cls)
         .invoke("hello")
         .content
         == "hi"
@@ -616,11 +588,7 @@ def test_nodebuilder_llm_guardrail_vs_user_middleware_order_is_list_position(
     ).build()
 
     def run(node_cls, flow_name):
-        @rt.function_node
-        async def entry(user_input):
-            return await rt.call(node_cls, user_input=user_input)
-
-        return rt.Flow(flow_name, entry).invoke("hi")
+        return rt.Flow(flow_name, node_cls).invoke(user_input="hi")
 
     guard_first_result = run(guard_first_cls, "guard_first_order")
     user_first_result = run(user_first_cls, "user_first_order")

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -413,11 +413,13 @@ def test_nodebuilder_llm_middleware_sets_user_middleware(mock_llm):
         "TestNode", model=mock_llm(custom_response="hi"), middleware=[tag]
     ).build()
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node_cls, user_input="hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input=user_input)
 
-    asyncio.run(top())
+    rt.Flow("test_nodebuilder_llm_middleware_sets_user_middleware", entry).invoke(
+        "hello"
+    )
     assert fired["value"]
     assert len(node_cls._user_middleware) == 1
 
@@ -436,11 +438,13 @@ def test_nodebuilder_llm_model_middleware_wraps_model_call(mock_llm):
         "TestNode", model=mock_llm(custom_response="hi"), model_middleware=[tracer]
     ).build()
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node_cls, user_input="hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input=user_input)
 
-    result = asyncio.run(top())
+    result = rt.Flow(
+        "test_nodebuilder_llm_model_middleware_wraps_model_call", entry
+    ).invoke("hello")
     assert result.content == "hi"
     assert calls == ["in", "out"]
 
@@ -462,11 +466,20 @@ def test_nodebuilder_llm_context_injection_via_middleware(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     ).build()
 
-    async def top():
-        with rt.Session(context={"secret": "tomato"}):
-            return await rt.call(node_cls, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input=user_input)
 
-    assert asyncio.run(top()).content == "tomato"
+    assert (
+        rt.Flow(
+            "test_nodebuilder_llm_context_injection_via_middleware",
+            entry,
+            context={"secret": "tomato"},
+        )
+        .invoke(MessageHistory())
+        .content
+        == "tomato"
+    )
 
 
 def test_nodebuilder_llm_no_injection_by_default(mock_llm):
@@ -480,11 +493,20 @@ def test_nodebuilder_llm_no_injection_by_default(mock_llm):
         system_message=SystemMessage(content="{secret}"),
     ).build()
 
-    async def top():
-        with rt.Session(context={"secret": "tomato"}):
-            return await rt.call(node_cls, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input=user_input)
 
-    assert asyncio.run(top()).content == "{secret}"
+    assert (
+        rt.Flow(
+            "test_nodebuilder_llm_no_injection_by_default",
+            entry,
+            context={"secret": "tomato"},
+        )
+        .invoke(MessageHistory())
+        .content
+        == "{secret}"
+    )
 
 
 def test_nodebuilder_llm_guardrails_input_and_output_both_fire(mock_llm):
@@ -506,11 +528,13 @@ def test_nodebuilder_llm_guardrails_input_and_output_both_fire(mock_llm):
         model_middleware=[MarkInputGuard(), MarkOutputGuard()],
     ).build()
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node_cls, "hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input)
 
-    asyncio.run(top())
+    rt.Flow(
+        "test_nodebuilder_llm_guardrails_input_and_output_both_fire", entry
+    ).invoke("hello")
     assert fired == {"input": True, "output": True}
 
 
@@ -528,11 +552,13 @@ def test_nodebuilder_llm_guardrails_input_only_does_not_fire_output(mock_llm):
         model_middleware=[MarkInputGuard()],
     ).build()
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node_cls, "hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input)
 
-    result = asyncio.run(top())
+    result = rt.Flow(
+        "test_nodebuilder_llm_guardrails_input_only_does_not_fire_output", entry
+    ).invoke("hello")
     assert fired["input"]
     assert result.content == "hi"
 
@@ -542,11 +568,18 @@ def test_nodebuilder_llm_empty_model_middleware_is_a_no_op(mock_llm):
         "EmptyGuardNode", model=mock_llm(custom_response="hi"), model_middleware=[]
     ).build()
 
-    async def top():
-        with rt.Session():
-            return await rt.call(node_cls, "hello")
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node_cls, user_input)
 
-    assert asyncio.run(top()).content == "hi"
+    assert (
+        rt.Flow(
+            "test_nodebuilder_llm_empty_model_middleware_is_a_no_op", entry
+        )
+        .invoke("hello")
+        .content
+        == "hi"
+    )
 
 
 def test_nodebuilder_llm_guardrail_vs_user_middleware_order_is_list_position(
@@ -584,12 +617,15 @@ def test_nodebuilder_llm_guardrail_vs_user_middleware_order_is_list_position(
         model_middleware=[overwrite_after_guardrail, AlwaysRedactOutputGuard()],
     ).build()
 
-    async def top(node_cls):
-        with rt.Session():
-            return await rt.call(node_cls, user_input="hi")
+    def run(node_cls, flow_name):
+        @rt.function_node
+        async def entry(user_input):
+            return await rt.call(node_cls, user_input=user_input)
 
-    guard_first_result = asyncio.run(top(guard_first_cls))
-    user_first_result = asyncio.run(top(user_first_cls))
+        return rt.Flow(flow_name, entry).invoke("hi")
+
+    guard_first_result = run(guard_first_cls, "guard_first_order")
+    user_first_result = run(user_first_cls, "user_first_order")
 
     assert guard_first_result.content == "[REDACTED BY GUARDRAIL]"
     assert user_first_result.content == "overwritten by user middleware"

--- a/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
+++ b/packages/railtracks/tests/unit_tests/built_nodes/test_node_builder.py
@@ -532,9 +532,9 @@ def test_nodebuilder_llm_guardrails_input_and_output_both_fire(mock_llm):
     async def entry(user_input):
         return await rt.call(node_cls, user_input)
 
-    rt.Flow(
-        "test_nodebuilder_llm_guardrails_input_and_output_both_fire", entry
-    ).invoke("hello")
+    rt.Flow("test_nodebuilder_llm_guardrails_input_and_output_both_fire", entry).invoke(
+        "hello"
+    )
     assert fired == {"input": True, "output": True}
 
 
@@ -573,9 +573,7 @@ def test_nodebuilder_llm_empty_model_middleware_is_a_no_op(mock_llm):
         return await rt.call(node_cls, user_input)
 
     assert (
-        rt.Flow(
-            "test_nodebuilder_llm_empty_model_middleware_is_a_no_op", entry
-        )
+        rt.Flow("test_nodebuilder_llm_empty_model_middleware_is_a_no_op", entry)
         .invoke("hello")
         .content
         == "hi"

--- a/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
@@ -52,8 +52,11 @@ async def _run(node, *args):
 
 
 async def _run_agent(node_cls, user_input="hello"):
-    with rt.Session():
+    @rt.function_node
+    async def entry(user_input):
         return await rt.call(node_cls, user_input=user_input)
+
+    return await rt.Flow("test_couple_agent", entry).ainvoke(user_input)
 
 
 # =============================== middleware ===============================

--- a/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_couple.py
@@ -1,7 +1,5 @@
 """Unit tests for `couple` -- post-hoc middleware attachment."""
 
-import asyncio
-
 import pytest
 import railtracks as rt
 from railtracks.interaction import couple
@@ -52,11 +50,7 @@ async def _run(node, *args):
 
 
 async def _run_agent(node_cls, user_input="hello"):
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node_cls, user_input=user_input)
-
-    return await rt.Flow("test_couple_agent", entry).ainvoke(user_input)
+    return await rt.Flow("test_couple_agent", node_cls).ainvoke(user_input=user_input)
 
 
 # =============================== middleware ===============================
@@ -108,12 +102,12 @@ def test_couple_on_rt_function_preserves_name():
     assert result.__name__ == fn.__name__
 
 
-def test_couple_runs_middleware_around_the_call():
+async def test_couple_runs_middleware_around_the_call():
     log = []
     fn = _make_node()
     result = couple(fn, middleware=[_tracer("outer", log)])
 
-    value = asyncio.run(_run(result, 2, 3))
+    value = await _run(result, 2, 3)
 
     assert value == 5
     assert log == ["outer-in", "outer-out"]
@@ -121,11 +115,11 @@ def test_couple_runs_middleware_around_the_call():
     # the original was never touched, so running it directly must not see the
     # newly attached middleware
     log.clear()
-    asyncio.run(_run(fn, 2, 3))
+    await _run(fn, 2, 3)
     assert log == []
 
 
-def test_couple_twice_from_same_original_produces_independent_siblings():
+async def test_couple_twice_from_same_original_produces_independent_siblings():
     """Two `couple()` calls against the same original RTFunction each branch from
     that original's pristine state -- the second call does not see the first
     call's middleware, and the original itself never accumulates anything."""
@@ -134,19 +128,19 @@ def test_couple_twice_from_same_original_produces_independent_siblings():
     first = couple(fn, middleware=[_tracer("first", log)])
     second = couple(fn, middleware=[_tracer("second", log)])
 
-    asyncio.run(_run(first, 1, 1))
+    await _run(first, 1, 1)
     assert log == ["first-in", "first-out"]
 
     log.clear()
-    asyncio.run(_run(second, 1, 1))
+    await _run(second, 1, 1)
     assert log == ["second-in", "second-out"]
 
     log.clear()
-    asyncio.run(_run(fn, 1, 1))
+    await _run(fn, 1, 1)
     assert log == []
 
 
-def test_couple_chained_composes_second_outer_first_inner():
+async def test_couple_chained_composes_second_outer_first_inner():
     """To compose middleware across multiple `couple()` calls, chain off the
     previous result rather than calling `couple()` repeatedly against the same
     original -- each call wraps a fresh layer around whatever it's given."""
@@ -155,19 +149,19 @@ def test_couple_chained_composes_second_outer_first_inner():
     once = couple(fn, middleware=[_tracer("first", log)])
     twice = couple(once, middleware=[_tracer("second", log)])
 
-    asyncio.run(_run(twice, 1, 1))
+    await _run(twice, 1, 1)
 
     # second-coupled is outer (it wraps the result of the first couple() call),
     # first-coupled is inner
     assert log == ["second-in", "first-in", "first-out", "second-out"]
 
 
-def test_couple_with_multiple_middleware_in_one_call_preserves_list_order():
+async def test_couple_with_multiple_middleware_in_one_call_preserves_list_order():
     log = []
     fn = _make_node()
     result = couple(fn, middleware=[_tracer("first", log), _tracer("second", log)])
 
-    asyncio.run(_run(result, 1, 1))
+    await _run(result, 1, 1)
 
     assert log == ["first-in", "second-in", "second-out", "first-out"]
 
@@ -182,7 +176,7 @@ def test_couple_on_class_with_no_prior_middleware():
     assert new_cls._user_middleware == [mw]
 
 
-def test_couple_branching_from_same_base_does_not_cross_contaminate():
+async def test_couple_branching_from_same_base_does_not_cross_contaminate():
     """Two independent `couple()` calls against the same base class must not leak
     each other's middleware -- extend_middleware deep-copies the existing
     `_user_middleware` list on every call rather than mutating it in place."""
@@ -194,12 +188,12 @@ def test_couple_branching_from_same_base_does_not_cross_contaminate():
     branch_x = base_with_prefix.extend_middleware(_tracer("x", log_x))
     branch_y = base_with_prefix.extend_middleware(_tracer("y", log_y))
 
-    asyncio.run(_run(branch_x, 1, 2))
+    await _run(branch_x, 1, 2)
     assert prefix_log == ["prefix-in", "prefix-out"]
     assert log_x == ["x-in", "x-out"]
     assert log_y == []  # branch_y's middleware never ran
 
-    asyncio.run(_run(branch_y, 3, 4))
+    await _run(branch_y, 3, 4)
     assert log_y == ["y-in", "y-out"]
     assert log_x == ["x-in", "x-out"]  # unchanged by branch_y's run
 
@@ -230,13 +224,13 @@ def test_couple_model_middleware_creates_new_subclass_without_mutating_original(
     assert new_cls._user_model_middleware == [mw]
 
 
-def test_couple_model_middleware_wraps_the_raw_model_call(mock_llm):
+async def test_couple_model_middleware_wraps_the_raw_model_call(mock_llm):
     log = []
     agent_cls = _make_agent(mock_llm)
 
     new_cls = couple(agent_cls, model_middleware=[_model_tracer("m", log)])
 
-    result = asyncio.run(_run_agent(new_cls))
+    result = await _run_agent(new_cls)
 
     assert result.content == "hi"
     assert log == ["m-in", "m-out"]
@@ -244,11 +238,11 @@ def test_couple_model_middleware_wraps_the_raw_model_call(mock_llm):
     # original class is untouched, so calling it directly must not see the
     # newly attached model_middleware
     log.clear()
-    asyncio.run(_run_agent(agent_cls))
+    await _run_agent(agent_cls)
     assert log == []
 
 
-def test_couple_model_middleware_branching_does_not_cross_contaminate(mock_llm):
+async def test_couple_model_middleware_branching_does_not_cross_contaminate(mock_llm):
     prefix_log = []
     agent_cls = _make_agent(mock_llm)
     base_with_prefix = couple(
@@ -266,13 +260,13 @@ def test_couple_model_middleware_branching_does_not_cross_contaminate(mock_llm):
         branch_x._user_model_middleware is not base_with_prefix._user_model_middleware
     )
 
-    asyncio.run(_run_agent(branch_x))
+    await _run_agent(branch_x)
     assert prefix_log == ["prefix-in", "prefix-out"]
     assert log_x == ["x-in", "x-out"]
     assert log_y == []  # branch_y's middleware never ran
 
     prefix_log.clear()
-    asyncio.run(_run_agent(branch_y))
+    await _run_agent(branch_y)
     assert prefix_log == ["prefix-in", "prefix-out"]
     assert log_y == ["y-in", "y-out"]
     assert log_x == ["x-in", "x-out"]  # unchanged by branch_y's run
@@ -295,7 +289,7 @@ def test_couple_model_middleware_does_not_affect_a_sibling_built_separately(mock
     assert agent_b._user_model_middleware == []
 
 
-def test_couple_middleware_and_model_middleware_together(mock_llm):
+async def test_couple_middleware_and_model_middleware_together(mock_llm):
     """You can attach node-level middleware and model-level middleware in the
     same couple() call; each wraps its own boundary and both fire."""
     node_log, model_log = [], []
@@ -307,7 +301,7 @@ def test_couple_middleware_and_model_middleware_together(mock_llm):
         model_middleware=[_model_tracer("model", model_log)],
     )
 
-    result = asyncio.run(_run_agent(new_cls))
+    result = await _run_agent(new_cls)
 
     assert result.content == "hi"
     assert node_log == ["node-in", "node-out"]
@@ -330,14 +324,16 @@ def test_couple_middleware_alone_leaves_model_middleware_untouched(mock_llm):
     assert new_cls._user_model_middleware == agent_cls._user_model_middleware == []
 
 
-def test_couple_model_middleware_chained_composes_second_outer_first_inner(mock_llm):
+async def test_couple_model_middleware_chained_composes_second_outer_first_inner(
+    mock_llm,
+):
     log = []
     agent_cls = _make_agent(mock_llm)
 
     once = couple(agent_cls, model_middleware=[_model_tracer("first", log)])
     twice = couple(once, model_middleware=[_model_tracer("second", log)])
 
-    asyncio.run(_run_agent(twice))
+    await _run_agent(twice)
 
     # second-coupled is outer (it wraps the result of the first couple() call),
     # first-coupled is inner

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -24,11 +24,7 @@ def test_function_node_middleware_runs():
         """Add two numbers."""
         return a + b
 
-    @rt.function_node
-    async def entry(a, b):
-        return await rt.call(add, a, b)
-
-    result = rt.Flow("test_function_node_middleware_runs", entry).invoke(1, 2)
+    result = rt.Flow("test_function_node_middleware_runs", add).invoke(1, 2)
     assert result == 3
     assert events == ["before", "after"]
 
@@ -43,12 +39,8 @@ def test_function_node_middleware_can_short_circuit():
         """Add two numbers."""
         return a + b
 
-    @rt.function_node
-    async def entry(a, b):
-        return await rt.call(add, a, b)
-
     assert (
-        rt.Flow("test_function_node_middleware_can_short_circuit", entry).invoke(1, 2)
+        rt.Flow("test_function_node_middleware_can_short_circuit", add).invoke(1, 2)
         == -1
     )
 
@@ -76,13 +68,9 @@ def test_middleware_exception_propagates_through_multiple_layers():
     def boom(a: int, b: int) -> int:
         raise ValueError("kaboom")
 
-    @rt.function_node
-    async def entry(a, b):
-        return await rt.call(boom, a, b)
-
     with pytest.raises(ValueError, match="kaboom"):
         rt.Flow(
-            "test_middleware_exception_propagates_through_multiple_layers", entry
+            "test_middleware_exception_propagates_through_multiple_layers", boom
         ).invoke(1, 2)
     assert log == ["outer-in", "inner-in", "inner-out", "outer-out"]
 
@@ -109,11 +97,9 @@ def test_multiple_middleware_outer_to_inner_order():
         log.append("core")
         return x
 
-    @rt.function_node
-    async def entry(x):
-        return await rt.call(identity, x)
-
-    result = rt.Flow("test_multiple_middleware_outer_to_inner_order", entry).invoke(5)
+    result = rt.Flow("test_multiple_middleware_outer_to_inner_order", identity).invoke(
+        5
+    )
     assert result == 5
     assert log == ["first-in", "second-in", "core", "second-out", "first-out"]
 
@@ -129,12 +115,8 @@ def test_after_does_not_run_when_call_raises():
     def boom() -> int:
         raise ValueError("nope")
 
-    @rt.function_node
-    async def entry():
-        return await rt.call(boom)
-
     with pytest.raises(ValueError, match="nope"):
-        rt.Flow("test_after_does_not_run_when_call_raises", entry).invoke()
+        rt.Flow("test_after_does_not_run_when_call_raises", boom).invoke()
     assert fn_called["value"] is False
 
 
@@ -143,8 +125,4 @@ def test_after_replaces_return_value_on_success():
     def five() -> int:
         return 5
 
-    @rt.function_node
-    async def entry():
-        return await rt.call(five)
-
-    assert rt.Flow("test_after_replaces_return_value_on_success", entry).invoke() == 50
+    assert rt.Flow("test_after_replaces_return_value_on_success", five).invoke() == 50

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -5,8 +5,6 @@ These tests prove the chain holds for function nodes built via the parametrized
 decorator form (`@rt.function_node(middleware=[...])`).
 """
 
-import asyncio
-
 import pytest
 import railtracks as rt
 
@@ -26,11 +24,11 @@ def test_function_node_middleware_runs():
         """Add two numbers."""
         return a + b
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(add, 1, 2)
+    @rt.function_node
+    async def entry(a, b):
+        return await rt.call(add, a, b)
 
-    result = asyncio.run(top_level())
+    result = rt.Flow("test_function_node_middleware_runs", entry).invoke(1, 2)
     assert result == 3
     assert events == ["before", "after"]
 
@@ -45,11 +43,11 @@ def test_function_node_middleware_can_short_circuit():
         """Add two numbers."""
         return a + b
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(add, 1, 2)
+    @rt.function_node
+    async def entry(a, b):
+        return await rt.call(add, a, b)
 
-    assert asyncio.run(top_level()) == -1
+    assert rt.Flow("test_function_node_middleware_can_short_circuit", entry).invoke(1, 2) == -1
 
 
 def test_middleware_exception_propagates_through_multiple_layers():
@@ -75,12 +73,14 @@ def test_middleware_exception_propagates_through_multiple_layers():
     def boom(a: int, b: int) -> int:
         raise ValueError("kaboom")
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(boom, 1, 2)
+    @rt.function_node
+    async def entry(a, b):
+        return await rt.call(boom, a, b)
 
     with pytest.raises(ValueError, match="kaboom"):
-        asyncio.run(top_level())
+        rt.Flow(
+            "test_middleware_exception_propagates_through_multiple_layers", entry
+        ).invoke(1, 2)
     assert log == ["outer-in", "inner-in", "inner-out", "outer-out"]
 
 
@@ -106,11 +106,11 @@ def test_multiple_middleware_outer_to_inner_order():
         log.append("core")
         return x
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(identity, 5)
+    @rt.function_node
+    async def entry(x):
+        return await rt.call(identity, x)
 
-    result = asyncio.run(top_level())
+    result = rt.Flow("test_multiple_middleware_outer_to_inner_order", entry).invoke(5)
     assert result == 5
     assert log == ["first-in", "second-in", "core", "second-out", "first-out"]
 
@@ -126,12 +126,12 @@ def test_after_does_not_run_when_call_raises():
     def boom() -> int:
         raise ValueError("nope")
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(boom)
+    @rt.function_node
+    async def entry():
+        return await rt.call(boom)
 
     with pytest.raises(ValueError, match="nope"):
-        asyncio.run(top_level())
+        rt.Flow("test_after_does_not_run_when_call_raises", entry).invoke()
     assert fn_called["value"] is False
 
 
@@ -140,8 +140,8 @@ def test_after_replaces_return_value_on_success():
     def five() -> int:
         return 5
 
-    async def top_level():
-        with rt.Session():
-            return await rt.call(five)
+    @rt.function_node
+    async def entry():
+        return await rt.call(five)
 
-    assert asyncio.run(top_level()) == 50
+    assert rt.Flow("test_after_replaces_return_value_on_success", entry).invoke() == 50

--- a/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_node_middleware.py
@@ -47,7 +47,10 @@ def test_function_node_middleware_can_short_circuit():
     async def entry(a, b):
         return await rt.call(add, a, b)
 
-    assert rt.Flow("test_function_node_middleware_can_short_circuit", entry).invoke(1, 2) == -1
+    assert (
+        rt.Flow("test_function_node_middleware_can_short_circuit", entry).invoke(1, 2)
+        == -1
+    )
 
 
 def test_middleware_exception_propagates_through_multiple_layers():

--- a/packages/railtracks/tests/unit_tests/middlewares/test_post_verifier.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_post_verifier.py
@@ -218,11 +218,16 @@ class TestPostVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(refund, order_id="A1", amount=50)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(refund, order_id=order_id, amount=amount)
 
-        assert asyncio.run(top_level()) == "refunded 50 for A1"
+        assert (
+            rt.Flow("test_approved_call_propagates_the_result", entry).invoke(
+                order_id="A1", amount=50
+            )
+            == "refunded 50 for A1"
+        )
 
     def test_accepted_with_override_propagates_the_overridden_result(self):
         gate = post_verifier(
@@ -234,11 +239,16 @@ class TestPostVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(refund, order_id="A1", amount=50)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(refund, order_id=order_id, amount=amount)
 
-        assert asyncio.run(top_level()) == "redacted"
+        assert (
+            rt.Flow(
+                "test_accepted_with_override_propagates_the_overridden_result", entry
+            ).invoke(order_id="A1", amount=50)
+            == "redacted"
+        )
 
     def test_declined_call_still_ran_the_node_but_blocks_propagation(self):
         gate = post_verifier(
@@ -252,12 +262,14 @@ class TestPostVerifierEndToEnd:
             ran["value"] = True
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(refund, order_id="A1", amount=500)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(refund, order_id=order_id, amount=amount)
 
         with pytest.raises(VerifierRejectedError):
-            asyncio.run(top_level())
+            rt.Flow(
+                "test_declined_call_still_ran_the_node_but_blocks_propagation", entry
+            ).invoke(order_id="A1", amount=500)
         assert ran["value"] is True
 
 
@@ -290,13 +302,13 @@ class TestVerifierComposition:
             """Send an email."""
             return f"sent to {to}: {subject}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(
-                    send_email, to="a@b.com", subject="hi", body="hello"
-                )
+        @rt.function_node
+        async def entry(to, subject, body):
+            return await rt.call(send_email, to=to, subject=subject, body=body)
 
-        result = asyncio.run(top_level())
+        result = rt.Flow("test_pre_and_post_both_apply_on_one_node", entry).invoke(
+            to="a@b.com", subject="hi", body="hello"
+        )
         assert result == "sent to a@b.com: hi"
         assert pre_seen["value"] is True
         assert post_seen["value"] is True
@@ -324,10 +336,16 @@ class TestVerifierComposition:
                 raise ValueError("downstream hiccup")
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(flaky_refund, order_id="A1", amount=50)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(flaky_refund, order_id=order_id, amount=amount)
 
-        assert asyncio.run(top_level()) == "refunded 50 for A1"
+        assert (
+            rt.Flow(
+                "test_post_placed_outside_retry_only_sees_the_final_settled_result",
+                entry,
+            ).invoke(order_id="A1", amount=50)
+            == "refunded 50 for A1"
+        )
         assert attempts["count"] == 3
         assert reviewed_results == ["refunded 50 for A1"]

--- a/packages/railtracks/tests/unit_tests/middlewares/test_post_verifier.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_post_verifier.py
@@ -218,12 +218,8 @@ class TestPostVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(refund, order_id=order_id, amount=amount)
-
         assert (
-            rt.Flow("test_approved_call_propagates_the_result", entry).invoke(
+            rt.Flow("test_approved_call_propagates_the_result", refund).invoke(
                 order_id="A1", amount=50
             )
             == "refunded 50 for A1"
@@ -239,13 +235,9 @@ class TestPostVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(refund, order_id=order_id, amount=amount)
-
         assert (
             rt.Flow(
-                "test_accepted_with_override_propagates_the_overridden_result", entry
+                "test_accepted_with_override_propagates_the_overridden_result", refund
             ).invoke(order_id="A1", amount=50)
             == "redacted"
         )
@@ -262,13 +254,9 @@ class TestPostVerifierEndToEnd:
             ran["value"] = True
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(refund, order_id=order_id, amount=amount)
-
         with pytest.raises(VerifierRejectedError):
             rt.Flow(
-                "test_declined_call_still_ran_the_node_but_blocks_propagation", entry
+                "test_declined_call_still_ran_the_node_but_blocks_propagation", refund
             ).invoke(order_id="A1", amount=500)
         assert ran["value"] is True
 
@@ -302,11 +290,7 @@ class TestVerifierComposition:
             """Send an email."""
             return f"sent to {to}: {subject}"
 
-        @rt.function_node
-        async def entry(to, subject, body):
-            return await rt.call(send_email, to=to, subject=subject, body=body)
-
-        result = rt.Flow("test_pre_and_post_both_apply_on_one_node", entry).invoke(
+        result = rt.Flow("test_pre_and_post_both_apply_on_one_node", send_email).invoke(
             to="a@b.com", subject="hi", body="hello"
         )
         assert result == "sent to a@b.com: hi"
@@ -336,14 +320,10 @@ class TestVerifierComposition:
                 raise ValueError("downstream hiccup")
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(flaky_refund, order_id=order_id, amount=amount)
-
         assert (
             rt.Flow(
                 "test_post_placed_outside_retry_only_sees_the_final_settled_result",
-                entry,
+                flaky_refund,
             ).invoke(order_id="A1", amount=50)
             == "refunded 50 for A1"
         )

--- a/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
@@ -155,7 +155,7 @@ class TestPreVerifierEndToEnd:
             return await rt.call(refund, order_id=order_id, amount=amount)
 
         with pytest.raises(VerifierRejectedError):
-            rt.Flow(
-                "test_declined_call_blocks_the_node_and_propagates", entry
-            ).invoke(order_id="A1", amount=500)
+            rt.Flow("test_declined_call_blocks_the_node_and_propagates", entry).invoke(
+                order_id="A1", amount=500
+            )
         assert ran["value"] is False

--- a/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
@@ -129,12 +129,8 @@ class TestPreVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(refund, order_id=order_id, amount=amount)
-
         assert (
-            rt.Flow("test_approved_call_runs_the_node", entry).invoke(
+            rt.Flow("test_approved_call_runs_the_node", refund).invoke(
                 order_id="A1", amount=50
             )
             == "refunded 50 for A1"
@@ -150,12 +146,8 @@ class TestPreVerifierEndToEnd:
             ran["value"] = True
             return f"refunded {amount} for {order_id}"
 
-        @rt.function_node
-        async def entry(order_id, amount):
-            return await rt.call(refund, order_id=order_id, amount=amount)
-
         with pytest.raises(VerifierRejectedError):
-            rt.Flow("test_declined_call_blocks_the_node_and_propagates", entry).invoke(
+            rt.Flow("test_declined_call_blocks_the_node_and_propagates", refund).invoke(
                 order_id="A1", amount=500
             )
         assert ran["value"] is False

--- a/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_pre_verifier.py
@@ -129,11 +129,16 @@ class TestPreVerifierEndToEnd:
             """Refund an order."""
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(refund, order_id="A1", amount=50)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(refund, order_id=order_id, amount=amount)
 
-        assert asyncio.run(top_level()) == "refunded 50 for A1"
+        assert (
+            rt.Flow("test_approved_call_runs_the_node", entry).invoke(
+                order_id="A1", amount=50
+            )
+            == "refunded 50 for A1"
+        )
 
     def test_declined_call_blocks_the_node_and_propagates(self):
         gate = pre_verifier(lambda order_id, amount: Verdict(accepted=amount <= 100))
@@ -145,10 +150,12 @@ class TestPreVerifierEndToEnd:
             ran["value"] = True
             return f"refunded {amount} for {order_id}"
 
-        async def top_level():
-            with rt.Session():
-                return await rt.call(refund, order_id="A1", amount=500)
+        @rt.function_node
+        async def entry(order_id, amount):
+            return await rt.call(refund, order_id=order_id, amount=amount)
 
         with pytest.raises(VerifierRejectedError):
-            asyncio.run(top_level())
+            rt.Flow(
+                "test_declined_call_blocks_the_node_and_propagates", entry
+            ).invoke(order_id="A1", amount=500)
         assert ran["value"] is False

--- a/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_context_injection.py
+++ b/packages/railtracks/tests/unit_tests/middlewares/test_prebuilt_context_injection.py
@@ -29,8 +29,15 @@ async def test_injects_active_session_context_before_calling_onward():
 
     history = MessageHistory([SystemMessage("You are helping {user_name}.")])
 
-    with rt.Session(context={"user_name": "Alice"}):
-        result = await ContextInjection().wrap(fake_call)(history, None, None)
+    @rt.function_node
+    async def entry(user_input):
+        return await ContextInjection().wrap(fake_call)(user_input, None, None)
+
+    result = await rt.Flow(
+        "test_injects_active_session_context_before_calling_onward",
+        entry,
+        context={"user_name": "Alice"},
+    ).ainvoke(history)
 
     assert result == "response"
     assert seen["content"] == "You are helping Alice."

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
@@ -72,9 +72,9 @@ def test_prompt_numerical(mock_llm):
     async def entry(user_input):
         return await rt.call(node, user_input=user_input)
 
-    response = rt.Flow(
-        "test_prompt_numerical", entry, context={"1": "tomato"}
-    ).invoke(MessageHistory())
+    response = rt.Flow("test_prompt_numerical", entry, context={"1": "tomato"}).invoke(
+        MessageHistory()
+    )
 
     assert response.content == "tomato"
 

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import railtracks as rt
 from railtracks.llm import Message, MessageHistory
 from railtracks.llm.message import Role
@@ -25,12 +23,13 @@ def test_context_injection(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    async def top_level():
-        with rt.Session(context={"secret": "tomato"}):
-            response = await rt.call(node, user_input=MessageHistory())
-        return response
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    response = asyncio.run(top_level())
+    response = rt.Flow(
+        "test_context_injection", entry, context={"secret": "tomato"}
+    ).invoke(MessageHistory())
     assert response.content == "tomato"
 
 
@@ -46,12 +45,13 @@ def test_context_injection_bypass(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    async def top_level():
-        with rt.Session(context={"secret_value": "tomato"}):
-            response = await rt.call(node, user_input=MessageHistory())
-        return response
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    response = asyncio.run(top_level())
+    response = rt.Flow(
+        "test_context_injection_bypass", entry, context={"secret_value": "tomato"}
+    ).invoke(MessageHistory())
 
     assert response.content == "{secret_value}"
 
@@ -68,12 +68,13 @@ def test_prompt_numerical(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    async def top_level():
-        with rt.Session(context={"1": "tomato"}):
-            response = await rt.call(node, user_input=MessageHistory())
-        return response
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-    response = asyncio.run(top_level())
+    response = rt.Flow(
+        "test_prompt_numerical", entry, context={"1": "tomato"}
+    ).invoke(MessageHistory())
 
     assert response.content == "tomato"
 
@@ -90,13 +91,11 @@ def test_prompt_not_in_context(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    async def top_level():
-        with rt.Session():
-            response = await rt.call(node, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-        return response
-
-    response = asyncio.run(top_level())
+    response = rt.Flow("test_prompt_not_in_context", entry).invoke(MessageHistory())
 
     assert response.content == "{secret2}"
 
@@ -113,13 +112,15 @@ def test_no_injection_without_middleware(mock_llm):
         llm=model,
     )
 
-    async def top_level():
-        with rt.Session(context={"secret_value": "tomato"}):
-            response = await rt.call(node, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        return await rt.call(node, user_input=user_input)
 
-        return response
-
-    response = asyncio.run(top_level())
+    response = rt.Flow(
+        "test_no_injection_without_middleware",
+        entry,
+        context={"secret_value": "tomato"},
+    ).invoke(MessageHistory())
     assert response.content == "{secret_value}"
 
 
@@ -147,13 +148,17 @@ def test_context_injection_shared_middleware_list_stays_independent(mock_llm):
         model_middleware=[],
     )
 
-    async def top_level():
-        with rt.Session(context={"secret_value": "tomato"}):
-            on = await rt.call(node_on, user_input=MessageHistory())
-            off = await rt.call(node_off, user_input=MessageHistory())
+    @rt.function_node
+    async def entry(user_input):
+        on = await rt.call(node_on, user_input=user_input)
+        off = await rt.call(node_off, user_input=user_input)
         return on, off
 
-    on, off = asyncio.run(top_level())
+    on, off = rt.Flow(
+        "test_context_injection_shared_middleware_list_stays_independent",
+        entry,
+        context={"secret_value": "tomato"},
+    ).invoke(MessageHistory())
     assert on.content == "tomato"
     assert off.content == "{secret_value}"
     assert len(shared_middleware) == 1

--- a/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
+++ b/packages/railtracks/tests/unit_tests/prompt/test_prompt.py
@@ -23,12 +23,8 @@ def test_context_injection(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
     response = rt.Flow(
-        "test_context_injection", entry, context={"secret": "tomato"}
+        "test_context_injection", node, context={"secret": "tomato"}
     ).invoke(MessageHistory())
     assert response.content == "tomato"
 
@@ -45,12 +41,8 @@ def test_context_injection_bypass(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
     response = rt.Flow(
-        "test_context_injection_bypass", entry, context={"secret_value": "tomato"}
+        "test_context_injection_bypass", node, context={"secret_value": "tomato"}
     ).invoke(MessageHistory())
 
     assert response.content == "{secret_value}"
@@ -68,11 +60,7 @@ def test_prompt_numerical(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
-    response = rt.Flow("test_prompt_numerical", entry, context={"1": "tomato"}).invoke(
+    response = rt.Flow("test_prompt_numerical", node, context={"1": "tomato"}).invoke(
         MessageHistory()
     )
 
@@ -91,11 +79,7 @@ def test_prompt_not_in_context(mock_llm):
         model_middleware=[rt.prebuilt.middleware.ContextInjection()],
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
-    response = rt.Flow("test_prompt_not_in_context", entry).invoke(MessageHistory())
+    response = rt.Flow("test_prompt_not_in_context", node).invoke(MessageHistory())
 
     assert response.content == "{secret2}"
 
@@ -112,13 +96,9 @@ def test_no_injection_without_middleware(mock_llm):
         llm=model,
     )
 
-    @rt.function_node
-    async def entry(user_input):
-        return await rt.call(node, user_input=user_input)
-
     response = rt.Flow(
         "test_no_injection_without_middleware",
-        entry,
+        node,
         context={"secret_value": "tomato"},
     ).invoke(MessageHistory())
     assert response.content == "{secret_value}"


### PR DESCRIPTION
## Summary

Closes #1153. Changing tests to use `Flow` instead of `Session`, except for unit tests for the `Session` class itself.


## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Docs
- [x] Refactor / chore / build / tests

## Checklist

- [x] Lint & format pass (`ruff check . && ruff format .`)