### PR TITLE
Fix: null cost from failed pricing lookup renders as unknown, not $0.00

### DIFF
--- a/packages/railtracks/src/railtracks/cli/viz_api/models.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/models.py
@@ -324,7 +324,8 @@ class SessionSummary(BaseModel):
     #: ``session.completed.duration_seconds`` when completed, else ``end_time - start_time``.
     duration: float | None = None
     status: SessionStatus
-    total_cost: float = 0.0
+    #: None when every LLM call in the session had an unresolvable pricing entry.
+    total_cost: float | None = None
     input_tokens: int = 0
     output_tokens: int = 0
     node_count: int = 0
@@ -388,7 +389,8 @@ class NodeDetail(BaseModel):
     tool_output: Any = None
     model_name: str | None = None
     model_provider: str | None = None
-    total_cost: float = 0.0
+    #: None when the node's LLM calls all had an unresolvable pricing entry.
+    total_cost: float | None = None
     input_tokens: int = 0
     output_tokens: int = 0
     guardrails: list[Guardrail] = Field(default_factory=list)
@@ -405,7 +407,8 @@ class GraphNode(BaseModel):
     time: float | None = None
     model_name: str | None = None
     model_provider: str | None = None
-    total_cost: float = 0.0
+    #: None when the node's LLM calls all had an unresolvable pricing entry.
+    total_cost: float | None = None
     input_tokens: int = 0
     output_tokens: int = 0
     latency_seconds: float | None = None
@@ -475,7 +478,8 @@ class LLMTrace(BaseModel):
     error_message: str | None = None
     input_tokens: int = 0
     output_tokens: int = 0
-    total_cost: float = 0.0
+    #: None when the model had no pricing entry (unpriced/self-hosted model).
+    total_cost: float | None = None
     #: Per-call latency reported by the provider, in seconds. Null when the
     #: provider did not report one, and always null on an error row.
     latency_seconds: float | None = None

--- a/packages/railtracks/src/railtracks/cli/viz_api/queries/llm_traces.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/queries/llm_traces.py
@@ -272,7 +272,7 @@ def list_llm_trace_rows(
       r.exception_message                            AS error_message,
       COALESCE(r.input_tokens, 0)                    AS input_tokens,
       COALESCE(r.output_tokens, 0)                   AS output_tokens,
-      COALESCE(r.total_cost, 0.0)                    AS total_cost,
+      r.total_cost                                    AS total_cost,
       r.latency                                      AS latency_seconds,
       CAST(r.message_input AS VARCHAR)               AS message_input_json,
       CAST(r.output AS VARCHAR)                      AS output_json

--- a/packages/railtracks/src/railtracks/cli/viz_api/queries/nodes.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/queries/nodes.py
@@ -100,7 +100,7 @@ def list_llm_totals_by_node(
       SELECT node_id,
              SUM(COALESCE(input_tokens, 0))   AS input_tokens,
              SUM(COALESCE(output_tokens, 0))  AS output_tokens,
-             SUM(COALESCE(total_cost, 0.0))   AS total_cost,
+             SUM(total_cost)                  AS total_cost,
              MAX(timestamp)                   AS last_at
       FROM resp
       GROUP BY node_id
@@ -179,7 +179,7 @@ def get_agent_llm_details(
     totals AS (
       SELECT SUM(COALESCE(input_tokens, 0))   AS input_tokens,
              SUM(COALESCE(output_tokens, 0))  AS output_tokens,
-             SUM(COALESCE(total_cost, 0.0))   AS total_cost
+             SUM(total_cost)                  AS total_cost
       FROM resp
     ),
     {_LLM_CREATION_JOIN_CTE.lstrip()}

--- a/packages/railtracks/src/railtracks/cli/viz_api/queries/sessions.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/queries/sessions.py
@@ -39,7 +39,7 @@ llm_agg AS (
   SELECT scope_id,
          SUM(COALESCE(input_tokens, 0)) AS input_tokens,
          SUM(COALESCE(output_tokens, 0)) AS output_tokens,
-         SUM(COALESCE(total_cost, 0.0)) AS total_cost
+         SUM(total_cost) AS total_cost
   FROM llm
   WHERE event_type = 'llm.response'
   GROUP BY scope_id
@@ -92,7 +92,9 @@ SELECT s.scope_id                                    AS session_id,
        c.duration_seconds                            AS duration,
        COALESCE(l.input_tokens, 0)                   AS input_tokens,
        COALESCE(l.output_tokens, 0)                  AS output_tokens,
-       COALESCE(l.total_cost, 0.0)                   AS total_cost,
+       CASE WHEN l.input_tokens IS NULL THEN 0.0
+            ELSE l.total_cost
+       END                                           AS total_cost,
        COALESCE(n.node_count, 0)                     AS node_count,
        -- The rolled-up status, in SQL rather than Python, so the same
        -- definition serves the row, the status filter and the stat tiles. Two

--- a/packages/railtracks/src/railtracks/cli/viz_api/routes/sessions.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/routes/sessions.py
@@ -224,7 +224,7 @@ async def get_node_detail(
         tool_output=tool_output,
         model_name=model_name,
         model_provider=model_provider,
-        total_cost=float(totals["total_cost"] or 0.0),
+        total_cost=float(totals["total_cost"]) if totals["total_cost"] is not None else None,
         input_tokens=int(totals["input_tokens"] or 0),
         output_tokens=int(totals["output_tokens"] or 0),
         guardrails=[Guardrail(**g) for g in guardrails],
@@ -250,7 +250,7 @@ async def get_session_graph(
     graph_nodes: list[GraphNode] = []
     graph_edges: list[GraphEdge] = []
     for n in node_rows:
-        totals = llm_totals.get(n["node_id"], {})
+        totals = llm_totals.get(n["node_id"], {"total_cost": 0.0})
         graph_nodes.append(
             GraphNode(
                 id=n["node_id"],
@@ -259,7 +259,7 @@ async def get_session_graph(
                 time=n["started_at"] or n["created_at"],
                 model_name=totals.get("model_name"),
                 model_provider=totals.get("model_provider"),
-                total_cost=float(totals.get("total_cost") or 0.0),
+                total_cost=float(totals["total_cost"]) if totals.get("total_cost") is not None else None,
                 input_tokens=int(totals.get("input_tokens") or 0),
                 output_tokens=int(totals.get("output_tokens") or 0),
                 latency_seconds=_latency(n),

--- a/packages/railtracks/src/railtracks/cli/viz_api/row_mapping.py
+++ b/packages/railtracks/src/railtracks/cli/viz_api/row_mapping.py
@@ -84,7 +84,7 @@ def _row_to_summary(
         # would give the status filter and the stat tiles a second definition to
         # drift from.
         status=SessionStatus(row["status"]),
-        total_cost=float(row["total_cost"] or 0.0),
+        total_cost=float(row["total_cost"]) if row["total_cost"] is not None else None,
         input_tokens=int(row["input_tokens"] or 0),
         output_tokens=int(row["output_tokens"] or 0),
         node_count=int(row["node_count"] or 0),
@@ -108,7 +108,7 @@ def _row_to_llm_trace(row: dict[str, Any]) -> LLMTrace:
         error_message=row.get("error_message"),
         input_tokens=int(row["input_tokens"] or 0),
         output_tokens=int(row["output_tokens"] or 0),
-        total_cost=float(row["total_cost"] or 0.0),
+        total_cost=float(row["total_cost"]) if row["total_cost"] is not None else None,
         latency_seconds=(
             float(row["latency_seconds"])
             if row.get("latency_seconds") is not None

--- a/packages/railtracks/tests/unit_tests/cli/viz_api/test_api_queries.py
+++ b/packages/railtracks/tests/unit_tests/cli/viz_api/test_api_queries.py
@@ -444,3 +444,131 @@ def test_query_failures_emit_structured_error_logs(
     assert payload["path"] == "/api/v2/sessions"
     assert payload["error_type"] == "RuntimeError"
     assert payload["error"] == "duckdb exploded"
+
+
+def _llm_session_events(
+    session_id: str,
+    node_id: str,
+    llm_id: str,
+    total_cost: float | None,
+) -> list[dict[str, object]]:
+    """Minimal event stream for a session with one LLM response.
+
+    ``total_cost`` is passed through unchanged so callers can write either a
+    known value or ``None`` (unpriced model) and verify how the API renders it.
+    """
+    stamp = "2026-01-01T00:00:00+00:00"
+    return [
+        _event(
+            f"started-{session_id}",
+            "session.started",
+            session_id,
+            {"session_id": session_id, "flow_name": f"flow-{session_id}"},
+            stamp=stamp,
+        ),
+        _event(
+            f"node-{session_id}",
+            "node.creation",
+            session_id,
+            {"node_id": node_id, "name": "agent", "node_type": "Agent"},
+            stamp=stamp,
+        ),
+        _event(
+            f"llm-creation-{session_id}",
+            "llm.creation",
+            session_id,
+            {"llm_id": llm_id, "model_provider": "openai", "model_name": "gpt-4o"},
+            stamp=stamp,
+        ),
+        _event(
+            f"llm-response-{session_id}",
+            "llm.response",
+            session_id,
+            {
+                "spatial_parent_node_id": node_id,
+                "parent_llm_type_id": llm_id,
+                "input_tokens": 10,
+                "output_tokens": 5,
+                "total_cost": total_cost,
+                "message_input": [{"role": "user", "content": "hi"}],
+                "output": {"role": "assistant", "content": "hello"},
+            },
+            stamp=stamp,
+        ),
+        _event(
+            f"completed-{session_id}",
+            "session.completed",
+            session_id,
+            {"status": "success", "duration_seconds": 1.0},
+            stamp=stamp,
+        ),
+    ]
+
+
+def test_null_cost_surfaces_as_null_in_session_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed pricing lookup must not silently render as $0.00.
+
+    When every LLM call in a session has total_cost=NULL (unpriced model),
+    the session-list endpoint must return total_cost=null, not 0.0.
+    """
+    monkeypatch.setenv(EVENTS_DIR_ENV, str(tmp_path))
+    _write_events(
+        tmp_path,
+        "unpriced",
+        *_llm_session_events("unpriced", "node-u", "llm-u", total_cost=None),
+    )
+
+    response = TestClient(app).get("/api/v2/sessions")
+
+    assert response.status_code == 200
+    rows = response.json()["rows"]
+    assert len(rows) == 1
+    assert rows[0]["total_cost"] is None, (
+        f"expected null for unpriced model, got {rows[0]['total_cost']!r}"
+    )
+
+
+def test_zero_cost_surfaces_as_zero_in_session_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A genuinely free call must still render as $0.00, not null."""
+    monkeypatch.setenv(EVENTS_DIR_ENV, str(tmp_path))
+    _write_events(
+        tmp_path,
+        "free",
+        *_llm_session_events("free", "node-f", "llm-f", total_cost=0.0),
+    )
+
+    response = TestClient(app).get("/api/v2/sessions")
+
+    assert response.status_code == 200
+    rows = response.json()["rows"]
+    assert len(rows) == 1
+    assert rows[0]["total_cost"] == 0.0, (
+        f"expected 0.0 for a free call, got {rows[0]['total_cost']!r}"
+    )
+
+
+def test_null_cost_surfaces_as_null_in_llm_traces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """total_cost=null must pass through the LLM-traces endpoint unchanged."""
+    monkeypatch.setenv(EVENTS_DIR_ENV, str(tmp_path))
+    _write_events(
+        tmp_path,
+        "trace-unpriced",
+        *_llm_session_events(
+            "trace-unpriced", "node-t", "llm-t", total_cost=None
+        ),
+    )
+
+    response = TestClient(app).get("/api/llm-traces")
+
+    assert response.status_code == 200
+    rows = response.json()["rows"]
+    assert len(rows) == 1
+    assert rows[0]["total_cost"] is None, (
+        f"expected null for unpriced trace, got {rows[0]['total_cost']!r}"
+    )


### PR DESCRIPTION
## Summary

- When a model has no litellm pricing entry (self-hosted, brand-new, or unrecognized routing prefix), `extract_message_info` returns `total_cost=None`. Three layers were silently converting that `None` to `0.0`, making an unresolvable cost look identical to a genuinely free call.
- Fix all three layers: the SQL queries (remove `COALESCE(total_cost, 0.0)` from per-row and per-node selects), the Pydantic models (widen `total_cost` from `float` to `float | None`), and the Python mapping/route code (replace `float(x or 0.0)` with `float(x) if x is not None else None`).
- Session and node rollups that have no LLM calls at all still report `0.0` (they are genuinely free). Aggregate stat tiles (SessionStats, LLMTraceStats) keep their `COALESCE` because they sum known costs across many sessions, which is still useful.

## Test plan

- [x] Added `test_null_cost_surfaces_as_null_in_session_list`: writes a session whose single LLM response has `total_cost=null` and asserts the sessions API returns `total_cost: null`.
- [x] Added `test_zero_cost_surfaces_as_zero_in_session_list`: writes a session with `total_cost=0.0` and asserts the API still returns `0.0` (genuinely free calls are unaffected).
- [x] Added `test_null_cost_surfaces_as_null_in_llm_traces`: same null-cost event, verified through the `/api/llm-traces` endpoint.

Fixes #1553